### PR TITLE
Check for subscription before calling through with data.

### DIFF
--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewClickEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewClickEventOnSubscribe.java
@@ -21,7 +21,9 @@ final class ViewClickEventOnSubscribe implements Observable.OnSubscribe<ViewClic
 
     View.OnClickListener listener = new View.OnClickListener() {
       @Override public void onClick(View v) {
-        subscriber.onNext(ViewClickEvent.create(view));
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(ViewClickEvent.create(view));
+        }
       }
     };
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewClickOnSubscribe.java
@@ -22,7 +22,9 @@ final class ViewClickOnSubscribe implements Observable.OnSubscribe<Object> {
 
     View.OnClickListener listener = new View.OnClickListener() {
       @Override public void onClick(View v) {
-        subscriber.onNext(event);
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(event);
+        }
       }
     };
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewDragEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewDragEventOnSubscribe.java
@@ -27,7 +27,9 @@ final class ViewDragEventOnSubscribe implements Observable.OnSubscribe<ViewDragE
       @Override public boolean onDrag(View v, DragEvent dragEvent) {
         ViewDragEvent event = ViewDragEvent.create(view, dragEvent);
         if (handled.call(event)) {
-          subscriber.onNext(event);
+          if (!subscriber.isUnsubscribed()) {
+            subscriber.onNext(event);
+          }
           return true;
         }
         return false;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewDragOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewDragOnSubscribe.java
@@ -26,7 +26,9 @@ final class ViewDragOnSubscribe implements Observable.OnSubscribe<DragEvent> {
     View.OnDragListener listener = new View.OnDragListener() {
       @Override public boolean onDrag(View v, DragEvent event) {
         if (handled.call(event)) {
-          subscriber.onNext(event);
+          if (!subscriber.isUnsubscribed()) {
+            subscriber.onNext(event);
+          }
           return true;
         }
         return false;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewFocusChangeEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewFocusChangeEventOnSubscribe.java
@@ -22,7 +22,9 @@ final class ViewFocusChangeEventOnSubscribe
 
     View.OnFocusChangeListener listener = new View.OnFocusChangeListener() {
       @Override public void onFocusChange(View v, boolean hasFocus) {
-        subscriber.onNext(ViewFocusChangeEvent.create(view, hasFocus));
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(ViewFocusChangeEvent.create(view, hasFocus));
+        }
       }
     };
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewFocusChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewFocusChangeOnSubscribe.java
@@ -21,7 +21,9 @@ final class ViewFocusChangeOnSubscribe implements Observable.OnSubscribe<Boolean
 
     View.OnFocusChangeListener listener = new View.OnFocusChangeListener() {
       @Override public void onFocusChange(View v, boolean hasFocus) {
-        subscriber.onNext(hasFocus);
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(hasFocus);
+        }
       }
     };
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewLongClickEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewLongClickEventOnSubscribe.java
@@ -26,7 +26,9 @@ final class ViewLongClickEventOnSubscribe implements Observable.OnSubscribe<View
       @Override public boolean onLongClick(View v) {
         ViewLongClickEvent event = ViewLongClickEvent.create(view);
         if (handled.call(event)) {
-          subscriber.onNext(event);
+          if (!subscriber.isUnsubscribed()) {
+            subscriber.onNext(event);
+          }
           return true;
         }
         return false;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewLongClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewLongClickOnSubscribe.java
@@ -26,7 +26,9 @@ final class ViewLongClickOnSubscribe implements Observable.OnSubscribe<Object> {
     View.OnLongClickListener listener = new View.OnLongClickListener() {
       @Override public boolean onLongClick(View v) {
         if (handled.call()) {
-          subscriber.onNext(event);
+          if (!subscriber.isUnsubscribed()) {
+            subscriber.onNext(event);
+          }
           return true;
         }
         return false;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTouchEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTouchEventOnSubscribe.java
@@ -28,7 +28,9 @@ final class ViewTouchEventOnSubscribe implements Observable.OnSubscribe<ViewTouc
       @Override public boolean onTouch(View v, @NonNull MotionEvent motionEvent) {
         ViewTouchEvent event = ViewTouchEvent.create(view, motionEvent);
         if (handled.call(event)) {
-          subscriber.onNext(event);
+          if (!subscriber.isUnsubscribed()) {
+            subscriber.onNext(event);
+          }
           return true;
         }
         return false;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTouchOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTouchOnSubscribe.java
@@ -27,7 +27,9 @@ final class ViewTouchOnSubscribe implements Observable.OnSubscribe<MotionEvent> 
     View.OnTouchListener listener = new View.OnTouchListener() {
       @Override public boolean onTouch(View v, @NonNull MotionEvent event) {
         if (handled.call(event)) {
-          subscriber.onNext(event);
+          if (!subscriber.isUnsubscribed()) {
+            subscriber.onNext(event);
+          }
           return true;
         }
         return false;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterDataChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterDataChangeOnSubscribe.java
@@ -23,7 +23,9 @@ final class AdapterDataChangeOnSubscribe<T extends Adapter>
 
     final DataSetObserver observer = new DataSetObserver() {
       @Override public void onChanged() {
-        subscriber.onNext(adapter);
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(adapter);
+        }
       }
     };
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemClickEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemClickEventOnSubscribe.java
@@ -23,7 +23,9 @@ final class AdapterViewItemClickEventOnSubscribe
 
     AdapterView.OnItemClickListener listener = new AdapterView.OnItemClickListener() {
       @Override public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-        subscriber.onNext(AdapterViewItemClickEvent.create(parent, view, position, id));
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(AdapterViewItemClickEvent.create(parent, view, position, id));
+        }
       }
     };
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemClickOnSubscribe.java
@@ -22,7 +22,9 @@ final class AdapterViewItemClickOnSubscribe implements Observable.OnSubscribe<In
 
     AdapterView.OnItemClickListener listener = new AdapterView.OnItemClickListener() {
       @Override public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-        subscriber.onNext(position);
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(position);
+        }
       }
     };
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemLongClickEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemLongClickEventOnSubscribe.java
@@ -31,7 +31,9 @@ final class AdapterViewItemLongClickEventOnSubscribe
         AdapterViewItemLongClickEvent event =
             AdapterViewItemLongClickEvent.create(parent, view, position, id);
         if (handled.call(event)) {
-          subscriber.onNext(event);
+          if (!subscriber.isUnsubscribed()) {
+            subscriber.onNext(event);
+          }
           return true;
         }
         return false;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemLongClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemLongClickOnSubscribe.java
@@ -27,7 +27,9 @@ final class AdapterViewItemLongClickOnSubscribe implements Observable.OnSubscrib
       @Override
       public boolean onItemLongClick(AdapterView<?> parent, View view, int position, long id) {
         if (handled.call()) {
-          subscriber.onNext(position);
+          if (!subscriber.isUnsubscribed()) {
+            subscriber.onNext(position);
+          }
           return true;
         }
         return false;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemSelectionOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemSelectionOnSubscribe.java
@@ -23,7 +23,9 @@ final class AdapterViewItemSelectionOnSubscribe implements Observable.OnSubscrib
     AdapterView.OnItemSelectedListener listener = new AdapterView.OnItemSelectedListener() {
       @Override
       public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-        subscriber.onNext(position);
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(position);
+        }
       }
 
       @Override public void onNothingSelected(AdapterView<?> parent) {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewSelectionOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewSelectionOnSubscribe.java
@@ -24,11 +24,15 @@ final class AdapterViewSelectionOnSubscribe
     AdapterView.OnItemSelectedListener listener = new AdapterView.OnItemSelectedListener() {
       @Override
       public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-        subscriber.onNext(AdapterViewItemSelectionEvent.create(parent, view, position, id));
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(AdapterViewItemSelectionEvent.create(parent, view, position, id));
+        }
       }
 
       @Override public void onNothingSelected(AdapterView<?> parent) {
-        subscriber.onNext(AdapterViewNothingSelectionEvent.create(parent));
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(AdapterViewNothingSelectionEvent.create(parent));
+        }
       }
     };
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/CompoundButtonCheckedChangeEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/CompoundButtonCheckedChangeEventOnSubscribe.java
@@ -23,7 +23,9 @@ final class CompoundButtonCheckedChangeEventOnSubscribe
 
     CompoundButton.OnCheckedChangeListener listener = new CompoundButton.OnCheckedChangeListener() {
       @Override public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-        subscriber.onNext(CompoundButtonCheckedChangeEvent.create(view, isChecked));
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(CompoundButtonCheckedChangeEvent.create(view, isChecked));
+        }
       }
     };
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/CompoundButtonCheckedChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/CompoundButtonCheckedChangeOnSubscribe.java
@@ -21,7 +21,9 @@ final class CompoundButtonCheckedChangeOnSubscribe implements Observable.OnSubsc
 
     CompoundButton.OnCheckedChangeListener listener = new CompoundButton.OnCheckedChangeListener() {
       @Override public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-        subscriber.onNext(isChecked);
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(isChecked);
+        }
       }
     };
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RadioGroupCheckedChangeEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RadioGroupCheckedChangeEventOnSubscribe.java
@@ -22,7 +22,9 @@ final class RadioGroupCheckedChangeEventOnSubscribe
 
     RadioGroup.OnCheckedChangeListener listener = new RadioGroup.OnCheckedChangeListener() {
       @Override public void onCheckedChanged(RadioGroup group, int checkedId) {
-        subscriber.onNext(RadioGroupCheckedChangeEvent.create(group, checkedId));
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(RadioGroupCheckedChangeEvent.create(group, checkedId));
+        }
       }
     };
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RadioGroupCheckedChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RadioGroupCheckedChangeOnSubscribe.java
@@ -21,7 +21,9 @@ final class RadioGroupCheckedChangeOnSubscribe implements Observable.OnSubscribe
 
     RadioGroup.OnCheckedChangeListener listener = new RadioGroup.OnCheckedChangeListener() {
       @Override public void onCheckedChanged(RadioGroup group, int checkedId) {
-        subscriber.onNext(checkedId);
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(checkedId);
+        }
       }
     };
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RatingBarRatingChangeEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RatingBarRatingChangeEventOnSubscribe.java
@@ -22,7 +22,9 @@ final class RatingBarRatingChangeEventOnSubscribe
 
     RatingBar.OnRatingBarChangeListener listener = new RatingBar.OnRatingBarChangeListener() {
       @Override public void onRatingChanged(RatingBar ratingBar, float rating, boolean fromUser) {
-        subscriber.onNext(RatingBarChangeEvent.create(ratingBar, rating, fromUser));
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(RatingBarChangeEvent.create(ratingBar, rating, fromUser));
+        }
       }
     };
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RatingBarRatingChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RatingBarRatingChangeOnSubscribe.java
@@ -21,7 +21,9 @@ final class RatingBarRatingChangeOnSubscribe implements Observable.OnSubscribe<F
 
     RatingBar.OnRatingBarChangeListener listener = new RatingBar.OnRatingBarChangeListener() {
       @Override public void onRatingChanged(RatingBar ratingBar, float rating, boolean fromUser) {
-        subscriber.onNext(rating);
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(rating);
+        }
       }
     };
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SeekBarChangeEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SeekBarChangeEventOnSubscribe.java
@@ -1,10 +1,10 @@
 package com.jakewharton.rxbinding.widget;
 
 import android.widget.SeekBar;
+import com.jakewharton.rxbinding.internal.AndroidSubscriptions;
 import rx.Observable;
 import rx.Subscriber;
 import rx.Subscription;
-import com.jakewharton.rxbinding.internal.AndroidSubscriptions;
 import rx.functions.Action0;
 
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
@@ -22,15 +22,21 @@ final class SeekBarChangeEventOnSubscribe
 
     SeekBar.OnSeekBarChangeListener listener = new SeekBar.OnSeekBarChangeListener() {
       @Override public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
-        subscriber.onNext(SeekBarProgressChangeEvent.create(seekBar, progress, fromUser));
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(SeekBarProgressChangeEvent.create(seekBar, progress, fromUser));
+        }
       }
 
       @Override public void onStartTrackingTouch(SeekBar seekBar) {
-        subscriber.onNext(SeekBarStartChangeEvent.create(seekBar));
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(SeekBarStartChangeEvent.create(seekBar));
+        }
       }
 
       @Override public void onStopTrackingTouch(SeekBar seekBar) {
-        subscriber.onNext(SeekBarStopChangeEvent.create(seekBar));
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(SeekBarStopChangeEvent.create(seekBar));
+        }
       }
     };
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SeekBarChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SeekBarChangeOnSubscribe.java
@@ -21,7 +21,9 @@ final class SeekBarChangeOnSubscribe implements Observable.OnSubscribe<Integer> 
 
     SeekBar.OnSeekBarChangeListener listener = new SeekBar.OnSeekBarChangeListener() {
       @Override public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
-        subscriber.onNext(progress);
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(progress);
+        }
       }
 
       @Override public void onStartTrackingTouch(SeekBar seekBar) {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewEditorActionEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewEditorActionEventOnSubscribe.java
@@ -29,7 +29,9 @@ final class TextViewEditorActionEventOnSubscribe
       @Override public boolean onEditorAction(TextView v, int actionId, KeyEvent keyEvent) {
         TextViewEditorActionEvent event = TextViewEditorActionEvent.create(v, actionId, keyEvent);
         if (handled.call(event)) {
-          subscriber.onNext(event);
+          if (!subscriber.isUnsubscribed()) {
+            subscriber.onNext(event);
+          }
           return true;
         }
         return false;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewEditorActionOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewEditorActionOnSubscribe.java
@@ -26,7 +26,9 @@ final class TextViewEditorActionOnSubscribe implements Observable.OnSubscribe<In
     TextView.OnEditorActionListener listener = new TextView.OnEditorActionListener() {
       @Override public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
         if (handled.call(actionId)) {
-          subscriber.onNext(actionId);
+          if (!subscriber.isUnsubscribed()) {
+            subscriber.onNext(actionId);
+          }
           return true;
         }
         return false;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewTextEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewTextEventOnSubscribe.java
@@ -27,7 +27,9 @@ final class TextViewTextEventOnSubscribe
       }
 
       @Override public void onTextChanged(CharSequence s, int start, int before, int count) {
-        subscriber.onNext(TextViewTextChangeEvent.create(view, s, start, before, count));
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(TextViewTextChangeEvent.create(view, s, start, before, count));
+        }
       }
 
       @Override public void afterTextChanged(Editable s) {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewTextOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewTextOnSubscribe.java
@@ -26,7 +26,9 @@ final class TextViewTextOnSubscribe implements Observable.OnSubscribe<CharSequen
       }
 
       @Override public void onTextChanged(CharSequence s, int start, int before, int count) {
-        subscriber.onNext(s);
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(s);
+        }
       }
 
       @Override public void afterTextChanged(Editable s) {


### PR DESCRIPTION
This solves a subtle race due to the fact that we have to post to the main thread to remove the listener. In some cases events could be queued and processed after the downstream subscriber called unsubscribe but we had not detached the listener.