### PR TITLE
Bindings for android.widget.SearchView closes #41

### DIFF
--- a/rxbinding/src/androidTest/AndroidManifest.xml
+++ b/rxbinding/src/androidTest/AndroidManifest.xml
@@ -6,5 +6,6 @@
     <activity android:name=".widget.RxAdapterViewTestActivity"/>
     <activity android:name=".widget.RxRatingBarTestActivity"/>
     <activity android:name=".widget.RxSeekBarTestActivity"/>
+    <activity android:name=".widget.RxSearchViewTestActivity"/>
   </application>
 </manifest>

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/widget/RxSearchViewTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/widget/RxSearchViewTest.java
@@ -84,6 +84,8 @@ public final class RxSearchViewTest {
         RecordingObserver<SearchViewQueryTextEvent> o = new RecordingObserver<>();
         Subscription subscription = RxSearchView.queryTextEvents(searchView).subscribe(o);
 
+        assertThat(o.takeNext().queryText().toString()).isEmpty();
+
         searchView.setQuery("q", false);
         SearchViewQueryTextEvent event = o.takeNext();
         assertThat(event.queryText().toString()).isEqualTo("q");
@@ -94,6 +96,8 @@ public final class RxSearchViewTest {
     @Test @UiThreadTest public void queryTextEventSubmitted() {
         RecordingObserver<SearchViewQueryTextEvent> o = new RecordingObserver<>();
         Subscription subscription = RxSearchView.queryTextEvents(searchView).subscribe(o);
+
+        assertThat(o.takeNext().queryText().toString()).isEmpty();
 
         searchView.setQuery("q", true);
         // Text change event:

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/widget/RxSearchViewTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/widget/RxSearchViewTest.java
@@ -33,15 +33,15 @@ public final class RxSearchViewTest {
         searchView.setQuery("Initial", false);
         RecordingObserver<CharSequence> o = new RecordingObserver<>();
         Subscription subscription = RxSearchView.queryTextChanges(searchView).subscribe(o);
-        assertThat(o.takeNext().toString().equals("Initial"));
+        assertThat(o.takeNext().toString()).isEqualTo("Initial");
 
         searchView.setQuery("H", false);
-        assertThat(o.takeNext().toString().equals("H"));
+        assertThat(o.takeNext().toString()).isEqualTo("H");
         searchView.setQuery("He", false);
-        assertThat(o.takeNext().toString().equals("He"));
+        assertThat(o.takeNext().toString()).isEqualTo("He");
 
         searchView.setQuery(null, false); // Internally coerced to empty string.
-        assertThat(o.takeNext().toString().equals(""));
+        assertThat(o.takeNext().toString()).isEmpty();
 
         subscription.unsubscribe();
 
@@ -55,7 +55,8 @@ public final class RxSearchViewTest {
 
         searchView.setQuery("a submitted query", true);
         SearchViewQueryTextEvent event = o.takeNext();
-        assertThat(event.queryText().equals("a submitted query") && event.isSubmitted());
+        assertThat(event.queryText().toString()).isEqualTo("a submitted query");
+        assertThat(event.isSubmitted()).isTrue();
 
         subscription.unsubscribe();
 
@@ -73,10 +74,10 @@ public final class RxSearchViewTest {
 
     @Test @UiThreadTest public void query() {
         RxSearchView.query(searchView, false).call("Hey");
-        assertThat(searchView.getQuery().equals("Hey"));
+        assertThat(searchView.getQuery().toString()).isEqualTo("Hey");
 
         RxSearchView.query(searchView, true).call("Bye");
-        assertThat(searchView.getQuery().equals("Bye"));
+        assertThat(searchView.getQuery().toString()).isEqualTo("Bye");
     }
 
     @Test @UiThreadTest public void queryTextEventNotSubmitted() {
@@ -85,7 +86,8 @@ public final class RxSearchViewTest {
 
         searchView.setQuery("q", false);
         SearchViewQueryTextEvent event = o.takeNext();
-        assertThat(event.queryText().equals("q") && !event.isSubmitted());
+        assertThat(event.queryText().toString()).isEqualTo("q");
+        assertThat(event.isSubmitted()).isFalse();
         o.assertNoMoreEvents();
     }
 
@@ -96,10 +98,12 @@ public final class RxSearchViewTest {
         searchView.setQuery("q", true);
         // Text change event:
         SearchViewQueryTextEvent event = o.takeNext();
-        assertThat(event.queryText().equals("q") && !event.isSubmitted());
+        assertThat(event.queryText().toString()).isEqualTo("q");
+        assertThat(event.isSubmitted()).isFalse();
         // Submission event:
         SearchViewQueryTextEvent event1 = o.takeNext();
-        assertThat(event1.queryText().equals("q") && event1.isSubmitted());
+        assertThat(event1.queryText().toString()).isEqualTo("q");
+        assertThat(event1.isSubmitted()).isTrue();
     }
 
 }

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/widget/RxSearchViewTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/widget/RxSearchViewTest.java
@@ -1,0 +1,105 @@
+package com.jakewharton.rxbinding.widget;
+
+import android.support.test.annotation.UiThreadTest;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.widget.SearchView;
+
+import com.jakewharton.rxbinding.RecordingObserver;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import rx.Subscription;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(AndroidJUnit4.class)
+public final class RxSearchViewTest {
+    @Rule
+    public final ActivityTestRule<RxSearchViewTestActivity>
+            activityRule = new ActivityTestRule<>(RxSearchViewTestActivity.class);
+
+    private SearchView searchView;
+
+    @Before
+    public void setUp() {
+        searchView = activityRule.getActivity().searchView;
+    }
+
+    @Test @UiThreadTest public void queryTextChanges() {
+        searchView.setQuery("Initial", false);
+        RecordingObserver<CharSequence> o = new RecordingObserver<>();
+        Subscription subscription = RxSearchView.queryTextChanges(searchView).subscribe(o);
+        assertThat(o.takeNext().toString().equals("Initial"));
+
+        searchView.setQuery("H", false);
+        assertThat(o.takeNext().toString().equals("H"));
+        searchView.setQuery("He", false);
+        assertThat(o.takeNext().toString().equals("He"));
+
+        searchView.setQuery(null, false); // Internally coerced to empty string.
+        assertThat(o.takeNext().toString().equals(""));
+
+        subscription.unsubscribe();
+
+        searchView.setQuery("Silent", false);
+        o.assertNoMoreEvents();
+    }
+
+    @Test @UiThreadTest public void querySubmissionPositive() {
+        RecordingObserver<SearchViewQueryTextEvent> o = new RecordingObserver<>();
+        Subscription subscription = RxSearchView.queryTextSubmissions(searchView).subscribe(o);
+
+        searchView.setQuery("a submitted query", true);
+        SearchViewQueryTextEvent event = o.takeNext();
+        assertThat(event.queryText().equals("a submitted query") && event.isSubmitted());
+
+        subscription.unsubscribe();
+
+        searchView.setQuery("Silent", true);
+        o.assertNoMoreEvents();
+    }
+
+    @Test @UiThreadTest public void querySubmissionsNegative() {
+        RecordingObserver<SearchViewQueryTextEvent> o = new RecordingObserver<>();
+        Subscription subscription = RxSearchView.queryTextSubmissions(searchView).subscribe(o);
+
+        searchView.setQuery("Silent", false);
+        o.assertNoMoreEvents();
+    }
+
+    @Test @UiThreadTest public void query() {
+        RxSearchView.query(searchView, false).call("Hey");
+        assertThat(searchView.getQuery().equals("Hey"));
+
+        RxSearchView.query(searchView, true).call("Bye");
+        assertThat(searchView.getQuery().equals("Bye"));
+    }
+
+    @Test @UiThreadTest public void queryTextEventNotSubmitted() {
+        RecordingObserver<SearchViewQueryTextEvent> o = new RecordingObserver<>();
+        Subscription subscription = RxSearchView.queryTextEvents(searchView).subscribe(o);
+
+        searchView.setQuery("q", false);
+        SearchViewQueryTextEvent event = o.takeNext();
+        assertThat(event.queryText().equals("q") && !event.isSubmitted());
+        o.assertNoMoreEvents();
+    }
+
+    @Test @UiThreadTest public void queryTextEventSubmitted() {
+        RecordingObserver<SearchViewQueryTextEvent> o = new RecordingObserver<>();
+        Subscription subscription = RxSearchView.queryTextEvents(searchView).subscribe(o);
+
+        searchView.setQuery("q", true);
+        // Text change event:
+        SearchViewQueryTextEvent event = o.takeNext();
+        assertThat(event.queryText().equals("q") && !event.isSubmitted());
+        // Submission event:
+        SearchViewQueryTextEvent event1 = o.takeNext();
+        assertThat(event1.queryText().equals("q") && event1.isSubmitted());
+    }
+
+}

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RxSearchView.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RxSearchView.java
@@ -12,7 +12,7 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkNotNull;
  * Static factory methods for creating {@linkplain Observable observables} and {@linkplain Action1
  * actions} for {@link SearchView}.
  */
-public class RxSearchView {
+public final class RxSearchView {
     /**
      * Create an observable of {@linkplain SearchViewQueryTextEvent query text events}
      * on {@code view}.

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RxSearchView.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RxSearchView.java
@@ -72,4 +72,7 @@ public final class RxSearchView {
         };
     }
 
+    private RxSearchView() {
+        throw new AssertionError("No instances.");
+    }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RxSearchView.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RxSearchView.java
@@ -34,13 +34,7 @@ public class RxSearchView {
 
     public static Observable<? extends CharSequence> queryTextChanges(SearchView view) {
         checkNotNull(view, "view == null");
-        return RxSearchView.queryTextEvents(view)
-                .map(new Func1<SearchViewQueryTextEvent, CharSequence>() {
-                    @Override
-                    public CharSequence call(SearchViewQueryTextEvent searchViewQueryTextEvent) {
-                        return searchViewQueryTextEvent.queryText();
-                    }
-                });
+        return Observable.create(new SearchViewQueryTextChangesOnSubscribe(view));
     }
 
     /**

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RxSearchView.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RxSearchView.java
@@ -1,0 +1,81 @@
+package com.jakewharton.rxbinding.widget;
+
+import android.widget.SearchView;
+
+import rx.Observable;
+import rx.functions.Action1;
+import rx.functions.Func1;
+
+import static com.jakewharton.rxbinding.internal.Preconditions.checkNotNull;
+
+/**
+ * Static factory methods for creating {@linkplain Observable observables} and {@linkplain Action1
+ * actions} for {@link SearchView}.
+ */
+public class RxSearchView {
+    /**
+     * Create an observable of {@linkplain SearchViewQueryTextEvent query text events}
+     * on {@code view}.
+     * <p>
+     * <em>Warning:</em> The created observable keeps a strong reference to {@code view}.
+     * Unsubscribe to free this reference.
+     */
+    public static Observable<SearchViewQueryTextEvent> queryTextEvents(SearchView view) {
+        checkNotNull(view, "view == null");
+        return Observable.create(new SearchViewQueryTextEventsOnSubscribe(view));
+    }
+
+    /**
+     * Create an observable of character sequences for query text changes on {@code view}.
+     * <p>
+     * <em>Warning:</em> The created observable keeps a strong reference to {@code view}.
+     * Unsubscribe to free this reference.
+     */
+
+    public static Observable<? extends CharSequence> queryTextChanges(SearchView view) {
+        checkNotNull(view, "view == null");
+        return RxSearchView.queryTextEvents(view)
+                .map(new Func1<SearchViewQueryTextEvent, CharSequence>() {
+                    @Override
+                    public CharSequence call(SearchViewQueryTextEvent searchViewQueryTextEvent) {
+                        return searchViewQueryTextEvent.queryText();
+                    }
+                });
+    }
+
+    /**
+     * Create an observable of {@linkplain SearchViewQueryTextEvent query text events}
+     * for queries that are submitted on {@code view}.
+     * <p>
+     * <em>Warning:</em> The created observable keeps a strong reference to {@code view}.
+     * Unsubscribe to free this reference.
+     */
+    public static Observable<SearchViewQueryTextEvent> queryTextSubmissions(SearchView view) {
+        checkNotNull(view, "view == null");
+        return RxSearchView.queryTextEvents(view)
+                .filter(new Func1<SearchViewQueryTextEvent, Boolean>() {
+                    @Override
+                    public Boolean call(SearchViewQueryTextEvent searchViewQueryTextEvent) {
+                        return searchViewQueryTextEvent.isSubmitted();
+                    }
+                });
+    }
+
+    /**
+     * An action which sets the query property of {@code view} with character sequences.
+     * <p>
+     * <em>Warning:</em> The created observable keeps a strong reference to {@code view}.
+     * Unsubscribe to free this reference.
+     *
+     * @param submit weather to submit query right after updating query text
+     */
+    public static Action1<? super CharSequence> query(final SearchView view, final boolean submit) {
+        checkNotNull(view, "view == null");
+        return new Action1<CharSequence>() {
+            @Override public void call(CharSequence text) {
+                view.setQuery(text, submit);
+            }
+        };
+    }
+
+}

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RxSearchViewTestActivity.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RxSearchViewTestActivity.java
@@ -1,0 +1,16 @@
+package com.jakewharton.rxbinding.widget;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.widget.SearchView;
+
+public final class RxSearchViewTestActivity extends Activity {
+    SearchView searchView;
+
+    @Override protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        searchView = new SearchView(this);
+        setContentView(searchView);
+    }
+}

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewQueryTextChangesOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewQueryTextChangesOnSubscribe.java
@@ -1,0 +1,52 @@
+package com.jakewharton.rxbinding.widget;
+
+import android.widget.SearchView;
+
+import com.jakewharton.rxbinding.internal.MainThreadSubscription;
+
+import rx.Observable;
+import rx.Subscriber;
+
+import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
+
+public class SearchViewQueryTextChangesOnSubscribe implements Observable.OnSubscribe<CharSequence> {
+    private SearchView view;
+
+    public SearchViewQueryTextChangesOnSubscribe(SearchView view) {
+        this.view = view;
+    }
+
+    @Override
+    public void call(final Subscriber<? super CharSequence> subscriber) {
+        checkUiThread();
+
+        final SearchView.OnQueryTextListener watcher = new SearchView.OnQueryTextListener() {
+            @Override
+            public boolean onQueryTextChange(String s) {
+                if (!subscriber.isUnsubscribed()) {
+                    subscriber.onNext(s);
+                    return true;
+                }
+                return false;
+            }
+
+            @Override
+            public boolean onQueryTextSubmit(String query) {
+                return false;
+            }
+
+        };
+
+        subscriber.add(new MainThreadSubscription() {
+            @Override
+            protected void onUnsubscribe() {
+                view.setOnQueryTextListener(null);
+            }
+        });
+
+        view.setOnQueryTextListener(watcher);
+
+        // Send out the initial value.
+        subscriber.onNext(view.getQuery());
+    }
+}

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewQueryTextEvent.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewQueryTextEvent.java
@@ -5,7 +5,7 @@ import android.widget.SearchView;
 
 import com.jakewharton.rxbinding.view.ViewEvent;
 
-public class SearchViewQueryTextEvent extends ViewEvent<SearchView> {
+public final class SearchViewQueryTextEvent extends ViewEvent<SearchView> {
     private final CharSequence queryText;
     private final boolean submitted;
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewQueryTextEvent.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewQueryTextEvent.java
@@ -1,0 +1,52 @@
+package com.jakewharton.rxbinding.widget;
+
+import android.support.annotation.NonNull;
+import android.widget.SearchView;
+
+import com.jakewharton.rxbinding.view.ViewEvent;
+
+public class SearchViewQueryTextEvent extends ViewEvent<SearchView> {
+    private final CharSequence queryText;
+    private final boolean submitted;
+
+    protected SearchViewQueryTextEvent(@NonNull SearchView view,
+                                       @NonNull CharSequence queryText,
+                                       boolean submitted) {
+        super(view);
+        this.queryText = queryText;
+        this.submitted = submitted;
+    }
+
+    public CharSequence queryText() {
+        return queryText;
+    }
+
+    public boolean isSubmitted() {
+        return submitted;
+    }
+
+    @Override public boolean equals(Object o) {
+        if (o == this) return true;
+        if (!(o instanceof SearchViewQueryTextEvent)) return false;
+        SearchViewQueryTextEvent other = (SearchViewQueryTextEvent) o;
+        return other.view() == view() && other.queryText.equals(queryText) && other.submitted == submitted;
+    }
+
+    @Override public int hashCode() {
+        int result = 17;
+        result = result * 37 + view().hashCode();
+        result = result * 37 + queryText.hashCode();
+        result = result * 37 + (submitted ? 1 : 0);
+        return result;
+    }
+
+    @Override public String toString() {
+        return "TextViewEditorActionEvent{view="
+                + view()
+                + ", queryText="
+                + queryText
+                + ", submitted="
+                + submitted
+                + '}';
+    }
+}

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewQueryTextEvent.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewQueryTextEvent.java
@@ -9,12 +9,18 @@ public final class SearchViewQueryTextEvent extends ViewEvent<SearchView> {
     private final CharSequence queryText;
     private final boolean submitted;
 
-    protected SearchViewQueryTextEvent(@NonNull SearchView view,
-                                       @NonNull CharSequence queryText,
-                                       boolean submitted) {
+    private SearchViewQueryTextEvent(@NonNull SearchView view,
+                                     @NonNull CharSequence queryText,
+                                     boolean submitted) {
         super(view);
         this.queryText = queryText;
         this.submitted = submitted;
+    }
+
+    public static SearchViewQueryTextEvent create(@NonNull SearchView view,
+                                                  @NonNull CharSequence queryText,
+                                                  boolean submitted) {
+        return new SearchViewQueryTextEvent(view, queryText, submitted);
     }
 
     public CharSequence queryText() {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewQueryTextEventsOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewQueryTextEventsOnSubscribe.java
@@ -1,0 +1,71 @@
+package com.jakewharton.rxbinding.widget;
+
+import android.text.TextUtils;
+import android.widget.SearchView;
+
+import com.jakewharton.rxbinding.internal.MainThreadSubscription;
+
+import rx.Observable;
+import rx.Subscriber;
+
+import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
+
+public class SearchViewQueryTextEventsOnSubscribe implements Observable.OnSubscribe<SearchViewQueryTextEvent> {
+    private final boolean sendQueryTextChanges;
+    private final boolean sendQueryTextSubmissions;
+    private SearchView view;
+
+    public SearchViewQueryTextEventsOnSubscribe(SearchView view) {
+        this(view, true, true);
+    }
+
+    public SearchViewQueryTextEventsOnSubscribe(SearchView view,
+                                                  boolean sendQueryTextChanges,
+                                                  boolean sendQueryTextSubmissions) {
+        this.view = view;
+        this.sendQueryTextChanges = sendQueryTextChanges;
+        this.sendQueryTextSubmissions = sendQueryTextSubmissions;
+    }
+
+    @Override
+    public void call(final Subscriber<? super SearchViewQueryTextEvent> subscriber) {
+        checkUiThread();
+
+        final SearchView.OnQueryTextListener watcher = new SearchView.OnQueryTextListener() {
+            @Override
+            public boolean onQueryTextChange(String s) {
+                if (sendQueryTextChanges && !subscriber.isUnsubscribed()) {
+                    subscriber.onNext(new SearchViewQueryTextEvent(view, s, false));
+                    return true;
+                }
+                return false;
+            }
+
+            @Override
+            public boolean onQueryTextSubmit(String query) {
+                if (sendQueryTextSubmissions && !subscriber.isUnsubscribed()) {
+                    subscriber.onNext(new SearchViewQueryTextEvent(view, view.getQuery(), true ));
+                    return true;
+                }
+                return false;
+            }
+
+        };
+
+        subscriber.add(new MainThreadSubscription() {
+            @Override
+            protected void onUnsubscribe() {
+                view.setOnQueryTextListener(null);
+            }
+        });
+
+        view.setOnQueryTextListener(watcher);
+
+        // Send out the initial value.
+        CharSequence q = view.getQuery();
+        if (!TextUtils.isEmpty(q)) {
+            subscriber.onNext(new SearchViewQueryTextEvent(view, q, false));
+        }
+    }
+
+}

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewQueryTextEventsOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewQueryTextEventsOnSubscribe.java
@@ -1,6 +1,5 @@
 package com.jakewharton.rxbinding.widget;
 
-import android.text.TextUtils;
 import android.widget.SearchView;
 
 import com.jakewharton.rxbinding.internal.MainThreadSubscription;
@@ -62,10 +61,7 @@ final class SearchViewQueryTextEventsOnSubscribe implements Observable.OnSubscri
         view.setOnQueryTextListener(watcher);
 
         // Send out the initial value.
-        CharSequence q = view.getQuery();
-        if (!TextUtils.isEmpty(q)) {
-            subscriber.onNext(new SearchViewQueryTextEvent(view, q, false));
-        }
+        subscriber.onNext(new SearchViewQueryTextEvent(view, view.getQuery(), false));
     }
 
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewQueryTextEventsOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewQueryTextEventsOnSubscribe.java
@@ -43,7 +43,7 @@ final class SearchViewQueryTextEventsOnSubscribe implements Observable.OnSubscri
             @Override
             public boolean onQueryTextSubmit(String query) {
                 if (sendQueryTextSubmissions && !subscriber.isUnsubscribed()) {
-                    subscriber.onNext(new SearchViewQueryTextEvent(view, view.getQuery(), true ));
+                    subscriber.onNext(new SearchViewQueryTextEvent(view, view.getQuery(), true));
                     return true;
                 }
                 return false;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewQueryTextEventsOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewQueryTextEventsOnSubscribe.java
@@ -34,7 +34,7 @@ final class SearchViewQueryTextEventsOnSubscribe implements Observable.OnSubscri
             @Override
             public boolean onQueryTextChange(String s) {
                 if (sendQueryTextChanges && !subscriber.isUnsubscribed()) {
-                    subscriber.onNext(new SearchViewQueryTextEvent(view, s, false));
+                    subscriber.onNext(SearchViewQueryTextEvent.create(view, s, false));
                     return true;
                 }
                 return false;
@@ -43,7 +43,7 @@ final class SearchViewQueryTextEventsOnSubscribe implements Observable.OnSubscri
             @Override
             public boolean onQueryTextSubmit(String query) {
                 if (sendQueryTextSubmissions && !subscriber.isUnsubscribed()) {
-                    subscriber.onNext(new SearchViewQueryTextEvent(view, view.getQuery(), true));
+                    subscriber.onNext(SearchViewQueryTextEvent.create(view, view.getQuery(), true));
                     return true;
                 }
                 return false;
@@ -61,7 +61,7 @@ final class SearchViewQueryTextEventsOnSubscribe implements Observable.OnSubscri
         view.setOnQueryTextListener(watcher);
 
         // Send out the initial value.
-        subscriber.onNext(new SearchViewQueryTextEvent(view, view.getQuery(), false));
+        subscriber.onNext(SearchViewQueryTextEvent.create(view, view.getQuery(), false));
     }
 
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewQueryTextEventsOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewQueryTextEventsOnSubscribe.java
@@ -10,7 +10,7 @@ import rx.Subscriber;
 
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
-public class SearchViewQueryTextEventsOnSubscribe implements Observable.OnSubscribe<SearchViewQueryTextEvent> {
+final class SearchViewQueryTextEventsOnSubscribe implements Observable.OnSubscribe<SearchViewQueryTextEvent> {
     private final boolean sendQueryTextChanges;
     private final boolean sendQueryTextSubmissions;
     private SearchView view;


### PR DESCRIPTION
Note: SearchView does not allow to set query text change and query text submit listeners separately which complicates the design a little bit.