### PR TITLE
Add custom test runner to kill keyguard and hold wake lock

### DIFF
--- a/rxbinding/build.gradle
+++ b/rxbinding/build.gradle
@@ -23,7 +23,7 @@ android {
   defaultConfig {
     minSdkVersion rootProject.ext.minSdkVersion
 
-    testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
+    testInstrumentationRunner 'com.jakewharton.rxbinding.RxBindingTestRunner'
   }
 
   compileOptions {

--- a/rxbinding/src/androidTest/AndroidManifest.xml
+++ b/rxbinding/src/androidTest/AndroidManifest.xml
@@ -2,6 +2,10 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.jakewharton.rxbinding">
+
+  <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
+  <uses-permission android:name="android.permission.WAKE_LOCK" />
+
   <application>
     <activity android:name=".widget.RxAdapterViewTestActivity"/>
     <activity android:name=".widget.RxRatingBarTestActivity"/>

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/RxBindingTestRunner.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/RxBindingTestRunner.java
@@ -15,22 +15,16 @@ public class RxBindingTestRunner extends AndroidJUnitRunner {
   private PowerManager.WakeLock wakeLock;
 
   @Override public void onStart() {
-    runOnMainSync(new Runnable() {
-      @SuppressWarnings("deprecation") // We don't care about deprecation here.
-      @Override public void run() {
-        Context app = getTargetContext().getApplicationContext();
+      Context app = getTargetContext().getApplicationContext();
 
-        String name = RxBindingTestRunner.class.getSimpleName();
-        // Unlock the device so that the tests can input keystrokes.
-        KeyguardManager keyguard = (KeyguardManager) app.getSystemService(KEYGUARD_SERVICE);
-        keyguard.newKeyguardLock(name).disableKeyguard();
-        // Wake up the screen.
-        PowerManager power = (PowerManager) app.getSystemService(POWER_SERVICE);
-        wakeLock =
-            power.newWakeLock(FULL_WAKE_LOCK | ACQUIRE_CAUSES_WAKEUP | ON_AFTER_RELEASE, name);
-        wakeLock.acquire();
-      }
-    });
+      String name = RxBindingTestRunner.class.getSimpleName();
+      // Unlock the device so that the tests can input keystrokes.
+      KeyguardManager keyguard = (KeyguardManager) app.getSystemService(KEYGUARD_SERVICE);
+      keyguard.newKeyguardLock(name).disableKeyguard();
+      // Wake up the screen.
+      PowerManager power = (PowerManager) app.getSystemService(POWER_SERVICE);
+      wakeLock = power.newWakeLock(FULL_WAKE_LOCK | ACQUIRE_CAUSES_WAKEUP | ON_AFTER_RELEASE, name);
+      wakeLock.acquire();
 
     super.onStart();
   }

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/RxBindingTestRunner.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/RxBindingTestRunner.java
@@ -12,6 +12,8 @@ import static android.os.PowerManager.FULL_WAKE_LOCK;
 import static android.os.PowerManager.ON_AFTER_RELEASE;
 
 public class RxBindingTestRunner extends AndroidJUnitRunner {
+  private PowerManager.WakeLock wakeLock;
+
   @Override public void onStart() {
     runOnMainSync(new Runnable() {
       @SuppressWarnings("deprecation") // We don't care about deprecation here.
@@ -24,11 +26,18 @@ public class RxBindingTestRunner extends AndroidJUnitRunner {
         keyguard.newKeyguardLock(name).disableKeyguard();
         // Wake up the screen.
         PowerManager power = (PowerManager) app.getSystemService(POWER_SERVICE);
-        power.newWakeLock(FULL_WAKE_LOCK | ACQUIRE_CAUSES_WAKEUP | ON_AFTER_RELEASE, name)
-            .acquire();
+        wakeLock =
+            power.newWakeLock(FULL_WAKE_LOCK | ACQUIRE_CAUSES_WAKEUP | ON_AFTER_RELEASE, name);
+        wakeLock.acquire();
       }
     });
 
     super.onStart();
+  }
+
+  @Override public void onDestroy() {
+    super.onDestroy();
+
+    wakeLock.release();
   }
 }

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/RxBindingTestRunner.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/RxBindingTestRunner.java
@@ -15,16 +15,16 @@ public class RxBindingTestRunner extends AndroidJUnitRunner {
   private PowerManager.WakeLock wakeLock;
 
   @Override public void onStart() {
-      Context app = getTargetContext().getApplicationContext();
+    Context app = getTargetContext().getApplicationContext();
 
-      String name = RxBindingTestRunner.class.getSimpleName();
-      // Unlock the device so that the tests can input keystrokes.
-      KeyguardManager keyguard = (KeyguardManager) app.getSystemService(KEYGUARD_SERVICE);
-      keyguard.newKeyguardLock(name).disableKeyguard();
-      // Wake up the screen.
-      PowerManager power = (PowerManager) app.getSystemService(POWER_SERVICE);
-      wakeLock = power.newWakeLock(FULL_WAKE_LOCK | ACQUIRE_CAUSES_WAKEUP | ON_AFTER_RELEASE, name);
-      wakeLock.acquire();
+    String name = RxBindingTestRunner.class.getSimpleName();
+    // Unlock the device so that the tests can input keystrokes.
+    KeyguardManager keyguard = (KeyguardManager) app.getSystemService(KEYGUARD_SERVICE);
+    keyguard.newKeyguardLock(name).disableKeyguard();
+    // Wake up the screen.
+    PowerManager power = (PowerManager) app.getSystemService(POWER_SERVICE);
+    wakeLock = power.newWakeLock(FULL_WAKE_LOCK | ACQUIRE_CAUSES_WAKEUP | ON_AFTER_RELEASE, name);
+    wakeLock.acquire();
 
     super.onStart();
   }

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/RxBindingTestRunner.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/RxBindingTestRunner.java
@@ -1,0 +1,34 @@
+package com.jakewharton.rxbinding;
+
+import android.app.KeyguardManager;
+import android.content.Context;
+import android.os.PowerManager;
+import android.support.test.runner.AndroidJUnitRunner;
+
+import static android.content.Context.KEYGUARD_SERVICE;
+import static android.content.Context.POWER_SERVICE;
+import static android.os.PowerManager.ACQUIRE_CAUSES_WAKEUP;
+import static android.os.PowerManager.FULL_WAKE_LOCK;
+import static android.os.PowerManager.ON_AFTER_RELEASE;
+
+public class RxBindingTestRunner extends AndroidJUnitRunner {
+  @Override public void onStart() {
+    runOnMainSync(new Runnable() {
+      @SuppressWarnings("deprecation") // We don't care about deprecation here.
+      @Override public void run() {
+        Context app = getTargetContext().getApplicationContext();
+
+        String name = RxBindingTestRunner.class.getSimpleName();
+        // Unlock the device so that the tests can input keystrokes.
+        KeyguardManager keyguard = (KeyguardManager) app.getSystemService(KEYGUARD_SERVICE);
+        keyguard.newKeyguardLock(name).disableKeyguard();
+        // Wake up the screen.
+        PowerManager power = (PowerManager) app.getSystemService(POWER_SERVICE);
+        power.newWakeLock(FULL_WAKE_LOCK | ACQUIRE_CAUSES_WAKEUP | ON_AFTER_RELEASE, name)
+            .acquire();
+      }
+    });
+
+    super.onStart();
+  }
+}


### PR DESCRIPTION
Addresses #27 

I guess the question is - is there any way to avoid copy-pasting the test runner into the other modules? AFAIK the `androidTest` source set is not available in the `rxbinding-support-v4` module for instance, so the same issue will show up?