### PR TITLE
Ignore kotlin generated annotations directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # IntelliJ IDEA
 .idea
 *.iml
+annotations
 
 # Gradle
 .gradle


### PR DESCRIPTION
IntelliJ will generate annotation information for its static analysis into a top-level `annotations` directory. This adds a line to .gitignore to ignore it