### PR TITLE
Regenerate kotlin bindings via KotlinGen plugin

### DIFF
--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/view/RxView.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/view/RxView.kt
@@ -1,151 +1,265 @@
 package com.jakewharton.rxbinding.view
 
 import android.view.DragEvent
+import android.view.MotionEvent
 import android.view.View
 import rx.Observable
+import com.jakewharton.rxbinding.internal.Functions
 import rx.functions.Action1
+import rx.functions.Func0
+import rx.functions.Func1
 
 /**
  * Create an observable of timestamps for clicks on {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
- * <p>
- * <em>Warning:</em> The created observable uses {@link View#setOnClickListener} to observe
+ * 
+ * *Warning:* The created observable uses {@link View#setOnClickListener} to observe
  * clicks. Only one observable can be used for a view at a time.
  */
 public inline fun View.clicks(): Observable<Any> = RxView.clicks(this)
 
 /**
  * Create an observable of click events for {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
- * <p>
- * <em>Warning:</em> The created observable uses {@link View#setOnClickListener} to observe
+ * 
+ * *Warning:* The created observable uses {@link View#setOnClickListener} to observe
  * clicks. Only one observable can be used for a view at a time.
  */
 public inline fun View.clickEvents(): Observable<ViewClickEvent> = RxView.clickEvents(this)
 
 /**
  * Create an observable of {@link DragEvent} for drags on {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
- * <p>
- * <em>Warning:</em> The created observable uses {@link View#setOnDragListener} to observe
+ * 
+ * *Warning:* The created observable uses {@link View#setOnDragListener} to observe
  * drags. Only one observable can be used for a view at a time.
  */
 public inline fun View.drags(): Observable<DragEvent> = RxView.drags(this)
-// TODO overload with Func
+
+/**
+ * Create an observable of {@link DragEvent} for {@code view}.
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * to free this reference.
+ * 
+ * *Warning:* The created observable uses {@link View#setOnDragListener} to observe
+ * drags. Only one observable can be used for a view at a time.
+ *
+ * @param handled Function invoked with each value to determine the return value of the
+ * underlying {@link View.OnDragListener}.
+ */
+public inline fun View.drags(handled: Func1<DragEvent, Boolean>): Observable<DragEvent> = RxView.drags(this, handled)
 
 /**
  * Create an observable of drag events for {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
- * <p>
- * <em>Warning:</em> The created observable uses {@link View#setOnDragListener} to observe
+ * 
+ * *Warning:* The created observable uses {@link View#setOnDragListener} to observe
  * drags. Only one observable can be used for a view at a time.
  */
 public inline fun View.dragEvents(): Observable<ViewDragEvent> = RxView.dragEvents(this)
-// TODO overload with Func
+
+/**
+ * Create an observable of drag events for {@code view}.
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * to free this reference.
+ * 
+ * *Warning:* The created observable uses {@link View#setOnDragListener} to observe
+ * drags. Only one observable can be used for a view at a time.
+ *
+ * @param handled Function invoked with each value to determine the return value of the
+ * underlying {@link View.OnDragListener}.
+ */
+public inline fun View.dragEvents(handled: Func1<ViewDragEvent, Boolean>): Observable<ViewDragEvent> = RxView.dragEvents(this, handled)
 
 /**
  * Create an observable of booleans representing the focus of {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
- * <p>
- * <em>Warning:</em> The created observable uses {@link View#setOnFocusChangeListener} to observe
+ * 
+ * *Warning:* The created observable uses {@link View#setOnFocusChangeListener} to observe
  * focus change. Only one observable can be used for a view at a time.
  */
 public inline fun View.focusChanges(): Observable<Boolean> = RxView.focusChanges(this)
 
 /**
  * Create an observable of focus-change events for {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
- * <p>
- * <em>Warning:</em> The created observable uses {@link View#setOnFocusChangeListener} to observe
+ * 
+ * *Warning:* The created observable uses {@link View#setOnFocusChangeListener} to observe
  * focus change. Only one observable can be used for a view at a time.
  */
 public inline fun View.focusChangeEvents(): Observable<ViewFocusChangeEvent> = RxView.focusChangeEvents(this)
 
 /**
  * Create an observable of timestamps for long-clicks on {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
- * <p>
- * <em>Warning:</em> The created observable uses {@link View#setOnLongClickListener} to observe
+ * 
+ * *Warning:* The created observable uses {@link View#setOnLongClickListener} to observe
  * long clicks. Only one observable can be used for a view at a time.
  */
 public inline fun View.longClicks(): Observable<Any> = RxView.longClicks(this)
-// TODO overload with Func
+
+/**
+ * Create an observable of timestamps for clicks on {@code view}.
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * to free this reference.
+ * 
+ * *Warning:* The created observable uses {@link View#setOnLongClickListener} to observe
+ * long clicks. Only one observable can be used for a view at a time.
+ *
+ * @param handled Function invoked each occurrence to determine the return value of the
+ * underlying {@link View.OnLongClickListener}.
+ */
+public inline fun View.longClicks(handled: Func0<Boolean>): Observable<Any> = RxView.longClicks(this, handled)
 
 /**
  * Create an observable of long-clicks events for {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
- * <p>
- * <em>Warning:</em> The created observable uses {@link View#setOnLongClickListener} to observe
+ * 
+ * *Warning:* The created observable uses {@link View#setOnLongClickListener} to observe
  * long clicks. Only one observable can be used for a view at a time.
  */
 public inline fun View.longClickEvents(): Observable<ViewLongClickEvent> = RxView.longClickEvents(this)
-// TODO overload with Func
+
+/**
+ * Create an observable of long-click events for {@code view}.
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * to free this reference.
+ * 
+ * *Warning:* The created observable uses {@link View#setOnLongClickListener} to observe
+ * long clicks. Only one observable can be used for a view at a time.
+ *
+ * @param handled Function invoked with each value to determine the return value of the
+ * underlying {@link View.OnLongClickListener}.
+ */
+public inline fun View.longClickEvents(handled: Func1<in ViewLongClickEvent, Boolean>): Observable<ViewLongClickEvent> = RxView.longClickEvents(this, handled)
+
+/**
+ * Create an observable of touch events for {@code view}.
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * to free this reference.
+ * 
+ * *Warning:* The created observable uses {@link View#setOnTouchListener} to observe
+ * touches. Only one observable can be used for a view at a time.
+ */
+public inline fun View.touches(): Observable<MotionEvent> = RxView.touches(this)
+
+/**
+ * Create an observable of touch events for {@code view}.
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * to free this reference.
+ * 
+ * *Warning:* The created observable uses {@link View#setOnTouchListener} to observe
+ * touches. Only one observable can be used for a view at a time.
+ *
+ * @param handled Function invoked with each value to determine the return value of the
+ * underlying {@link View.OnTouchListener}.
+ */
+public inline fun View.touches(handled: Func1<in MotionEvent, Boolean>): Observable<MotionEvent> = RxView.touches(this, handled)
+
+/**
+ * Create an observable of touch events for {@code view}.
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * to free this reference.
+ * 
+ * *Warning:* The created observable uses {@link View#setOnTouchListener} to observe
+ * touches. Only one observable can be used for a view at a time.
+ */
+public inline fun View.touchEvents(): Observable<ViewTouchEvent> = RxView.touchEvents(this)
+
+/**
+ * Create an observable of touch events for {@code view}.
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * to free this reference.
+ * 
+ * *Warning:* The created observable uses {@link View#setOnTouchListener} to observe
+ * touches. Only one observable can be used for a view at a time.
+ *
+ * @param handled Function invoked with each value to determine the return value of the
+ * underlying {@link View.OnTouchListener}.
+ */
+public inline fun View.touchEvents(handled: Func1<in ViewTouchEvent, Boolean>): Observable<ViewTouchEvent> = RxView.touchEvents(this, handled)
 
 /**
  * An action which sets the activated property of {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun View.activated(): Action1<in Boolean> = RxView.activated(this)
 
 /**
  * An action which sets the clickable property of {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun View.clickable(): Action1<in Boolean> = RxView.clickable(this)
 
 /**
  * An action which sets the enabled property of {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun View.enabled(): Action1<in Boolean> = RxView.enabled(this)
 
 /**
  * An action which sets the pressed property of {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun View.pressed(): Action1<in Boolean> = RxView.pressed(this)
 
 /**
  * An action which sets the selected property of {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun View.selected(): Action1<in Boolean> = RxView.selected(this)
 
 /**
+ * An action which sets the visibility property of {@code view}. {@code false} values use
+ * {@link View#GONE View.GONE}.
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * to free this reference.
+ */
+public inline fun View.visibility(): Action1<in Boolean> = RxView.visibility(this)
+
+/**
  * An action which sets the visibility property of {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  *
  * @param visibilityWhenFalse Visibility to set on a {@code false} value ({@link View#INVISIBLE
  * View.INVISIBLE} or {@link View#GONE View.GONE}).
  */
-public inline fun View.visibility(visibilityWhenFalse: Int = View.GONE): Action1<in Boolean> {
-  return RxView.visibility(this, visibilityWhenFalse)
-}
+public inline fun View.visibility(visibilityWhenFalse: Int): Action1<in Boolean> = RxView.visibility(this, visibilityWhenFalse)
+

--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/widget/RxAdapter.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/widget/RxAdapter.kt
@@ -1,10 +1,8 @@
 package com.jakewharton.rxbinding.widget
 
-import android.view.View
-import android.view.ViewGroup
 import android.widget.Adapter
-import android.widget.BaseAdapter
 import rx.Observable
 
 /** Create an observable of data change events for {@code adapter}. */
 public inline fun <T : Adapter> T.dataChanges(): Observable<T> = RxAdapter.dataChanges(this)
+

--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/widget/RxAdapterView.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/widget/RxAdapterView.kt
@@ -2,63 +2,87 @@ package com.jakewharton.rxbinding.widget
 
 import android.widget.Adapter
 import android.widget.AdapterView
+import com.jakewharton.rxbinding.internal.Functions
 import rx.Observable
 import rx.functions.Action1
+import rx.functions.Func0
+import rx.functions.Func1
 
 /**
  * Create an observable of the selected position of {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun <T : Adapter> AdapterView<T>.itemSelections(): Observable<Int> = RxAdapterView.itemSelections(this)
 
 /**
  * Create an observable of selection events for {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun <T : Adapter> AdapterView<T>.selectionEvents(): Observable<AdapterViewSelectionEvent> = RxAdapterView.selectionEvents(this)
 
 /**
  * Create an observable of the position of item clicks for {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun <T : Adapter> AdapterView<T>.itemClicks(): Observable<Int> = RxAdapterView.itemClicks(this)
 
 /**
  * Create an observable of the item click events for {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun <T : Adapter> AdapterView<T>.itemClickEvents(): Observable<AdapterViewItemClickEvent> = RxAdapterView.itemClickEvents(this)
 
 /**
  * Create an observable of the position of item long-clicks for {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun <T : Adapter> AdapterView<T>.itemLongClicks(): Observable<Int> = RxAdapterView.itemLongClicks(this)
-// TODO overload with Func
+
+/**
+ * Create an observable of the position of item long-clicks for {@code view}.
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * to free this reference.
+ *
+ * @param handled Function invoked each occurrence to determine the return value of the
+ * underlying {@link AdapterView.OnItemLongClickListener}.
+ */
+public inline fun <T : Adapter> AdapterView<T>.itemLongClicks(handled: Func0<Boolean>): Observable<Int> = RxAdapterView.itemLongClicks(this, handled)
 
 /**
  * Create an observable of the item long-click events for {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun <T : Adapter> AdapterView<T>.itemLongClickEvents(): Observable<AdapterViewItemLongClickEvent> = RxAdapterView.itemLongClickEvents(this)
-// TODO overload with Func
+
+/**
+ * Create an observable of the item long-click events for {@code view}.
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * to free this reference.
+ *
+ * @param handled Function invoked with each value to determine the return value of the
+ * underlying {@link AdapterView.OnItemLongClickListener}.
+ */
+public inline fun <T : Adapter> AdapterView<T>.itemLongClickEvents(handled: Func1<in AdapterViewItemLongClickEvent, Boolean>): Observable<AdapterViewItemLongClickEvent> = RxAdapterView.itemLongClickEvents(this, handled)
 
 /**
  * An action which sets the selected position of {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun <T : Adapter> AdapterView<T>.selection(): Action1<in Int> = RxAdapterView.selection(this)
+

--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/widget/RxCompoundButton.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/widget/RxCompoundButton.kt
@@ -6,38 +6,39 @@ import rx.functions.Action1
 
 /**
  * Create an observable of booleans representing the checked state of {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
- * <p>
- * <em>Warning:</em> The created observable uses {@link CompoundButton#setOnCheckedChangeListener}
+ * 
+ * *Warning:* The created observable uses {@link CompoundButton#setOnCheckedChangeListener}
  * to observe checked changes. Only one observable can be used for a view at a time.
  */
 public inline fun CompoundButton.checkedChanges(): Observable<Boolean> = RxCompoundButton.checkedChanges(this)
 
 /**
  * Create an observable of checked change events for {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
- * <p>
- * <em>Warning:</em> The created observable uses {@link CompoundButton#setOnCheckedChangeListener}
+ * 
+ * *Warning:* The created observable uses {@link CompoundButton#setOnCheckedChangeListener}
  * to observe checked changes. Only one observable can be used for a view at a time.
  */
 public inline fun CompoundButton.checkedChangeEvents(): Observable<CompoundButtonCheckedChangeEvent> = RxCompoundButton.checkedChangeEvents(this)
 
 /**
  * An action which sets the checked property of {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun CompoundButton.checked(): Action1<in Boolean> = RxCompoundButton.checked(this)
 
 /**
  * An action which sets the toggles property of {@code view} with each value.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun CompoundButton.toggle(): Action1<in Any> = RxCompoundButton.toggle(this)
+

--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/widget/RxProgressBar.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/widget/RxProgressBar.kt
@@ -5,48 +5,49 @@ import rx.functions.Action1
 
 /**
  * An action which increments the progress value of {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
-public inline fun ProgressBar.incrementProgress(): Action1<in Int> = RxProgressBar.incrementProgressBy(this)
+public inline fun ProgressBar.incrementProgressBy(): Action1<in Int> = RxProgressBar.incrementProgressBy(this)
 
 /**
  * An action which increments the secondary progress value of {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
-public inline fun ProgressBar.incrementSecondaryProgress(): Action1<in Int> = RxProgressBar.incrementSecondaryProgressBy(this)
+public inline fun ProgressBar.incrementSecondaryProgressBy(): Action1<in Int> = RxProgressBar.incrementSecondaryProgressBy(this)
 
 /**
  * An action which sets whether {@code view} is indeterminate.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun ProgressBar.indeterminate(): Action1<in Boolean> = RxProgressBar.indeterminate(this)
 
 /**
  * An action which sets the max value of {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun ProgressBar.max(): Action1<in Int> = RxProgressBar.max(this)
 
 /**
  * An action which sets the progress value of {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun ProgressBar.progress(): Action1<in Int> = RxProgressBar.progress(this)
 
 /**
  * An action which sets the secondary progress value of {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun ProgressBar.secondaryProgress(): Action1<in Int> = RxProgressBar.secondaryProgress(this)
+

--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/widget/RxRadioGroup.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/widget/RxRadioGroup.kt
@@ -6,16 +6,16 @@ import rx.functions.Action1
 
 /**
  * Create an observable of the checked view ID changes in {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun RadioGroup.checkedChanges(): Observable<Int> = RxRadioGroup.checkedChanges(this)
 
 /**
  * Create an observable of the checked view ID change events in {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun RadioGroup.checkedChangeEvents(): Observable<RadioGroupCheckedChangeEvent> = RxRadioGroup.checkedChangeEvents(this)
@@ -23,8 +23,9 @@ public inline fun RadioGroup.checkedChangeEvents(): Observable<RadioGroupChecked
 /**
  * An action which sets the checked child of {@code view} with ID. Passing {@code -1} will clear
  * any checked view.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun RadioGroup.checked(): Action1<in Int> = RxRadioGroup.checked(this)
+

--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/widget/RxRatingBar.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/widget/RxRatingBar.kt
@@ -6,32 +6,33 @@ import rx.functions.Action1
 
 /**
  * Create an observable of the rating changes on {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun RatingBar.ratingChanges(): Observable<Float> = RxRatingBar.ratingChanges(this)
 
 /**
  * Create an observable of the rating change events on {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun RatingBar.ratingChangeEvents(): Observable<RatingBarChangeEvent> = RxRatingBar.ratingChangeEvents(this)
 
 /**
  * An action which sets the rating of {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun RatingBar.rating(): Action1<in Float> = RxRatingBar.rating(this)
 
 /**
  * An action which sets whether {@code view} is an indicator (thus non-changeable by the user).
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun RatingBar.isIndicator(): Action1<in Boolean> = RxRatingBar.isIndicator(this)
+

--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/widget/RxSeekBar.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/widget/RxSeekBar.kt
@@ -5,16 +5,17 @@ import rx.Observable
 
 /**
  * Create an observable of progress value changes on {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun SeekBar.changes(): Observable<Int> = RxSeekBar.changes(this)
 
 /**
  * Create an observable of progress change events for {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun SeekBar.changeEvents(): Observable<SeekBarChangeEvent> = RxSeekBar.changeEvents(this)
+

--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/widget/RxTextView.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/widget/RxTextView.kt
@@ -1,67 +1,90 @@
 package com.jakewharton.rxbinding.widget
 
 import android.widget.TextView
-import com.jakewharton.rxbinding.internal.Functions
 import rx.Observable
+import com.jakewharton.rxbinding.internal.Functions
 import rx.functions.Action1
 import rx.functions.Func1
 
 /**
  * Create an observable of editor actions on {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
- * <p>
- * <em>Warning:</em> The created observable uses {@link TextView.OnEditorActionListener} to
+ * 
+ * *Warning:* The created observable uses {@link TextView.OnEditorActionListener} to
+ * observe actions. Only one observable can be used for a view at a time.
+ */
+public inline fun TextView.editorActions(): Observable<Int> = RxTextView.editorActions(this)
+
+/**
+ * Create an observable of editor actions on {@code view}.
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * to free this reference.
+ * 
+ * *Warning:* The created observable uses {@link TextView.OnEditorActionListener} to
  * observe actions. Only one observable can be used for a view at a time.
  *
  * @param handled Function invoked each occurrence to determine the return value of the
  * underlying {@link TextView.OnEditorActionListener}.
  */
-public inline fun TextView.editorActions(handled: Func1<in Int, Boolean> = Functions.FUNC1_ALWAYS_TRUE): Observable<Int> = RxTextView.editorActions(this, handled)
+public inline fun TextView.editorActions(handled: Func1<in Int, Boolean>): Observable<Int> = RxTextView.editorActions(this, handled)
 
 /**
  * Create an observable of editor action events on {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
- * <p>
- * <em>Warning:</em> The created observable uses {@link TextView.OnEditorActionListener} to
+ * 
+ * *Warning:* The created observable uses {@link TextView.OnEditorActionListener} to
+ * observe actions. Only one observable can be used for a view at a time.
+ */
+public inline fun TextView.editorActionEvents(): Observable<TextViewEditorActionEvent> = RxTextView.editorActionEvents(this)
+
+/**
+ * Create an observable of editor action events on {@code view}.
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * to free this reference.
+ * 
+ * *Warning:* The created observable uses {@link TextView.OnEditorActionListener} to
  * observe actions. Only one observable can be used for a view at a time.
  *
  * @param handled Function invoked each occurrence to determine the return value of the
  * underlying {@link TextView.OnEditorActionListener}.
  */
-public inline fun TextView.editorActionEvents(handled: Func1<in TextViewEditorActionEvent, Boolean> = Functions.FUNC1_ALWAYS_TRUE): Observable<TextViewEditorActionEvent> = RxTextView.editorActionEvents(this, handled)
+public inline fun TextView.editorActionEvents(handled: Func1<in TextViewEditorActionEvent, Boolean>): Observable<TextViewEditorActionEvent> = RxTextView.editorActionEvents(this, handled)
 
 /**
  * Create an observable of character sequences for text changes on {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun TextView.textChanges(): Observable<CharSequence> = RxTextView.textChanges(this)
 
 /**
  * Create an observable of text change events for {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun TextView.textChangeEvents(): Observable<TextViewTextChangeEvent> = RxTextView.textChangeEvents(this)
 
 /**
  * An action which sets the text property of {@code view} with character sequences.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun TextView.text(): Action1<in CharSequence> = RxTextView.text(this)
 
 /**
  * An action which sets the text property of {@code view} string resource IDs.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun TextView.textRes(): Action1<in Int> = RxTextView.textRes(this)
+

--- a/rxbinding-support-v4-kotlin/src/main/kotlin/com/jakewharton/rxbinding/support/v4/widget/RxDrawerLayout.kt
+++ b/rxbinding-support-v4-kotlin/src/main/kotlin/com/jakewharton/rxbinding/support/v4/widget/RxDrawerLayout.kt
@@ -6,16 +6,16 @@ import rx.functions.Action1
 
 /**
  * Create an observable of the open state of the drawer of {@code view}.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun DrawerLayout.drawerOpen(): Observable<Boolean> = RxDrawerLayout.drawerOpen(this)
 
 /**
  * An action which sets whether the drawer with {@code gravity} of {@code view} is open.
- * <p>
- * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+ * 
+ * *Warning:* The created observable keeps a strong reference to {@code view}. Unsubscribe
  * to free this reference.
  */
 public inline fun DrawerLayout.open(gravity: Int): Action1<in Boolean> = RxDrawerLayout.open(this, gravity)


### PR DESCRIPTION
This includes some touchups to the documentations to make them more kotlin-esque and adds the following missing implementations:

- `View.drags(Func1)`
- `View.dragEvents(Func1)`
- `View.longClicks(Func0)`
- `View.longClickEvents(Func1)`
- `View.touches()`
- `View.touches(Func0)`
- `View.touchEvents()`
- `View.touchEvents(Func1)`
- `View.visibility()`
- `AdapterView.itemLongClicks(Func0)`
- `AdapterView.itemLongClickEvents(Func1)`
- `TextView.editorActions()`
- `TextView.editorActionEvents()`