### PR TITLE
Debounce checked changes in radio groups.

### DIFF
--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/widget/RxRadioGroupTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/widget/RxRadioGroupTest.java
@@ -36,9 +36,7 @@ public final class RxRadioGroupTest {
 
   @Test @UiThreadTest public void checkedChanges() {
     RecordingObserver<Integer> o = new RecordingObserver<>();
-    Subscription subscription = RxRadioGroup.checkedChanges(view)
-        .distinctUntilChanged() // Radio group changes fire twice!
-        .subscribe(o);
+    Subscription subscription = RxRadioGroup.checkedChanges(view).subscribe(o);
     o.assertNoMoreEvents();
 
     view.check(1);
@@ -58,9 +56,7 @@ public final class RxRadioGroupTest {
 
   @Test @UiThreadTest public void checkedChangeEvents() {
     RecordingObserver<RadioGroupCheckedChangeEvent> o = new RecordingObserver<>();
-    Subscription subscription = RxRadioGroup.checkedChangeEvents(view)
-        .distinctUntilChanged() // Radio group changes fire twice!
-        .subscribe(o);
+    Subscription subscription = RxRadioGroup.checkedChangeEvents(view).subscribe(o);
     o.assertNoMoreEvents();
 
     view.check(1);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RxRadioGroup.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RxRadioGroup.java
@@ -12,7 +12,8 @@ public final class RxRadioGroup {
    * to free this reference.
    */
   public static Observable<Integer> checkedChanges(RadioGroup view) {
-    return Observable.create(new RadioGroupCheckedChangeOnSubscribe(view));
+    return Observable.create(new RadioGroupCheckedChangeOnSubscribe(view))
+        .distinctUntilChanged(); // Radio group can fire non-changes.
   }
 
   /**
@@ -22,7 +23,8 @@ public final class RxRadioGroup {
    * to free this reference.
    */
   public static Observable<RadioGroupCheckedChangeEvent> checkedChangeEvents(RadioGroup view) {
-    return Observable.create(new RadioGroupCheckedChangeEventOnSubscribe(view));
+    return Observable.create(new RadioGroupCheckedChangeEventOnSubscribe(view))
+        .distinctUntilChanged(); // Radio group can fire non-changes.
   }
 
   /**


### PR DESCRIPTION
Radio group tends to fire changes twice and re-fire already-selected IDs when clearing.