### PR TITLE
Implement view attach events + tests

### DIFF
--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/view/RxView.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/view/RxView.kt
@@ -36,7 +36,8 @@ public inline fun View.attachEvents(): Observable<ViewAttachEvent> = RxView.atta
 public inline fun View.detaches(): Observable<Any> = RxView.detaches(this)
 
 /**
- * Create an observable of timestamps for clicks on `view`.
+ * Create an observable which emits on `view` click events. The emitted value is
+ * unspecified and should only be used as notification.
  * 
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
@@ -134,7 +135,8 @@ public inline fun View.focusChanges(): Observable<Boolean> = RxView.focusChanges
 public inline fun View.focusChangeEvents(): Observable<ViewFocusChangeEvent> = RxView.focusChangeEvents(this)
 
 /**
- * Create an observable of timestamps for long-clicks on `view`.
+ * Create an observable which emits on `view` long-click events. The emitted value is
+ * unspecified and should only be used as notification.
  * 
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
@@ -145,7 +147,8 @@ public inline fun View.focusChangeEvents(): Observable<ViewFocusChangeEvent> = R
 public inline fun View.longClicks(): Observable<Any> = RxView.longClicks(this)
 
 /**
- * Create an observable of timestamps for clicks on `view`.
+ * Create an observable which emits on `view` long-click events. The emitted value is
+ * unspecified and should only be used as notification.
  * 
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.

--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/view/RxView.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/view/RxView.kt
@@ -10,12 +10,28 @@ import rx.functions.Func0
 import rx.functions.Func1
 
 /**
+ * Create an observable of timestamps for `view`'s attaches.
+ * 
+ * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
+ * to free this reference.
+ */
+public inline fun View.attaches(): Observable<Any> = RxView.attaches(this)
+
+/**
  * Create an observable of attach and detach events on `view`.
  * 
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
  */
 public inline fun View.attachEvents(): Observable<ViewAttachEvent> = RxView.attachEvents(this)
+
+/**
+ * Create an observable of timestamps for `view`'s detaches.
+ * 
+ * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
+ * to free this reference.
+ */
+public inline fun View.detaches(): Observable<Any> = RxView.detaches(this)
 
 /**
  * Create an observable of timestamps for clicks on `view`.

--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/view/RxView.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/view/RxView.kt
@@ -10,7 +10,8 @@ import rx.functions.Func0
 import rx.functions.Func1
 
 /**
- * Create an observable of timestamps for `view`'s attaches.
+ * Create an observable which emits on `view` attach events. The emitted value is
+ * unspecified and should only be used as notification.
  * 
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
@@ -26,7 +27,8 @@ public inline fun View.attaches(): Observable<Any> = RxView.attaches(this)
 public inline fun View.attachEvents(): Observable<ViewAttachEvent> = RxView.attachEvents(this)
 
 /**
- * Create an observable of timestamps for `view`'s detaches.
+ * Create an observable which emits on `view` detach events. The emitted value is
+ * unspecified and should only be used as notification.
  * 
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.

--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/view/RxView.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/view/RxView.kt
@@ -3,11 +3,19 @@ package com.jakewharton.rxbinding.view
 import android.view.DragEvent
 import android.view.MotionEvent
 import android.view.View
-import rx.Observable
 import com.jakewharton.rxbinding.internal.Functions
+import rx.Observable
 import rx.functions.Action1
 import rx.functions.Func0
 import rx.functions.Func1
+
+/**
+ * Create an observable of attach and detach events on `view`.
+ * 
+ * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
+ * to free this reference.
+ */
+public inline fun View.attachEvents(): Observable<ViewAttachEvent> = RxView.attachEvents(this)
 
 /**
  * Create an observable of timestamps for clicks on `view`.

--- a/rxbinding/src/androidTest/AndroidManifest.xml
+++ b/rxbinding/src/androidTest/AndroidManifest.xml
@@ -4,6 +4,7 @@
     package="com.jakewharton.rxbinding">
 
   <application>
+    <activity android:name=".view.RxViewAttachTestActivity"/>
     <activity android:name=".widget.RxAdapterViewTestActivity"/>
     <activity android:name=".widget.RxRatingBarTestActivity"/>
     <activity android:name=".widget.RxSeekBarTestActivity"/>

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/view/RxViewAttachTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/view/RxViewAttachTest.java
@@ -9,7 +9,6 @@ import android.widget.FrameLayout;
 
 import com.jakewharton.rxbinding.RecordingObserver;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -35,9 +34,6 @@ public final class RxViewAttachTest {
     RxViewAttachTestActivity activity = activityRule.getActivity();
     parent = activity.parent;
     child = activity.child;
-  }
-
-  @After public void tearDown() {
   }
 
   @Test public void attachEvents() {

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/view/RxViewAttachTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/view/RxViewAttachTest.java
@@ -1,0 +1,82 @@
+package com.jakewharton.rxbinding.view;
+
+import android.app.Instrumentation;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.espresso.Espresso;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.view.View;
+import android.widget.FrameLayout;
+
+import com.jakewharton.rxbinding.RecordingObserver;
+import com.jakewharton.rxbinding.ViewDirtyIdlingResource;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import rx.Subscription;
+import rx.android.schedulers.AndroidSchedulers;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.jakewharton.rxbinding.view.ViewAttachEvent.ATTACH;
+import static com.jakewharton.rxbinding.view.ViewAttachEvent.DETACH;
+
+@RunWith(AndroidJUnit4.class)
+public final class RxViewAttachTest {
+  @Rule public final ActivityTestRule<RxViewAttachTestActivity> activityRule =
+      new ActivityTestRule<>(RxViewAttachTestActivity.class);
+
+  private final Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
+  private FrameLayout parent;
+  private View child;
+  private ViewDirtyIdlingResource viewDirtyIdler;
+
+  @Before public void setUp() {
+    RxViewAttachTestActivity activity = activityRule.getActivity();
+    parent = activity.parent;
+    child = activity.child;
+    viewDirtyIdler = new ViewDirtyIdlingResource(activity);
+    Espresso.registerIdlingResources(viewDirtyIdler);
+  }
+
+  @After public void tearDown() {
+    Espresso.unregisterIdlingResources(viewDirtyIdler);
+  }
+
+  @Test public void attachEvents() {
+    RecordingObserver<ViewAttachEvent> o = new RecordingObserver<>();
+    Subscription subscription = RxView.attachEvents(child)
+        .subscribeOn(AndroidSchedulers.mainThread())
+        .subscribe(o);
+    o.assertNoMoreEvents(); // No initial value.
+
+    instrumentation.runOnMainSync(new Runnable() {
+      @Override public void run() {
+        parent.addView(child);
+      }
+    });
+    instrumentation.waitForIdleSync();
+    assertThat(o.takeNext().kind()).isEqualTo(ATTACH);
+    instrumentation.runOnMainSync(new Runnable() {
+      @Override public void run() {
+        parent.removeView(child);
+      }
+    });
+    instrumentation.waitForIdleSync();
+    assertThat(o.takeNext().kind()).isEqualTo(DETACH);
+
+    subscription.unsubscribe();
+
+    instrumentation.runOnMainSync(new Runnable() {
+      @Override public void run() {
+        parent.addView(child);
+        parent.removeView(child);
+      }
+    });
+    instrumentation.waitForIdleSync();
+    o.assertNoMoreEvents();
+  }
+}

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/view/RxViewAttachTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/view/RxViewAttachTest.java
@@ -48,14 +48,12 @@ public final class RxViewAttachTest {
         parent.addView(child);
       }
     });
-    instrumentation.waitForIdleSync();
     assertThat(o.takeNext()).isNotNull();
     instrumentation.runOnMainSync(new Runnable() {
       @Override public void run() {
         parent.removeView(child);
       }
     });
-    instrumentation.waitForIdleSync();
     o.assertNoMoreEvents();
 
     subscription.unsubscribe();
@@ -66,7 +64,6 @@ public final class RxViewAttachTest {
         parent.removeView(child);
       }
     });
-    instrumentation.waitForIdleSync();
     o.assertNoMoreEvents();
   }
 
@@ -82,14 +79,12 @@ public final class RxViewAttachTest {
         parent.addView(child);
       }
     });
-    instrumentation.waitForIdleSync();
     assertThat(o.takeNext().kind()).isEqualTo(ATTACH);
     instrumentation.runOnMainSync(new Runnable() {
       @Override public void run() {
         parent.removeView(child);
       }
     });
-    instrumentation.waitForIdleSync();
     assertThat(o.takeNext().kind()).isEqualTo(DETACH);
 
     subscription.unsubscribe();
@@ -100,7 +95,6 @@ public final class RxViewAttachTest {
         parent.removeView(child);
       }
     });
-    instrumentation.waitForIdleSync();
     o.assertNoMoreEvents();
   }
 
@@ -116,14 +110,12 @@ public final class RxViewAttachTest {
         parent.addView(child);
       }
     });
-    instrumentation.waitForIdleSync();
     o.assertNoMoreEvents();
     instrumentation.runOnMainSync(new Runnable() {
       @Override public void run() {
         parent.removeView(child);
       }
     });
-    instrumentation.waitForIdleSync();
     assertThat(o.takeNext()).isNotNull();
 
     subscription.unsubscribe();
@@ -134,7 +126,6 @@ public final class RxViewAttachTest {
         parent.removeView(child);
       }
     });
-    instrumentation.waitForIdleSync();
     o.assertNoMoreEvents();
   }
 }

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/view/RxViewAttachTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/view/RxViewAttachTest.java
@@ -21,8 +21,8 @@ import rx.Subscription;
 import rx.android.schedulers.AndroidSchedulers;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.jakewharton.rxbinding.view.ViewAttachEvent.ATTACH;
-import static com.jakewharton.rxbinding.view.ViewAttachEvent.DETACH;
+import static com.jakewharton.rxbinding.view.ViewAttachEvent.Kind.ATTACH;
+import static com.jakewharton.rxbinding.view.ViewAttachEvent.Kind.DETACH;
 
 @RunWith(AndroidJUnit4.class)
 public final class RxViewAttachTest {

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/view/RxViewAttachTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/view/RxViewAttachTest.java
@@ -2,14 +2,12 @@ package com.jakewharton.rxbinding.view;
 
 import android.app.Instrumentation;
 import android.support.test.InstrumentationRegistry;
-import android.support.test.espresso.Espresso;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.view.View;
 import android.widget.FrameLayout;
 
 import com.jakewharton.rxbinding.RecordingObserver;
-import com.jakewharton.rxbinding.ViewDirtyIdlingResource;
 
 import org.junit.After;
 import org.junit.Before;
@@ -32,18 +30,14 @@ public final class RxViewAttachTest {
   private final Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
   private FrameLayout parent;
   private View child;
-  private ViewDirtyIdlingResource viewDirtyIdler;
 
   @Before public void setUp() {
     RxViewAttachTestActivity activity = activityRule.getActivity();
     parent = activity.parent;
     child = activity.child;
-    viewDirtyIdler = new ViewDirtyIdlingResource(activity);
-    Espresso.registerIdlingResources(viewDirtyIdler);
   }
 
   @After public void tearDown() {
-    Espresso.unregisterIdlingResources(viewDirtyIdler);
   }
 
   @Test public void attachEvents() {

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/view/RxViewAttachTestActivity.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/view/RxViewAttachTestActivity.java
@@ -1,0 +1,18 @@
+package com.jakewharton.rxbinding.view;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.FrameLayout;
+
+public final class RxViewAttachTestActivity extends Activity {
+  FrameLayout parent;
+  View child;
+
+  @Override protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    parent = new FrameLayout(this);
+    child = new View(this);
+    setContentView(parent);
+  }
+}

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/RxView.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/RxView.java
@@ -21,7 +21,8 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkNotNull;
  */
 public final class RxView {
   /**
-   * Create an observable of timestamps for {@code view}'s attaches.
+   * Create an observable which emits on {@code view} attach events. The emitted value is
+   * unspecified and should only be used as notification.
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
    * to free this reference.
@@ -44,7 +45,8 @@ public final class RxView {
   }
 
   /**
-   * Create an observable of timestamps for {@code view}'s detaches.
+   * Create an observable which emits on {@code view} detach events. The emitted value is
+   * unspecified and should only be used as notification.
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
    * to free this reference.

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/RxView.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/RxView.java
@@ -21,6 +21,17 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkNotNull;
  */
 public final class RxView {
   /**
+   * Create an observable of timestamps for {@code view}'s attaches.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+   * to free this reference.
+   */
+  public static Observable<Object> attaches(View view) {
+    checkNotNull(view, "view == null");
+    return Observable.create(new ViewAttachesOnSubscribe(view, true));
+  }
+
+  /**
    * Create an observable of attach and detach events on {@code view}.
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
@@ -30,6 +41,17 @@ public final class RxView {
   public static Observable<ViewAttachEvent> attachEvents(View view) {
     checkNotNull(view, "view == null");
     return Observable.create(new ViewAttachEventOnSubscribe(view));
+  }
+
+  /**
+   * Create an observable of timestamps for {@code view}'s detaches.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+   * to free this reference.
+   */
+  public static Observable<Object> detaches(View view) {
+    checkNotNull(view, "view == null");
+    return Observable.create(new ViewAttachesOnSubscribe(view, false));
   }
 
   /**

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/RxView.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/RxView.java
@@ -4,8 +4,10 @@ import android.support.annotation.CheckResult;
 import android.view.DragEvent;
 import android.view.MotionEvent;
 import android.view.View;
-import rx.Observable;
+
 import com.jakewharton.rxbinding.internal.Functions;
+
+import rx.Observable;
 import rx.functions.Action1;
 import rx.functions.Func0;
 import rx.functions.Func1;
@@ -18,6 +20,18 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkNotNull;
  * actions} for {@link View}.
  */
 public final class RxView {
+  /**
+   * Create an observable of attach and detach events on {@code view}.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+   * to free this reference.
+   */
+  @CheckResult
+  public static Observable<ViewAttachEvent> attachEvents(View view) {
+    checkNotNull(view, "view == null");
+    return Observable.create(new ViewAttachEventOnSubscribe(view));
+  }
+
   /**
    * Create an observable of timestamps for clicks on {@code view}.
    * <p>

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/RxView.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/RxView.java
@@ -57,7 +57,8 @@ public final class RxView {
   }
 
   /**
-   * Create an observable of timestamps for clicks on {@code view}.
+   * Create an observable which emits on {@code view} click events. The emitted value is
+   * unspecified and should only be used as notification.
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
    * to free this reference.
@@ -191,7 +192,8 @@ public final class RxView {
   }
 
   /**
-   * Create an observable of timestamps for long-clicks on {@code view}.
+   * Create an observable which emits on {@code view} long-click events. The emitted value is
+   * unspecified and should only be used as notification.
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
    * to free this reference.
@@ -206,7 +208,8 @@ public final class RxView {
   }
 
   /**
-   * Create an observable of timestamps for clicks on {@code view}.
+   * Create an observable which emits on {@code view} long-click events. The emitted value is
+   * unspecified and should only be used as notification.
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
    * to free this reference.

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewAttachEvent.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewAttachEvent.java
@@ -36,7 +36,7 @@ public final class ViewAttachEvent extends ViewEvent<View> {
     if (!(o instanceof ViewAttachEvent)) return false;
     ViewAttachEvent other = (ViewAttachEvent) o;
     return other.view() == view()
-        && kind() == other.kind();
+        && other.kind() == kind();
   }
 
   @Override public int hashCode() {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewAttachEvent.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewAttachEvent.java
@@ -1,7 +1,6 @@
 package com.jakewharton.rxbinding.view;
 
 import android.content.Context;
-import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 import android.view.View;
 
@@ -13,24 +12,22 @@ import android.view.View;
  */
 public final class ViewAttachEvent extends ViewEvent<View> {
 
-  public static final int ATTACH = 0;
-  public static final int DETACH = 1;
+  public enum Kind {
+    ATTACH, DETACH
+  }
 
-  @IntDef({ATTACH, DETACH})
-  public @interface Kind {}
-
-  public static ViewAttachEvent create(@NonNull View view, @Kind int kind) {
+  public static ViewAttachEvent create(@NonNull View view, Kind kind) {
     return new ViewAttachEvent(view, kind);
   }
 
-  @Kind private final int kind;
+  private final Kind kind;
 
-  private ViewAttachEvent(View view, @Kind int kind) {
+  private ViewAttachEvent(View view, Kind kind) {
     super(view);
     this.kind = kind;
   }
 
-  @Kind public int kind() {
+  public Kind kind() {
     return kind;
   }
 
@@ -45,7 +42,7 @@ public final class ViewAttachEvent extends ViewEvent<View> {
   @Override public int hashCode() {
     int result = 17;
     result = result * 37 + view().hashCode();
-    result = result * 37 + kind();
+    result = result * 37 + kind().hashCode();
     return result;
   }
 
@@ -53,7 +50,7 @@ public final class ViewAttachEvent extends ViewEvent<View> {
     return "ViewAttachEvent{view="
         + view()
         + ", kind="
-        + (kind == ATTACH ? "ATTACH" : "DETACH")
+        + kind()
         + '}';
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewAttachEvent.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewAttachEvent.java
@@ -1,0 +1,59 @@
+package com.jakewharton.rxbinding.view;
+
+import android.content.Context;
+import android.support.annotation.IntDef;
+import android.support.annotation.NonNull;
+import android.view.View;
+
+/**
+ * A view attach event on a view.
+ * <p>
+ * <strong>Warning:</strong> Instances keep a strong reference to the view. Operators that
+ * cache instances have the potential to leak the associated {@link Context}.
+ */
+public final class ViewAttachEvent extends ViewEvent<View> {
+
+  public static final int ATTACH = 0;
+  public static final int DETACH = 1;
+
+  @IntDef({ATTACH, DETACH})
+  public @interface Kind {}
+
+  public static ViewAttachEvent create(@NonNull View view, @Kind int kind) {
+    return new ViewAttachEvent(view, kind);
+  }
+
+  @Kind private final int kind;
+
+  private ViewAttachEvent(View view, @Kind int kind) {
+    super(view);
+    this.kind = kind;
+  }
+
+  @Kind public int kind() {
+    return kind;
+  }
+
+  @Override public boolean equals(Object o) {
+    if (o == this) return true;
+    if (!(o instanceof ViewAttachEvent)) return false;
+    ViewAttachEvent other = (ViewAttachEvent) o;
+    return other.view() == view()
+        && kind() == other.kind();
+  }
+
+  @Override public int hashCode() {
+    int result = 17;
+    result = result * 37 + view().hashCode();
+    result = result * 37 + kind();
+    return result;
+  }
+
+  @Override public String toString() {
+    return "ViewAttachEvent{view="
+        + view()
+        + ", kind="
+        + (kind == ATTACH ? "ATTACH" : "DETACH")
+        + '}';
+  }
+}

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewAttachEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewAttachEventOnSubscribe.java
@@ -9,8 +9,8 @@ import rx.Observable;
 import rx.Subscriber;
 
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
-import static com.jakewharton.rxbinding.view.ViewAttachEvent.ATTACH;
-import static com.jakewharton.rxbinding.view.ViewAttachEvent.DETACH;
+import static com.jakewharton.rxbinding.view.ViewAttachEvent.Kind.ATTACH;
+import static com.jakewharton.rxbinding.view.ViewAttachEvent.Kind.DETACH;
 
 final class ViewAttachEventOnSubscribe implements Observable.OnSubscribe<ViewAttachEvent> {
   private final View view;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewAttachEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewAttachEventOnSubscribe.java
@@ -1,0 +1,47 @@
+package com.jakewharton.rxbinding.view;
+
+import android.support.annotation.NonNull;
+import android.view.View;
+
+import com.jakewharton.rxbinding.internal.MainThreadSubscription;
+
+import rx.Observable;
+import rx.Subscriber;
+
+import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
+import static com.jakewharton.rxbinding.view.ViewAttachEvent.ATTACH;
+import static com.jakewharton.rxbinding.view.ViewAttachEvent.DETACH;
+
+final class ViewAttachEventOnSubscribe implements Observable.OnSubscribe<ViewAttachEvent> {
+  private final View view;
+
+  ViewAttachEventOnSubscribe(View view) {
+    this.view = view;
+  }
+
+  @Override public void call(final Subscriber<? super ViewAttachEvent> subscriber) {
+    checkUiThread();
+
+    final View.OnAttachStateChangeListener listener = new View.OnAttachStateChangeListener() {
+      @Override public void onViewAttachedToWindow(@NonNull final View v) {
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(ViewAttachEvent.create(view, ATTACH));
+        }
+      }
+
+      @Override public void onViewDetachedFromWindow(@NonNull final View v) {
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(ViewAttachEvent.create(view, DETACH));
+        }
+      }
+    };
+
+    subscriber.add(new MainThreadSubscription() {
+      @Override protected void onUnsubscribe() {
+        view.removeOnAttachStateChangeListener(listener);
+      }
+    });
+
+    view.addOnAttachStateChangeListener(listener);
+  }
+}

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewAttachesOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewAttachesOnSubscribe.java
@@ -1,0 +1,48 @@
+package com.jakewharton.rxbinding.view;
+
+import android.support.annotation.NonNull;
+import android.view.View;
+
+import com.jakewharton.rxbinding.internal.MainThreadSubscription;
+
+import rx.Observable;
+import rx.Subscriber;
+
+import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
+
+final class ViewAttachesOnSubscribe implements Observable.OnSubscribe<Object> {
+  private final Object event = new Object();
+  private final boolean callOnAttach;
+  private final View view;
+
+  ViewAttachesOnSubscribe(View view, boolean callOnAttach) {
+    this.view = view;
+    this.callOnAttach = callOnAttach;
+  }
+
+  @Override public void call(final Subscriber<? super Object> subscriber) {
+    checkUiThread();
+
+    final View.OnAttachStateChangeListener listener = new View.OnAttachStateChangeListener() {
+      @Override public void onViewAttachedToWindow(@NonNull final View v) {
+        if (callOnAttach && !subscriber.isUnsubscribed()) {
+          subscriber.onNext(event);
+        }
+      }
+
+      @Override public void onViewDetachedFromWindow(@NonNull final View v) {
+        if (!callOnAttach && !subscriber.isUnsubscribed()) {
+          subscriber.onNext(event);
+        }
+      }
+    };
+
+    subscriber.add(new MainThreadSubscription() {
+      @Override protected void onUnsubscribe() {
+        view.removeOnAttachStateChangeListener(listener);
+      }
+    });
+
+    view.addOnAttachStateChangeListener(listener);
+  }
+}


### PR DESCRIPTION
As brought up in #70 

@dlew and I talked in https://github.com/trello/RxLifecycle/pull/12 about it being nice if we could back its `bindView` implementation under the hood with the one you suggested in #70. This would also avoid the event class clashing if one uses both libraries.