### PR TITLE
Add listener to target view before registering unsubscribe action.

### DIFF
--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/ToolbarItemClickOnSubscribe.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/ToolbarItemClickOnSubscribe.java
@@ -26,13 +26,12 @@ final class ToolbarItemClickOnSubscribe implements Observable.OnSubscribe<MenuIt
         return true;
       }
     };
+    view.setOnMenuItemClickListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnMenuItemClickListener(null);
       }
     });
-
-    view.setOnMenuItemClickListener(listener);
   }
 }

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/NavigationViewItemSelectionsOnSubscribe.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/NavigationViewItemSelectionsOnSubscribe.java
@@ -28,14 +28,13 @@ final class NavigationViewItemSelectionsOnSubscribe implements Observable.OnSubs
             return true;
           }
         };
+    view.setNavigationItemSelectedListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setNavigationItemSelectedListener(null);
       }
     });
-
-    view.setNavigationItemSelectedListener(listener);
 
     // Emit initial checked item, if one can be found.
     Menu menu = view.getMenu();

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/TabLayoutSelectionEventOnSubscribe.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/TabLayoutSelectionEventOnSubscribe.java
@@ -41,14 +41,13 @@ final class TabLayoutSelectionEventOnSubscribe
         }
       }
     };
+    view.setOnTabSelectedListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnTabSelectedListener(null);
       }
     });
-
-    view.setOnTabSelectedListener(listener);
 
     int index = view.getSelectedTabPosition();
     if (index != -1) {

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/TabLayoutSelectionsOnSubscribe.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/TabLayoutSelectionsOnSubscribe.java
@@ -31,14 +31,13 @@ final class TabLayoutSelectionsOnSubscribe implements Observable.OnSubscribe<Tab
       @Override public void onTabReselected(Tab tab) {
       }
     };
+    view.setOnTabSelectedListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnTabSelectedListener(null);
       }
     });
-
-    view.setOnTabSelectedListener(listener);
 
     int index = view.getSelectedTabPosition();
     if (index != -1) {

--- a/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RecyclerViewScrollEventOnSubscribe.java
+++ b/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RecyclerViewScrollEventOnSubscribe.java
@@ -28,14 +28,12 @@ final class RecyclerViewScrollEventOnSubscribe
         }
       }
     };
+    recyclerView.addOnScrollListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
-      @Override
-      protected void onUnsubscribe() {
+      @Override protected void onUnsubscribe() {
         recyclerView.removeOnScrollListener(listener);
       }
     });
-
-    recyclerView.addOnScrollListener(listener);
   }
 }

--- a/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RecyclerViewScrollStateChangeEventOnSubscribe.java
+++ b/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RecyclerViewScrollStateChangeEventOnSubscribe.java
@@ -28,13 +28,12 @@ final class RecyclerViewScrollStateChangeEventOnSubscribe
         }
       }
     };
+    recyclerView.addOnScrollListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         recyclerView.removeOnScrollListener(listener);
       }
     });
-
-    recyclerView.addOnScrollListener(listener);
   }
 }

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/DrawerLayoutDrawerOpenedOnSubscribe.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/DrawerLayoutDrawerOpenedOnSubscribe.java
@@ -46,14 +46,13 @@ final class DrawerLayoutDrawerOpenedOnSubscribe implements Observable.OnSubscrib
         }
       }
     };
+    view.setDrawerListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setDrawerListener(null);
       }
     });
-
-    view.setDrawerListener(listener);
 
     // Emit initial value.
     subscriber.onNext(view.isDrawerOpen(gravity));

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/SwipeRefreshLayoutRefreshOnSubscribe.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/SwipeRefreshLayoutRefreshOnSubscribe.java
@@ -22,13 +22,12 @@ final class SwipeRefreshLayoutRefreshOnSubscribe implements Observable.OnSubscri
         subscriber.onNext(null);
       }
     };
+    view.setOnRefreshListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnRefreshListener(null);
       }
     });
-
-    view.setOnRefreshListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewAttachEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewAttachEventOnSubscribe.java
@@ -35,13 +35,12 @@ final class ViewAttachEventOnSubscribe implements Observable.OnSubscribe<ViewAtt
         }
       }
     };
+    view.addOnAttachStateChangeListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.removeOnAttachStateChangeListener(listener);
       }
     });
-
-    view.addOnAttachStateChangeListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewAttachesOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewAttachesOnSubscribe.java
@@ -36,13 +36,12 @@ final class ViewAttachesOnSubscribe implements Observable.OnSubscribe<Object> {
         }
       }
     };
+    view.addOnAttachStateChangeListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.removeOnAttachStateChangeListener(listener);
       }
     });
-
-    view.addOnAttachStateChangeListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewClickEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewClickEventOnSubscribe.java
@@ -24,13 +24,12 @@ final class ViewClickEventOnSubscribe implements Observable.OnSubscribe<ViewClic
         }
       }
     };
+    view.setOnClickListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnClickListener(null);
       }
     });
-
-    view.setOnClickListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewClickOnSubscribe.java
@@ -25,13 +25,12 @@ final class ViewClickOnSubscribe implements Observable.OnSubscribe<Object> {
         }
       }
     };
+    view.setOnClickListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnClickListener(null);
       }
     });
-
-    view.setOnClickListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewDragEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewDragEventOnSubscribe.java
@@ -33,13 +33,12 @@ final class ViewDragEventOnSubscribe implements Observable.OnSubscribe<ViewDragE
         return false;
       }
     };
+    view.setOnDragListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnDragListener(null);
       }
     });
-
-    view.setOnDragListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewDragOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewDragOnSubscribe.java
@@ -32,13 +32,12 @@ final class ViewDragOnSubscribe implements Observable.OnSubscribe<DragEvent> {
         return false;
       }
     };
+    view.setOnDragListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnDragListener(null);
       }
     });
-
-    view.setOnDragListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewFocusChangeEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewFocusChangeEventOnSubscribe.java
@@ -25,14 +25,13 @@ final class ViewFocusChangeEventOnSubscribe
         }
       }
     };
+    view.setOnFocusChangeListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnFocusChangeListener(null);
       }
     });
-
-    view.setOnFocusChangeListener(listener);
 
     // Emit initial value.
     subscriber.onNext(ViewFocusChangeEvent.create(view, view.hasFocus()));

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewFocusChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewFocusChangeOnSubscribe.java
@@ -24,14 +24,13 @@ final class ViewFocusChangeOnSubscribe implements Observable.OnSubscribe<Boolean
         }
       }
     };
+    view.setOnFocusChangeListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnFocusChangeListener(null);
       }
     });
-
-    view.setOnFocusChangeListener(listener);
 
     // Emit initial value.
     subscriber.onNext(view.hasFocus());

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewLongClickEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewLongClickEventOnSubscribe.java
@@ -32,13 +32,12 @@ final class ViewLongClickEventOnSubscribe implements Observable.OnSubscribe<View
         return false;
       }
     };
+    view.setOnLongClickListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnLongClickListener(null);
       }
     });
-
-    view.setOnLongClickListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewLongClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewLongClickOnSubscribe.java
@@ -32,13 +32,12 @@ final class ViewLongClickOnSubscribe implements Observable.OnSubscribe<Object> {
         return false;
       }
     };
+    view.setOnLongClickListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnLongClickListener(null);
       }
     });
-
-    view.setOnLongClickListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTouchEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTouchEventOnSubscribe.java
@@ -34,13 +34,12 @@ final class ViewTouchEventOnSubscribe implements Observable.OnSubscribe<ViewTouc
         return false;
       }
     };
+    view.setOnTouchListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnTouchListener(null);
       }
     });
-
-    view.setOnTouchListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTouchOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTouchOnSubscribe.java
@@ -33,13 +33,12 @@ final class ViewTouchOnSubscribe implements Observable.OnSubscribe<MotionEvent> 
         return false;
       }
     };
+    view.setOnTouchListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnTouchListener(null);
       }
     });
-
-    view.setOnTouchListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterDataChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterDataChangeOnSubscribe.java
@@ -26,14 +26,13 @@ final class AdapterDataChangeOnSubscribe<T extends Adapter>
         }
       }
     };
+    adapter.registerDataSetObserver(observer);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         adapter.unregisterDataSetObserver(observer);
       }
     });
-
-    adapter.registerDataSetObserver(observer);
 
     // Emit initial value.
     subscriber.onNext(adapter);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemClickEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemClickEventOnSubscribe.java
@@ -26,13 +26,12 @@ final class AdapterViewItemClickEventOnSubscribe
         }
       }
     };
+    view.setOnItemClickListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnItemClickListener(null);
       }
     });
-
-    view.setOnItemClickListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemClickOnSubscribe.java
@@ -25,13 +25,12 @@ final class AdapterViewItemClickOnSubscribe implements Observable.OnSubscribe<In
         }
       }
     };
+    view.setOnItemClickListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnItemClickListener(null);
       }
     });
-
-    view.setOnItemClickListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemLongClickEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemLongClickEventOnSubscribe.java
@@ -37,13 +37,12 @@ final class AdapterViewItemLongClickEventOnSubscribe
         return false;
       }
     };
+    view.setOnItemLongClickListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnItemLongClickListener(null);
       }
     });
-
-    view.setOnItemLongClickListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemLongClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemLongClickOnSubscribe.java
@@ -33,13 +33,12 @@ final class AdapterViewItemLongClickOnSubscribe implements Observable.OnSubscrib
         return false;
       }
     };
+    view.setOnItemLongClickListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnItemLongClickListener(null);
       }
     });
-
-    view.setOnItemLongClickListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemSelectionOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemSelectionOnSubscribe.java
@@ -33,14 +33,13 @@ final class AdapterViewItemSelectionOnSubscribe implements Observable.OnSubscrib
         }
       }
     };
+    view.setOnItemSelectedListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnItemSelectedListener(null);
       }
     });
-
-    view.setOnItemSelectedListener(listener);
 
     // Emit initial value.
     subscriber.onNext(view.getSelectedItemPosition());

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewSelectionOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewSelectionOnSubscribe.java
@@ -34,14 +34,13 @@ final class AdapterViewSelectionOnSubscribe
         }
       }
     };
+    view.setOnItemSelectedListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnItemSelectedListener(null);
       }
     });
-
-    view.setOnItemSelectedListener(listener);
 
     // Emit initial value.
     int selectedPosition = view.getSelectedItemPosition();

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/CompoundButtonCheckedChangeEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/CompoundButtonCheckedChangeEventOnSubscribe.java
@@ -26,14 +26,13 @@ final class CompoundButtonCheckedChangeEventOnSubscribe
         }
       }
     };
+    view.setOnCheckedChangeListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnCheckedChangeListener(null);
       }
     });
-
-    view.setOnCheckedChangeListener(listener);
 
     // Emit initial value.
     subscriber.onNext(CompoundButtonCheckedChangeEvent.create(view, view.isChecked()));

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/CompoundButtonCheckedChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/CompoundButtonCheckedChangeOnSubscribe.java
@@ -24,14 +24,13 @@ final class CompoundButtonCheckedChangeOnSubscribe implements Observable.OnSubsc
         }
       }
     };
+    view.setOnCheckedChangeListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnCheckedChangeListener(null);
       }
     });
-
-    view.setOnCheckedChangeListener(listener);
 
     // Emit initial value.
     subscriber.onNext(view.isChecked());

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RadioGroupCheckedChangeEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RadioGroupCheckedChangeEventOnSubscribe.java
@@ -25,14 +25,13 @@ final class RadioGroupCheckedChangeEventOnSubscribe
         }
       }
     };
+    view.setOnCheckedChangeListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnCheckedChangeListener(null);
       }
     });
-
-    view.setOnCheckedChangeListener(listener);
 
     // Emit initial value.
     subscriber.onNext(RadioGroupCheckedChangeEvent.create(view, view.getCheckedRadioButtonId()));

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RadioGroupCheckedChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RadioGroupCheckedChangeOnSubscribe.java
@@ -24,14 +24,13 @@ final class RadioGroupCheckedChangeOnSubscribe implements Observable.OnSubscribe
         }
       }
     };
+    view.setOnCheckedChangeListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnCheckedChangeListener(null);
       }
     });
-
-    view.setOnCheckedChangeListener(listener);
 
     // Emit initial value.
     subscriber.onNext(view.getCheckedRadioButtonId());

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RatingBarRatingChangeEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RatingBarRatingChangeEventOnSubscribe.java
@@ -25,14 +25,13 @@ final class RatingBarRatingChangeEventOnSubscribe
         }
       }
     };
+    view.setOnRatingBarChangeListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnRatingBarChangeListener(null);
       }
     });
-
-    view.setOnRatingBarChangeListener(listener);
 
     // Emit initial value.
     subscriber.onNext(RatingBarChangeEvent.create(view, view.getRating(), false));

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RatingBarRatingChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RatingBarRatingChangeOnSubscribe.java
@@ -24,14 +24,13 @@ final class RatingBarRatingChangeOnSubscribe implements Observable.OnSubscribe<F
         }
       }
     };
+    view.setOnRatingBarChangeListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnRatingBarChangeListener(null);
       }
     });
-
-    view.setOnRatingBarChangeListener(listener);
 
     // Emit initial value.
     subscriber.onNext(view.getRating());

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SeekBarChangeEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SeekBarChangeEventOnSubscribe.java
@@ -37,14 +37,13 @@ final class SeekBarChangeEventOnSubscribe
         }
       }
     };
+    view.setOnSeekBarChangeListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnSeekBarChangeListener(null);
       }
     });
-
-    view.setOnSeekBarChangeListener(listener);
 
     // Emit initial value.
     subscriber.onNext(SeekBarProgressChangeEvent.create(view, view.getProgress(), false));

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SeekBarChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SeekBarChangeOnSubscribe.java
@@ -30,14 +30,13 @@ final class SeekBarChangeOnSubscribe implements Observable.OnSubscribe<Integer> 
       @Override public void onStopTrackingTouch(SeekBar seekBar) {
       }
     };
+    view.setOnSeekBarChangeListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnSeekBarChangeListener(null);
       }
     });
-
-    view.setOnSeekBarChangeListener(listener);
 
     // Emit initial value.
     subscriber.onNext(view.getProgress());

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewEditorActionEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewEditorActionEventOnSubscribe.java
@@ -35,13 +35,12 @@ final class TextViewEditorActionEventOnSubscribe
         return false;
       }
     };
+    view.setOnEditorActionListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnEditorActionListener(null);
       }
     });
-
-    view.setOnEditorActionListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewEditorActionOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewEditorActionOnSubscribe.java
@@ -32,13 +32,12 @@ final class TextViewEditorActionOnSubscribe implements Observable.OnSubscribe<In
         return false;
       }
     };
+    view.setOnEditorActionListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnEditorActionListener(null);
       }
     });
-
-    view.setOnEditorActionListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewTextEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewTextEventOnSubscribe.java
@@ -33,14 +33,13 @@ final class TextViewTextEventOnSubscribe
       @Override public void afterTextChanged(Editable s) {
       }
     };
+    view.addTextChangedListener(watcher);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.removeTextChangedListener(watcher);
       }
     });
-
-    view.addTextChangedListener(watcher);
 
     // Emit initial value.
     subscriber.onNext(TextViewTextChangeEvent.create(view, view.getText(), 0, 0, 0));

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewTextOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewTextOnSubscribe.java
@@ -32,14 +32,13 @@ final class TextViewTextOnSubscribe implements Observable.OnSubscribe<CharSequen
       @Override public void afterTextChanged(Editable s) {
       }
     };
+    view.addTextChangedListener(watcher);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.removeTextChangedListener(watcher);
       }
     });
-
-    view.addTextChangedListener(watcher);
 
     // Emit initial value.
     subscriber.onNext(view.getText());


### PR DESCRIPTION
This avoids a theoretically possible (albeit technically implausible) leak which could happen if the new subscribe was unsubscribed on a different thread between what was previously the unsubscription action registration and then the listener adding. If this happened, the unsubscribe action would run immediately and then the listener would be added to the target view with no way to remove it. Events would not be emitted because of the `isUnsubscribed()` checks in the callbacks.