### PR TITLE
Binding for RecyclerView's Adapter 

### DIFF
--- a/rxbinding-recyclerview-v7-kotlin/src/main/kotlin/com/jakewharton/rxbinding/support/v7/widget/RxRecyclerViewAdapter.kt
+++ b/rxbinding-recyclerview-v7-kotlin/src/main/kotlin/com/jakewharton/rxbinding/support/v7/widget/RxRecyclerViewAdapter.kt
@@ -1,0 +1,13 @@
+package com.jakewharton.rxbinding.support.v7.widget
+
+import android.support.v7.widget.RecyclerView
+import android.support.v7.widget.RecyclerView.Adapter
+import android.support.v7.widget.RecyclerView.ViewHolder
+import rx.Observable
+
+/**
+ * Create an observable of data change events for `RecyclerView.adapter`.
+ * 
+ * *Note:* A value will be emitted immediately on subscribe.
+ */
+public inline fun <T : Adapter<out ViewHolder>> T.dataChanges(): Observable<T> = RxRecyclerViewAdapter.dataChanges(this)

--- a/rxbinding-recyclerview-v7/src/androidTest/java/com/jakewharton/rxbinding/support/v7/widget/RxRecyclerViewAdapterTest.java
+++ b/rxbinding-recyclerview-v7/src/androidTest/java/com/jakewharton/rxbinding/support/v7/widget/RxRecyclerViewAdapterTest.java
@@ -1,0 +1,55 @@
+package com.jakewharton.rxbinding.support.v7.widget;
+
+import android.support.test.annotation.UiThreadTest;
+import android.support.test.rule.UiThreadTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.RecyclerView.ViewHolder;
+import android.view.ViewGroup;
+
+import com.jakewharton.rxbinding.RecordingObserver;
+import com.jakewharton.rxbinding.widget.RxAdapter;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import rx.Subscription;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(AndroidJUnit4.class)
+public final class RxRecyclerViewAdapterTest {
+  @Rule public final UiThreadTestRule uiThread = new UiThreadTestRule();
+
+  private final TestRecyclerAdapter adapter = new TestRecyclerAdapter();
+
+  @Test @UiThreadTest public void dataChanges() {
+    RecordingObserver<Object> o = new RecordingObserver<>();
+    Subscription subscription = RxRecyclerViewAdapter.dataChanges(adapter).subscribe(o);
+    assertThat(o.takeNext()).isSameAs(adapter);
+
+    adapter.notifyDataSetChanged();
+    assertThat(o.takeNext()).isSameAs(adapter);
+
+    adapter.notifyDataSetChanged();
+    assertThat(o.takeNext()).isSameAs(adapter);
+
+    subscription.unsubscribe();
+    adapter.notifyDataSetChanged();
+    o.assertNoMoreEvents();
+  }
+
+  private static final class TestRecyclerAdapter extends RecyclerView.Adapter<ViewHolder> {
+    @Override public ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+      return null;
+    }
+
+    @Override public void onBindViewHolder(ViewHolder holder, int position) {
+    }
+
+    @Override public int getItemCount() {
+      return 0;
+    }
+  }
+}

--- a/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RecyclerAdapterDataChangeOnSubscribe.java
+++ b/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RecyclerAdapterDataChangeOnSubscribe.java
@@ -1,0 +1,45 @@
+package com.jakewharton.rxbinding.support.v7.widget;
+
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.RecyclerView.AdapterDataObserver;
+
+import com.jakewharton.rxbinding.internal.MainThreadSubscription;
+
+import rx.Observable;
+import rx.Subscriber;
+
+import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
+
+final class RecyclerAdapterDataChangeOnSubscribe<T extends RecyclerView.Adapter<? extends RecyclerView.ViewHolder>>
+        implements Observable.OnSubscribe<T> {
+  private final T adapter;
+
+  public RecyclerAdapterDataChangeOnSubscribe(T adapter) {
+    this.adapter = adapter;
+  }
+
+  @Override
+  public void call(final Subscriber<? super T> subscriber) {
+    checkUiThread();
+    final AdapterDataObserver observer = new RecyclerView.AdapterDataObserver() {
+      @Override
+      public void onChanged() {
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(adapter);
+        }
+      }
+    };
+    adapter.registerAdapterDataObserver(observer);
+
+    subscriber.add(new MainThreadSubscription() {
+      @Override protected void onUnsubscribe() {
+        adapter.unregisterAdapterDataObserver(observer);
+      }
+    });
+
+    // Emit initial value.
+    subscriber.onNext(adapter);
+  }
+
+
+}

--- a/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RxRecyclerViewAdapter.java
+++ b/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RxRecyclerViewAdapter.java
@@ -1,0 +1,28 @@
+package com.jakewharton.rxbinding.support.v7.widget;
+
+import android.support.annotation.CheckResult;
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.RecyclerView.Adapter;
+import android.support.v7.widget.RecyclerView.ViewHolder;
+
+import rx.Observable;
+
+/**
+ * Static factory methods for creating {@linkplain Observable observables} for {@link Adapter}.
+ */
+public final class RxRecyclerViewAdapter {
+  /**
+   * Create an observable of data change events for {@code RecyclerView.adapter}.
+   * <p>
+   * <em>Note:</em> A value will be emitted immediately on subscribe.
+   */
+  @CheckResult @NonNull
+  public static <T extends Adapter<? extends ViewHolder>> Observable<T> dataChanges(@NonNull T adapter) {
+    return Observable.create(new RecyclerAdapterDataChangeOnSubscribe<>(adapter));
+  }
+
+  private RxRecyclerViewAdapter() {
+    throw new AssertionError("No instances.");
+  }
+}


### PR DESCRIPTION
I had to change the generated RxRecyclerViewAdapter.kt manualy to fix recyclerview-v7-kotlin build  since KotlinGenTask doesnt seem to support nested levels of parameterized types. I'm not familiar with kotlin and groovy, but  i will continue looking at fixing kotlin generated code for this but thought i would start with this PR first. 