### PR TITLE
Variance annotation support and fixed typeParams

### DIFF
--- a/buildSrc/src/main/groovy/com/jakewharton/rxbinding/project/KotlinGenTask.groovy
+++ b/buildSrc/src/main/groovy/com/jakewharton/rxbinding/project/KotlinGenTask.groovy
@@ -199,7 +199,7 @@ class KotlinGenTask extends SourceTask {
 
       StringBuilder builder = new StringBuilder()
       builder.append("<")
-      params.each { p -> builder.append("${p.name} : ${p.typeBound[0].name}") }
+      params.each { p -> builder.append("${p.name} : ${resolveKotlinType(p.typeBound[0])}") }
       builder.append(">")
       return builder.toString()
     }

--- a/buildSrc/src/main/groovy/com/jakewharton/rxbinding/project/KotlinGenTask.groovy
+++ b/buildSrc/src/main/groovy/com/jakewharton/rxbinding/project/KotlinGenTask.groovy
@@ -270,7 +270,13 @@ class KotlinGenTask extends SourceTask {
       return resolveKotlinTypeByName(inputType.toString())
     } else if (inputType instanceof WildcardType) {
       WildcardType wc = inputType as WildcardType
-      return "in ${resolveKotlinType(wc.super)}"
+      if (wc.super) {
+        return "in ${resolveKotlinType(wc.super)}"
+      } else if (wc.extends) {
+        return "out ${resolveKotlinType(wc.extends)}"
+      } else {
+        throw IllegalStateException("Wildcard with no super or extends")
+      }
     } else {
       throw new NotImplementedException()
     }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/internal/MainThreadSubscription.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/internal/MainThreadSubscription.java
@@ -2,12 +2,15 @@ package com.jakewharton.rxbinding.internal;
 
 import android.os.Handler;
 import android.os.Looper;
+import android.support.annotation.Keep;
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import rx.Subscription;
 
 public abstract class MainThreadSubscription implements Subscription, Runnable {
   private static final Handler mainThread = new Handler(Looper.getMainLooper());
 
+  @Keep
   @SuppressWarnings("unused") // Updated by 'unsubscribedUpdater' object.
   private volatile int unsubscribed;
   private static final AtomicIntegerFieldUpdater<MainThreadSubscription> unsubscribedUpdater =


### PR DESCRIPTION
Should properly handle nested method type parameters now and also handle "? extends ___" wildcard objects, which use the `out` specifier rather than `in`

/CC @chemouna, this should fix the Kotlin generation issues in #109