### PR TITLE
Added bindings for hover events.

### DIFF
--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/view/RxView.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/view/RxView.kt
@@ -135,6 +135,56 @@ public inline fun View.focusChanges(): Observable<Boolean> = RxView.focusChanges
 public inline fun View.focusChangeEvents(): Observable<ViewFocusChangeEvent> = RxView.focusChangeEvents(this)
 
 /**
+ * Create an observable of hover events for `view`.
+ * 
+ * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
+ * to free this reference.
+ * 
+ * *Warning:* The created observable uses [View.setOnHoverListener] to observe
+ * touches. Only one observable can be used for a view at a time.
+ */
+public inline fun View.hovers(): Observable<MotionEvent> = RxView.hovers(this)
+
+/**
+ * Create an observable of hover events for `view`.
+ * 
+ * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
+ * to free this reference.
+ * 
+ * *Warning:* The created observable uses [View.setOnHoverListener] to observe
+ * touches. Only one observable can be used for a view at a time.
+ *
+ * @param handled Function invoked with each value to determine the return value of the
+ * underlying [View.OnHoverListener].
+ */
+public inline fun View.hovers(handled: Func1<in MotionEvent, Boolean>): Observable<MotionEvent> = RxView.hovers(this, handled)
+
+/**
+ * Create an observable of hover events for `view`.
+ * 
+ * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
+ * to free this reference.
+ * 
+ * *Warning:* The created observable uses [View.setOnHoverListener] to observe
+ * touches. Only one observable can be used for a view at a time.
+ */
+public inline fun View.hoverEvents(): Observable<ViewHoverEvent> = RxView.hoverEvents(this)
+
+/**
+ * Create an observable of hover events for `view`.
+ * 
+ * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
+ * to free this reference.
+ * 
+ * *Warning:* The created observable uses [View.setOnHoverListener] to observe
+ * touches. Only one observable can be used for a view at a time.
+ *
+ * @param handled Function invoked with each value to determine the return value of the
+ * underlying [View.OnHoverListener].
+ */
+public inline fun View.hoverEvents(handled: Func1<in ViewHoverEvent, Boolean>): Observable<ViewHoverEvent> = RxView.hoverEvents(this, handled)
+
+/**
  * Create an observable which emits on `view` long-click events. The emitted value is
  * unspecified and should only be used as notification.
  * 

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/view/RxViewTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/view/RxViewTest.java
@@ -16,6 +16,9 @@ import com.jakewharton.rxbinding.RecordingObserver;
 import rx.functions.Action1;
 
 import static android.view.MotionEvent.ACTION_DOWN;
+import static android.view.MotionEvent.ACTION_HOVER_ENTER;
+import static android.view.MotionEvent.ACTION_HOVER_EXIT;
+import static android.view.MotionEvent.ACTION_HOVER_MOVE;
 import static android.view.MotionEvent.ACTION_MOVE;
 import static android.view.MotionEvent.ACTION_UP;
 import static com.google.common.truth.Truth.assertThat;
@@ -128,6 +131,46 @@ public final class RxViewTest {
     subscription.unsubscribe();
 
     view.requestFocus();
+    o.assertNoMoreEvents();
+  }
+
+  @Test @UiThreadTest public void hovers() {
+    RecordingObserver<MotionEvent> o = new RecordingObserver<>();
+    Subscription subscription = RxView.hovers(view).subscribe(o);
+    o.assertNoMoreEvents();
+
+    view.dispatchGenericMotionEvent(motionEventAtPosition(view, ACTION_HOVER_ENTER, 0, 50));
+    MotionEvent event1 = o.takeNext();
+    assertThat(event1.getAction()).isEqualTo(ACTION_HOVER_ENTER);
+
+    view.dispatchGenericMotionEvent(motionEventAtPosition(view, ACTION_HOVER_MOVE, 1, 50));
+    MotionEvent event2 = o.takeNext();
+    assertThat(event2.getAction()).isEqualTo(ACTION_HOVER_MOVE);
+
+    subscription.unsubscribe();
+
+    view.dispatchGenericMotionEvent(motionEventAtPosition(view, ACTION_HOVER_EXIT, 1, 50));
+    o.assertNoMoreEvents();
+  }
+
+  @Test @UiThreadTest public void hoverEvents() {
+    RecordingObserver<ViewHoverEvent> o = new RecordingObserver<>();
+    Subscription subscription = RxView.hoverEvents(view).subscribe(o);
+    o.assertNoMoreEvents();
+
+    view.dispatchGenericMotionEvent(motionEventAtPosition(view, ACTION_HOVER_ENTER, 0, 50));
+    ViewHoverEvent event1 = o.takeNext();
+    assertThat(event1.view()).isSameAs(view);
+    assertThat(event1.motionEvent().getAction()).isEqualTo(ACTION_HOVER_ENTER);
+
+    view.dispatchGenericMotionEvent(motionEventAtPosition(view, ACTION_HOVER_MOVE, 1, 50));
+    ViewHoverEvent event2 = o.takeNext();
+    assertThat(event2.view()).isSameAs(view);
+    assertThat(event2.motionEvent().getAction()).isEqualTo(ACTION_HOVER_MOVE);
+
+    subscription.unsubscribe();
+
+    view.dispatchGenericMotionEvent(motionEventAtPosition(view, ACTION_HOVER_EXIT, 1, 50));
     o.assertNoMoreEvents();
   }
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/RxView.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/RxView.java
@@ -180,6 +180,70 @@ public final class RxView {
   }
 
   /**
+   * Create an observable of hover events for {@code view}.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+   * to free this reference.
+   * <p>
+   * <em>Warning:</em> The created observable uses {@link View#setOnHoverListener} to observe
+   * touches. Only one observable can be used for a view at a time.
+   */
+  @CheckResult @NonNull
+  public static Observable<MotionEvent> hovers(@NonNull View view) {
+    return hovers(view, Functions.FUNC1_ALWAYS_TRUE);
+  }
+
+  /**
+   * Create an observable of hover events for {@code view}.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+   * to free this reference.
+   * <p>
+   * <em>Warning:</em> The created observable uses {@link View#setOnHoverListener} to observe
+   * touches. Only one observable can be used for a view at a time.
+   *
+   * @param handled Function invoked with each value to determine the return value of the
+   * underlying {@link View.OnHoverListener}.
+   */
+  @CheckResult @NonNull
+  public static Observable<MotionEvent> hovers(@NonNull View view,
+      @NonNull Func1<? super MotionEvent, Boolean> handled) {
+    return Observable.create(new ViewHoverOnSubscribe(view, handled));
+  }
+
+  /**
+   * Create an observable of hover events for {@code view}.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+   * to free this reference.
+   * <p>
+   * <em>Warning:</em> The created observable uses {@link View#setOnHoverListener} to observe
+   * touches. Only one observable can be used for a view at a time.
+   */
+  @CheckResult @NonNull
+  public static Observable<ViewHoverEvent> hoverEvents(@NonNull View view) {
+    return hoverEvents(view, Functions.FUNC1_ALWAYS_TRUE);
+  }
+
+  /**
+   * Create an observable of hover events for {@code view}.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+   * to free this reference.
+   * <p>
+   * <em>Warning:</em> The created observable uses {@link View#setOnHoverListener} to observe
+   * touches. Only one observable can be used for a view at a time.
+   *
+   * @param handled Function invoked with each value to determine the return value of the
+   * underlying {@link View.OnHoverListener}.
+   */
+  @CheckResult @NonNull
+  public static Observable<ViewHoverEvent> hoverEvents(@NonNull View view,
+      @NonNull Func1<? super ViewHoverEvent, Boolean> handled) {
+    return Observable.create(new ViewHoverEventOnSubscribe(view, handled));
+  }
+
+  /**
    * Create an observable which emits on {@code view} long-click events. The emitted value is
    * unspecified and should only be used as notification.
    * <p>

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewHoverEvent.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewHoverEvent.java
@@ -1,0 +1,43 @@
+package com.jakewharton.rxbinding.view;
+
+import android.support.annotation.CheckResult;
+import android.support.annotation.NonNull;
+import android.view.MotionEvent;
+import android.view.View;
+
+public final class ViewHoverEvent extends ViewEvent<View> {
+  @CheckResult @NonNull
+  public static ViewHoverEvent create(@NonNull View view, @NonNull MotionEvent motionEvent) {
+    return new ViewHoverEvent(view, motionEvent);
+  }
+
+  private final MotionEvent motionEvent;
+
+  private ViewHoverEvent(@NonNull View view, @NonNull MotionEvent motionEvent) {
+    super(view);
+    this.motionEvent = motionEvent;
+  }
+
+  @NonNull
+  public MotionEvent motionEvent() {
+    return motionEvent;
+  }
+
+  @Override public boolean equals(Object o) {
+    if (o == this) return true;
+    if (!(o instanceof ViewTouchEvent)) return false;
+    ViewTouchEvent other = (ViewTouchEvent) o;
+    return other.view() == view() && other.motionEvent().equals(motionEvent);
+  }
+
+  @Override public int hashCode() {
+    int result = 17;
+    result = result * 37 + view().hashCode();
+    result = result * 37 + motionEvent.hashCode();
+    return result;
+  }
+
+  @Override public String toString() {
+    return "ViewHoverEvent{view=" + view() + ", motionEvent=" + motionEvent + '}';
+  }
+}

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewHoverEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewHoverEventOnSubscribe.java
@@ -1,0 +1,45 @@
+package com.jakewharton.rxbinding.view;
+
+import android.support.annotation.NonNull;
+import android.view.MotionEvent;
+import android.view.View;
+import com.jakewharton.rxbinding.internal.MainThreadSubscription;
+import rx.Observable;
+import rx.Subscriber;
+import rx.functions.Func1;
+
+import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
+
+final class ViewHoverEventOnSubscribe implements Observable.OnSubscribe<ViewHoverEvent> {
+  private final View view;
+  private final Func1<? super ViewHoverEvent, Boolean> handled;
+
+  public ViewHoverEventOnSubscribe(View view, Func1<? super ViewHoverEvent, Boolean> handled) {
+    this.view = view;
+    this.handled = handled;
+  }
+
+  @Override public void call(final Subscriber<? super ViewHoverEvent> subscriber) {
+    checkUiThread();
+
+    View.OnHoverListener listener = new View.OnHoverListener() {
+      @Override public boolean onHover(View v, @NonNull MotionEvent motionEvent) {
+        ViewHoverEvent event = ViewHoverEvent.create(view, motionEvent);
+        if (handled.call(event)) {
+          if (!subscriber.isUnsubscribed()) {
+            subscriber.onNext(event);
+          }
+          return true;
+        }
+        return false;
+      }
+    };
+    view.setOnHoverListener(listener);
+
+    subscriber.add(new MainThreadSubscription() {
+      @Override protected void onUnsubscribe() {
+        view.setOnHoverListener(null);
+      }
+    });
+  }
+}

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewHoverOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewHoverOnSubscribe.java
@@ -1,0 +1,44 @@
+package com.jakewharton.rxbinding.view;
+
+import android.support.annotation.NonNull;
+import android.view.MotionEvent;
+import android.view.View;
+import com.jakewharton.rxbinding.internal.MainThreadSubscription;
+import rx.Observable;
+import rx.Subscriber;
+import rx.functions.Func1;
+
+import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
+
+final class ViewHoverOnSubscribe implements Observable.OnSubscribe<MotionEvent> {
+  private final View view;
+  private final Func1<? super MotionEvent, Boolean> handled;
+
+  public ViewHoverOnSubscribe(View view, Func1<? super MotionEvent, Boolean> handled) {
+    this.view = view;
+    this.handled = handled;
+  }
+
+  @Override public void call(final Subscriber<? super MotionEvent> subscriber) {
+    checkUiThread();
+
+    View.OnHoverListener listener = new View.OnHoverListener() {
+      @Override public boolean onHover(View v, @NonNull MotionEvent event) {
+        if (handled.call(event)) {
+          if (!subscriber.isUnsubscribed()) {
+            subscriber.onNext(event);
+          }
+          return true;
+        }
+        return false;
+      }
+    };
+    view.setOnHoverListener(listener);
+
+    subscriber.add(new MainThreadSubscription() {
+      @Override protected void onUnsubscribe() {
+        view.setOnHoverListener(null);
+      }
+    });
+  }
+}

--- a/testing-utils/src/main/java/com/jakewharton/rxbinding/MotionEventUtil.java
+++ b/testing-utils/src/main/java/com/jakewharton/rxbinding/MotionEventUtil.java
@@ -1,6 +1,7 @@
 package com.jakewharton.rxbinding;
 
 import android.os.SystemClock;
+import android.view.InputDevice;
 import android.view.MotionEvent;
 import android.view.View;
 
@@ -29,7 +30,18 @@ public final class MotionEventUtil {
     float y = y1 + ((y2 - y1) * yPercent / 100f);
 
     long time = SystemClock.uptimeMillis();
-    return MotionEvent.obtain(time, time, action, x, y, 0);
+
+    MotionEvent.PointerProperties pointerProperties = new MotionEvent.PointerProperties();
+    pointerProperties.toolType = MotionEvent.TOOL_TYPE_UNKNOWN;
+
+    MotionEvent.PointerCoords pointerCoords = new MotionEvent.PointerCoords();
+    pointerCoords.setAxisValue(MotionEvent.AXIS_X, x);
+    pointerCoords.setAxisValue(MotionEvent.AXIS_Y, y);
+
+    return MotionEvent.obtain(time, time, action, 1,
+        new MotionEvent.PointerProperties[] {pointerProperties},
+        new MotionEvent.PointerCoords[]{pointerCoords}, 0, 0, 1.0f, 1.0f,
+        0, 0, InputDevice.SOURCE_CLASS_POINTER, 0);
   }
 
   private MotionEventUtil() {


### PR DESCRIPTION
Added bindings for `View.OnHoverListener` attached through `View#setOnHoverListener` (if needed, since it's not commonly used listener).

**Note:** I altered a bit `MotionEventUtil.motionEventAtPosition()` method to be able to generate hover events (`ACTION_HOVER_ENTER/EXIT/MOVE`) as well.