### PR TITLE
Add toolbar navigation click bindings

### DIFF
--- a/rxbinding-appcompat-v7-kotlin/src/main/kotlin/com/jakewharton/rxbinding/support/v7/widget/RxToolbar.kt
+++ b/rxbinding-appcompat-v7-kotlin/src/main/kotlin/com/jakewharton/rxbinding/support/v7/widget/RxToolbar.kt
@@ -12,3 +12,15 @@ import rx.functions.Action1
  * to free this reference.
  */
 public inline fun Toolbar.itemClicks(): Observable<MenuItem> = RxToolbar.itemClicks(this)
+
+/**
+ * Create an observable which emits on `view` navigation click events. The emitted value is
+ * unspecified and should only be used as notification.
+ * 
+ * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
+ * to free this reference.
+ * 
+ * *Warning:* The created observable uses [Toolbar.setNavigationOnClickListener]
+ * to observe clicks. Only one observable can be used for a view at a time.
+ */
+public inline fun Toolbar.navigationClicks(): Observable<Any> = RxToolbar.navigationClicks(this)

--- a/rxbinding-appcompat-v7/src/androidTest/java/com/jakewharton/rxbinding/support/v7/widget/RxToolbarTest.java
+++ b/rxbinding-appcompat-v7/src/androidTest/java/com/jakewharton/rxbinding/support/v7/widget/RxToolbarTest.java
@@ -42,4 +42,12 @@ public final class RxToolbarTest {
     menu.performIdentifierAction(2, 0);
     o.assertNoMoreEvents();
   }
+
+  @Test @UiThreadTest public void clicks() {
+    RecordingObserver<Object> o = new RecordingObserver<>();
+    Subscription subscription = RxToolbar.navigationClickEvents(view).subscribe(o);
+    o.assertNoMoreEvents(); // No initial value.
+
+    subscription.unsubscribe();
+  }
 }

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RxToolbar.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RxToolbar.java
@@ -23,6 +23,21 @@ public final class RxToolbar {
     return Observable.create(new ToolbarItemClickOnSubscribe(view));
   }
 
+  /**
+   * Create an observable which emits on {@code view} navigation click events. The emitted value is
+   * unspecified and should only be used as notification.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+   * to free this reference.
+   * <p>
+   * <em>Warning:</em> The created observable uses {@link Toolbar#setNavigationOnClickListener}
+   * to observe clicks. Only one observable can be used for a view at a time.
+   */
+  @CheckResult @NonNull
+  public static Observable<Object> navigationClicks(@NonNull Toolbar view) {
+    return Observable.create(new ToolbarNavigationClickOnSubscribe(view));
+  }
+
   private RxToolbar() {
     throw new AssertionError("No instances.");
   }

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/ToolbarNavigationClickOnSubscribe.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/ToolbarNavigationClickOnSubscribe.java
@@ -1,0 +1,37 @@
+package com.jakewharton.rxbinding.support.v7.widget;
+
+import android.support.v7.widget.Toolbar;
+import android.view.View;
+import com.jakewharton.rxbinding.internal.MainThreadSubscription;
+import rx.Observable;
+import rx.Subscriber;
+
+import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
+
+final class ToolbarNavigationClickOnSubscribe implements Observable.OnSubscribe<Object> {
+  private final Object event = new Object();
+  private final Toolbar view;
+
+  public ToolbarNavigationClickOnSubscribe(Toolbar view) {
+    this.view = view;
+  }
+
+  @Override public void call(final Subscriber<? super Object> subscriber) {
+    checkUiThread();
+
+    View.OnClickListener listener = new View.OnClickListener() {
+      @Override public void onClick(View v) {
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(event);
+        }
+      }
+    };
+    view.setNavigationOnClickListener(listener);
+
+    subscriber.add(new MainThreadSubscription() {
+      @Override protected void onUnsubscribe() {
+        view.setNavigationOnClickListener(null);
+      }
+    });
+  }
+}

--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/widget/RxToolbar.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/widget/RxToolbar.kt
@@ -12,3 +12,15 @@ import rx.functions.Action1
  * to free this reference.
  */
 public inline fun Toolbar.itemClicks(): Observable<MenuItem> = RxToolbar.itemClicks(this)
+
+/**
+ * Create an observable which emits on `view` navigation click events. The emitted value is
+ * unspecified and should only be used as notification.
+ * 
+ * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
+ * to free this reference.
+ * 
+ * *Warning:* The created observable uses [Toolbar.setNavigationOnClickListener]
+ * to observe clicks. Only one observable can be used for a view at a time.
+ */
+public inline fun Toolbar.navigationClicks(): Observable<Any> = RxToolbar.navigationClicks(this)

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/widget/RxToolbarTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/widget/RxToolbarTest.java
@@ -46,4 +46,12 @@ public final class RxToolbarTest {
     menu.performIdentifierAction(2, 0);
     o.assertNoMoreEvents();
   }
+
+  @Test @UiThreadTest public void clicks() {
+    RecordingObserver<Object> o = new RecordingObserver<>();
+    Subscription subscription = RxToolbar.navigationClickEvents(view).subscribe(o);
+    o.assertNoMoreEvents(); // No initial value.
+
+    subscription.unsubscribe();
+  }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RxToolbar.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RxToolbar.java
@@ -27,6 +27,21 @@ public final class RxToolbar {
     return Observable.create(new ToolbarItemClickOnSubscribe(view));
   }
 
+  /**
+   * Create an observable which emits on {@code view} navigation click events. The emitted value is
+   * unspecified and should only be used as notification.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+   * to free this reference.
+   * <p>
+   * <em>Warning:</em> The created observable uses {@link Toolbar#setNavigationOnClickListener}
+   * to observe clicks. Only one observable can be used for a view at a time.
+   */
+  @CheckResult @NonNull
+  public static Observable<Object> navigationClicks(@NonNull Toolbar view) {
+    return Observable.create(new ToolbarNavigationClickOnSubscribe(view));
+  }
+
   private RxToolbar() {
     throw new AssertionError("No instances.");
   }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/ToolbarNavigationClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/ToolbarNavigationClickOnSubscribe.java
@@ -1,0 +1,40 @@
+package com.jakewharton.rxbinding.widget;
+
+import android.annotation.TargetApi;
+import android.widget.Toolbar;
+import android.view.View;
+import com.jakewharton.rxbinding.internal.MainThreadSubscription;
+import rx.Observable;
+import rx.Subscriber;
+
+import static android.os.Build.VERSION_CODES.LOLLIPOP;
+import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
+
+@TargetApi(LOLLIPOP)
+final class ToolbarNavigationClickOnSubscribe implements Observable.OnSubscribe<Object> {
+  private final Object event = new Object();
+  private final Toolbar view;
+
+  public ToolbarNavigationClickOnSubscribe(Toolbar view) {
+    this.view = view;
+  }
+
+  @Override public void call(final Subscriber<? super Object> subscriber) {
+    checkUiThread();
+
+    View.OnClickListener listener = new View.OnClickListener() {
+      @Override public void onClick(View v) {
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(event);
+        }
+      }
+    };
+    view.setNavigationOnClickListener(listener);
+
+    subscriber.add(new MainThreadSubscription() {
+      @Override protected void onUnsubscribe() {
+        view.setNavigationOnClickListener(null);
+      }
+    });
+  }
+}


### PR DESCRIPTION
The tests currently only cover the initial Observable state because the "navigation view" is not exposed by Toolbar. If there is another way to perform clicks on it I'll happily add it.