### PR TITLE
Latest build tools. Use latest emulator.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: android
 
 android:
   components:
-    - build-tools-23.0.0
+    - build-tools-23.0.1
     - android-23
     - extra-android-m2repository
-    - sys-img-armeabi-v7a-android-15
+    - sys-img-armeabi-v7a-android-23
 
 jdk:
   - oraclejdk8
@@ -15,7 +15,7 @@ before_script:
   - ./gradlew generateKotlin
   - if [ ! -z "$(git status --porcelain)" ]; then echo "Bindings changed. Did you run 'generateKotlin'?"; exit 1; fi
   # Create and start an emulator for instrumentation tests.
-  - echo no | android create avd --force -n test -t android-18 --abi armeabi-v7a
+  - echo no | android create avd --force -n test -t android-23 --abi armeabi-v7a
   - emulator -avd test -no-skin -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82

--- a/build.gradle
+++ b/build.gradle
@@ -12,12 +12,13 @@ subprojects {
   group = GROUP
   version = VERSION_NAME
 
-  // The default 'assemble' task only applies to normal variants. Add test variants as well.
   afterEvaluate {
+    // The default 'assemble' task only applies to normal variants. Add test variants as well.
     android.testVariants.all { variant ->
       tasks.getByName('assemble').dependsOn variant.assemble
     }
 
+    // There is no logging for instrumentation tests. Hack it. http://b.android.com/182307
     tasks.withType(com.android.build.gradle.internal.tasks.AndroidTestTask) { task ->
       task.doFirst {
         logging.level = LogLevel.INFO
@@ -33,7 +34,7 @@ ext {
   androidPlugin = 'com.android.tools.build:gradle:1.3.1'
   minSdkVersion = 14
   compileSdkVersion = 23
-  buildToolsVersion = '23.0.0'
+  buildToolsVersion = '23.0.1'
 
   ci = 'true'.equals(System.getenv('CI'))
 


### PR DESCRIPTION
We are getting new L-only and M-only bindings which need their tests to run on CI.