### PR TITLE
Remove timestamp from ViewEvent docs.

### DIFF
--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewEvent.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewEvent.java
@@ -5,7 +5,7 @@ import android.support.annotation.NonNull;
 import android.view.View;
 
 /**
- * A timestamp and target view on which an event occurred (e.g., click).
+ * A target view on which an event occurred (e.g., click).
  * <p>
  * <strong>Warning:</strong> Instances keep a strong reference to the view. Operators that cache
  * instances have the potential to leak the associated {@link Context}.


### PR DESCRIPTION
Since `ViewEvent` doesn't contain a timestamp anymore.