### PR TITLE
Change dexing heap to double default value.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,8 @@ subprojects {
 
   // The default 'assemble' task only applies to normal variants. Add test variants as well.
   afterEvaluate {
+    android.dexOptions.javaMaxHeapSize = '2048M'
+
     android.testVariants.all { variant ->
       tasks.getByName('assemble').dependsOn variant.assemble
     }


### PR DESCRIPTION
This should hopefully fix the failures on CI which stem from dexing of the test APKs running out of memory.