### PR TITLE
Use Void not Object for stateless events, Unit in Kotlin.

### DIFF
--- a/buildSrc/src/main/groovy/com/jakewharton/rxbinding/project/KotlinGenTask.groovy
+++ b/buildSrc/src/main/groovy/com/jakewharton/rxbinding/project/KotlinGenTask.groovy
@@ -244,12 +244,18 @@ class KotlinGenTask extends SourceTask {
       builder.append(typeParameters ? typeParameters + " " : "")
 
       // return type
-      builder.append("$extendedClass.${name}($fParams): ${resolveKotlinType(returnType)}")
+      def kotlinType = resolveKotlinType(returnType)
+      builder.append("$extendedClass.${name}($fParams): ${kotlinType}")
 
       builder.append(" = ")
 
       // target method call
       builder.append("$bindingClass.$name(${jParams ? "this, $jParams" : "this"})")
+
+      // Void --> Unit mapping
+      if (kotlinType.equals("Observable<Unit>")) {
+        builder.append(".map { Unit }")
+      }
 
       return builder.toString()
     }
@@ -286,6 +292,8 @@ class KotlinGenTask extends SourceTask {
     switch (input) {
       case "Object":
         return "Any"
+      case "Void":
+        return "Unit"
       case "Integer":
         return "Int"
       case "int":

--- a/rxbinding-appcompat-v7-kotlin/src/main/kotlin/com/jakewharton/rxbinding/support/v7/widget/RxToolbar.kt
+++ b/rxbinding-appcompat-v7-kotlin/src/main/kotlin/com/jakewharton/rxbinding/support/v7/widget/RxToolbar.kt
@@ -23,4 +23,4 @@ public inline fun Toolbar.itemClicks(): Observable<MenuItem> = RxToolbar.itemCli
  * *Warning:* The created observable uses [Toolbar.setNavigationOnClickListener]
  * to observe clicks. Only one observable can be used for a view at a time.
  */
-public inline fun Toolbar.navigationClicks(): Observable<Any> = RxToolbar.navigationClicks(this)
+public inline fun Toolbar.navigationClicks(): Observable<Unit> = RxToolbar.navigationClicks(this).map { Unit }

--- a/rxbinding-appcompat-v7/src/androidTest/java/com/jakewharton/rxbinding/support/v7/widget/RxToolbarTest.java
+++ b/rxbinding-appcompat-v7/src/androidTest/java/com/jakewharton/rxbinding/support/v7/widget/RxToolbarTest.java
@@ -51,17 +51,17 @@ public final class RxToolbarTest {
   }
 
   @Test public void navigationClicks() {
-    RecordingObserver<Object> o = new RecordingObserver<>();
+    RecordingObserver<Void> o = new RecordingObserver<>();
     Subscription subscription = RxToolbar.navigationClicks(view)
         .subscribeOn(AndroidSchedulers.mainThread())
         .subscribe(o);
     o.assertNoMoreEvents(); // No initial value.
 
     onView(withContentDescription(NAVIGATION_CONTENT_DESCRIPTION)).perform(click());
-    assertThat(o.takeNext()).isNotNull();
+    assertThat(o.takeNext()).isNull();
 
     onView(withContentDescription(NAVIGATION_CONTENT_DESCRIPTION)).perform(click());
-    assertThat(o.takeNext()).isNotNull();
+    assertThat(o.takeNext()).isNull();
 
     subscription.unsubscribe();
 

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RxToolbar.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RxToolbar.java
@@ -34,7 +34,7 @@ public final class RxToolbar {
    * to observe clicks. Only one observable can be used for a view at a time.
    */
   @CheckResult @NonNull
-  public static Observable<Object> navigationClicks(@NonNull Toolbar view) {
+  public static Observable<Void> navigationClicks(@NonNull Toolbar view) {
     return Observable.create(new ToolbarNavigationClickOnSubscribe(view));
   }
 

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/ToolbarNavigationClickOnSubscribe.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/ToolbarNavigationClickOnSubscribe.java
@@ -8,21 +8,20 @@ import rx.Subscriber;
 
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
-final class ToolbarNavigationClickOnSubscribe implements Observable.OnSubscribe<Object> {
-  private final Object event = new Object();
+final class ToolbarNavigationClickOnSubscribe implements Observable.OnSubscribe<Void> {
   private final Toolbar view;
 
   public ToolbarNavigationClickOnSubscribe(Toolbar view) {
     this.view = view;
   }
 
-  @Override public void call(final Subscriber<? super Object> subscriber) {
+  @Override public void call(final Subscriber<? super Void> subscriber) {
     checkUiThread();
 
     View.OnClickListener listener = new View.OnClickListener() {
       @Override public void onClick(View v) {
         if (!subscriber.isUnsubscribed()) {
-          subscriber.onNext(event);
+          subscriber.onNext(null);
         }
       }
     };

--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/view/RxMenuItem.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/view/RxMenuItem.kt
@@ -17,7 +17,7 @@ import rx.functions.Func1
  * *Warning:* The created observable uses [MenuItem.setOnMenuItemClickListener] to
  * observe clicks. Only one observable can be used for a menu item at a time.
  */
-public inline fun MenuItem.clicks(): Observable<Any> = RxMenuItem.clicks(this)
+public inline fun MenuItem.clicks(): Observable<Unit> = RxMenuItem.clicks(this).map { Unit }
 
 /**
  * Create an observable which emits on `menuItem` click events. The emitted value is
@@ -32,7 +32,7 @@ public inline fun MenuItem.clicks(): Observable<Any> = RxMenuItem.clicks(this)
  * @param handled Function invoked with each value to determine the return value of the
  * underlying [MenuItem.OnMenuItemClickListener].
  */
-public inline fun MenuItem.clicks(handled: Func1<in MenuItem, Boolean>): Observable<Any> = RxMenuItem.clicks(this, handled)
+public inline fun MenuItem.clicks(handled: Func1<in MenuItem, Boolean>): Observable<Unit> = RxMenuItem.clicks(this, handled).map { Unit }
 
 /**
  * Create an observable of action view events for `menuItem`.

--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/view/RxView.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/view/RxView.kt
@@ -17,7 +17,7 @@ import rx.functions.Func1
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
  */
-public inline fun View.attaches(): Observable<Any> = RxView.attaches(this)
+public inline fun View.attaches(): Observable<Unit> = RxView.attaches(this).map { Unit }
 
 /**
  * Create an observable of attach and detach events on `view`.
@@ -34,7 +34,7 @@ public inline fun View.attachEvents(): Observable<ViewAttachEvent> = RxView.atta
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
  */
-public inline fun View.detaches(): Observable<Any> = RxView.detaches(this)
+public inline fun View.detaches(): Observable<Unit> = RxView.detaches(this).map { Unit }
 
 /**
  * Create an observable which emits on `view` click events. The emitted value is
@@ -46,7 +46,7 @@ public inline fun View.detaches(): Observable<Any> = RxView.detaches(this)
  * *Warning:* The created observable uses [View.setOnClickListener] to observe
  * clicks. Only one observable can be used for a view at a time.
  */
-public inline fun View.clicks(): Observable<Any> = RxView.clicks(this)
+public inline fun View.clicks(): Observable<Unit> = RxView.clicks(this).map { Unit }
 
 /**
  * Create an observable of [DragEvent] for drags on `view`.
@@ -82,7 +82,7 @@ public inline fun View.drags(handled: Func1<in DragEvent, Boolean>): Observable<
  * *Warning:* The created observable uses [ViewTreeObserver.addOnDrawListener] to observe
  * draws. Multiple observables can be used for a view at a time.
  */
-public inline fun View.draws(): Observable<Any> = RxView.draws(this)
+public inline fun View.draws(): Observable<Unit> = RxView.draws(this).map { Unit }
 
 /**
  * Create an observable of booleans representing the focus of `view`.
@@ -107,7 +107,7 @@ public inline fun View.focusChanges(): Observable<Boolean> = RxView.focusChanges
  * *Warning:* The created observable uses [ViewTreeObserver.addOnGlobalLayoutListener] to observe
  * globalLayouts. Multiple observables can be used for a view at a time.
  */
-public inline fun View.globalLayouts(): Observable<Any> = RxView.globalLayouts(this)
+public inline fun View.globalLayouts(): Observable<Unit> = RxView.globalLayouts(this).map { Unit }
 
 /**
  * Create an observable of hover events for `view`.
@@ -141,7 +141,7 @@ public inline fun View.hovers(handled: Func1<in MotionEvent, Boolean>): Observab
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
  */
-public inline fun View.layoutChanges(): Observable<Any> = RxView.layoutChanges(this)
+public inline fun View.layoutChanges(): Observable<Unit> = RxView.layoutChanges(this).map { Unit }
 
 /**
  * Create an observable of layout-change events for `view`.
@@ -161,7 +161,7 @@ public inline fun View.layoutChangeEvents(): Observable<ViewLayoutChangeEvent> =
  * *Warning:* The created observable uses [View.setOnLongClickListener] to observe
  * long clicks. Only one observable can be used for a view at a time.
  */
-public inline fun View.longClicks(): Observable<Any> = RxView.longClicks(this)
+public inline fun View.longClicks(): Observable<Unit> = RxView.longClicks(this).map { Unit }
 
 /**
  * Create an observable which emits on `view` long-click events. The emitted value is
@@ -176,7 +176,7 @@ public inline fun View.longClicks(): Observable<Any> = RxView.longClicks(this)
  * @param handled Function invoked each occurrence to determine the return value of the
  * underlying [View.OnLongClickListener].
  */
-public inline fun View.longClicks(handled: Func0<Boolean>): Observable<Any> = RxView.longClicks(this, handled)
+public inline fun View.longClicks(handled: Func0<Boolean>): Observable<Unit> = RxView.longClicks(this, handled).map { Unit }
 
 /**
  * Create an observable for pre-draws on `view`.
@@ -187,7 +187,7 @@ public inline fun View.longClicks(handled: Func0<Boolean>): Observable<Any> = Rx
  * *Warning:* The created observable uses [ViewTreeObserver.addOnPreDrawListener] to observe
  * preDraws. Multiple observables can be used for a view at a time.
  */
-public inline fun View.preDraws(proceedDrawingPass: Func1<in Any, Boolean>): Observable<Any> = RxView.preDraws(this, proceedDrawingPass)
+public inline fun View.preDraws(proceedDrawingPass: Func0<Boolean>): Observable<Unit> = RxView.preDraws(this, proceedDrawingPass).map { Unit }
 
 /**
  * Create an observable of scroll-change events for `view`.

--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/widget/RxToolbar.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/widget/RxToolbar.kt
@@ -23,4 +23,4 @@ public inline fun Toolbar.itemClicks(): Observable<MenuItem> = RxToolbar.itemCli
  * *Warning:* The created observable uses [Toolbar.setNavigationOnClickListener]
  * to observe clicks. Only one observable can be used for a view at a time.
  */
-public inline fun Toolbar.navigationClicks(): Observable<Any> = RxToolbar.navigationClicks(this)
+public inline fun Toolbar.navigationClicks(): Observable<Unit> = RxToolbar.navigationClicks(this).map { Unit }

--- a/rxbinding-leanback-v17-kotlin/src/main/kotlin/com/jakewharton/rxbinding/support/v17/leanback/widget/RxSearchEditText.kt
+++ b/rxbinding-leanback-v17-kotlin/src/main/kotlin/com/jakewharton/rxbinding/support/v17/leanback/widget/RxSearchEditText.kt
@@ -10,4 +10,4 @@ import rx.functions.Action1
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
  */
-public inline fun SearchEditText.keyboardDismisses(): Observable<Void> = RxSearchEditText.keyboardDismisses(this)
+public inline fun SearchEditText.keyboardDismisses(): Observable<Unit> = RxSearchEditText.keyboardDismisses(this).map { Unit }

--- a/rxbinding-support-v4-kotlin/src/main/kotlin/com/jakewharton/rxbinding/support/v4/widget/RxSwipeRefreshLayout.kt
+++ b/rxbinding-support-v4-kotlin/src/main/kotlin/com/jakewharton/rxbinding/support/v4/widget/RxSwipeRefreshLayout.kt
@@ -10,7 +10,7 @@ import rx.functions.Action1
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
  */
-public inline fun SwipeRefreshLayout.refreshes(): Observable<Void> = RxSwipeRefreshLayout.refreshes(this)
+public inline fun SwipeRefreshLayout.refreshes(): Observable<Unit> = RxSwipeRefreshLayout.refreshes(this).map { Unit }
 
 /**
  * An action which sets whether the layout is showing the refreshing indicator.

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/view/RxMenuItemTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/view/RxMenuItemTest.java
@@ -32,15 +32,15 @@ import static com.google.common.truth.Truth.assertThat;
   private final TestMenuItem menuItem = new TestMenuItem(context);
 
   @Test @UiThreadTest public void clicks() {
-    RecordingObserver<Object> o = new RecordingObserver<>();
+    RecordingObserver<Void> o = new RecordingObserver<>();
     Subscription subscription = RxMenuItem.clicks(menuItem).subscribe(o);
     o.assertNoMoreEvents(); // No initial value.
 
     menuItem.performClick();
-    assertThat(o.takeNext()).isNotNull();
+    assertThat(o.takeNext()).isNull();
 
     menuItem.performClick();
-    assertThat(o.takeNext()).isNotNull();
+    assertThat(o.takeNext()).isNull();
 
     subscription.unsubscribe();
 

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/view/RxViewAttachTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/view/RxViewAttachTest.java
@@ -37,7 +37,7 @@ public final class RxViewAttachTest {
   }
 
   @Test public void attaches() {
-    RecordingObserver<Object> o = new RecordingObserver<>();
+    RecordingObserver<Void> o = new RecordingObserver<>();
     Subscription subscription = RxView.attaches(child)
         .subscribeOn(AndroidSchedulers.mainThread())
         .subscribe(o);
@@ -48,7 +48,7 @@ public final class RxViewAttachTest {
         parent.addView(child);
       }
     });
-    assertThat(o.takeNext()).isNotNull();
+    assertThat(o.takeNext()).isNull();
     instrumentation.runOnMainSync(new Runnable() {
       @Override public void run() {
         parent.removeView(child);
@@ -99,7 +99,7 @@ public final class RxViewAttachTest {
   }
 
   @Test public void detaches() {
-    RecordingObserver<Object> o = new RecordingObserver<>();
+    RecordingObserver<Void> o = new RecordingObserver<>();
     Subscription subscription = RxView.detaches(child)
         .subscribeOn(AndroidSchedulers.mainThread())
         .subscribe(o);
@@ -116,7 +116,7 @@ public final class RxViewAttachTest {
         parent.removeView(child);
       }
     });
-    assertThat(o.takeNext()).isNotNull();
+    assertThat(o.takeNext()).isNull();
 
     subscription.unsubscribe();
 

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/view/RxViewTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/view/RxViewTest.java
@@ -39,15 +39,15 @@ public final class RxViewTest {
   private final View view = new View(context);
 
   @Test @UiThreadTest public void clicks() {
-    RecordingObserver<Object> o = new RecordingObserver<>();
+    RecordingObserver<Void> o = new RecordingObserver<>();
     Subscription subscription = RxView.clicks(view).subscribe(o);
     o.assertNoMoreEvents(); // No initial value.
 
     view.performClick();
-    assertThat(o.takeNext()).isNotNull();
+    assertThat(o.takeNext()).isNull();
 
     view.performClick();
-    assertThat(o.takeNext()).isNotNull();
+    assertThat(o.takeNext()).isNull();
 
     subscription.unsubscribe();
 
@@ -78,12 +78,12 @@ public final class RxViewTest {
   @TargetApi(JELLY_BEAN)
   @SdkSuppress(minSdkVersion = JELLY_BEAN)
   @Test @UiThreadTest public void drawEvents() {
-    RecordingObserver<Object> o = new RecordingObserver<>();
+    RecordingObserver<Void> o = new RecordingObserver<>();
     Subscription subscription = RxView.draws(view).subscribe(o);
     o.assertNoMoreEvents(); // No initial value.
 
     view.getViewTreeObserver().dispatchOnDraw();
-    assertThat(o.takeNext()).isNotNull();
+    assertThat(o.takeNext()).isNull();
 
     subscription.unsubscribe();
 
@@ -116,12 +116,12 @@ public final class RxViewTest {
   }
 
   @Test @UiThreadTest public void globalLayouts() {
-    RecordingObserver<Object> o = new RecordingObserver<>();
+    RecordingObserver<Void> o = new RecordingObserver<>();
     Subscription subscription = RxView.globalLayouts(view).subscribe(o);
     o.assertNoMoreEvents(); // No initial value.
 
     view.getViewTreeObserver().dispatchOnGlobalLayout();
-    assertThat(o.takeNext()).isNotNull();
+    assertThat(o.takeNext()).isNull();
 
     subscription.unsubscribe();
     view.getViewTreeObserver().dispatchOnGlobalLayout();
@@ -149,12 +149,12 @@ public final class RxViewTest {
   }
 
   @Test @UiThreadTest public void layoutChanges() {
-    RecordingObserver<Object> o = new RecordingObserver<>();
+    RecordingObserver<Void> o = new RecordingObserver<>();
     Subscription subscription = RxView.layoutChanges(view).subscribe(o);
     o.assertNoMoreEvents();
 
     view.layout(view.getLeft() - 5, view.getTop() - 5, view.getRight(), view.getBottom());
-    assertThat(o.takeNext()).isNotNull();
+    assertThat(o.takeNext()).isNull();
 
     view.layout(view.getLeft(), view.getTop(), view.getRight(), view.getBottom());
     o.assertNoMoreEvents();
@@ -192,15 +192,15 @@ public final class RxViewTest {
     };
     parent.addView(view);
 
-    RecordingObserver<Object> o = new RecordingObserver<>();
+    RecordingObserver<Void> o = new RecordingObserver<>();
     Subscription subscription = RxView.longClicks(view).subscribe(o);
     o.assertNoMoreEvents(); // No initial value.
 
     view.performLongClick();
-    assertThat(o.takeNext()).isNotNull();
+    assertThat(o.takeNext()).isNull();
 
     view.performLongClick();
-    assertThat(o.takeNext()).isNotNull();
+    assertThat(o.takeNext()).isNull();
 
     subscription.unsubscribe();
 
@@ -209,12 +209,12 @@ public final class RxViewTest {
   }
 
   @Test @UiThreadTest public void preDrawEvents() {
-    RecordingObserver<Object> o = new RecordingObserver<>();
-    Subscription subscription = RxView.preDraws(view, Functions.FUNC1_ALWAYS_TRUE).subscribe(o);
+    RecordingObserver<Void> o = new RecordingObserver<>();
+    Subscription subscription = RxView.preDraws(view, Functions.FUNC0_ALWAYS_TRUE).subscribe(o);
     o.assertNoMoreEvents(); // No initial value.
 
     view.getViewTreeObserver().dispatchOnPreDraw();
-    assertThat(o.takeNext()).isNotNull();
+    assertThat(o.takeNext()).isNull();
 
     subscription.unsubscribe();
 

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/widget/RxToolbarTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/widget/RxToolbarTest.java
@@ -56,17 +56,17 @@ public final class RxToolbarTest {
   }
 
   @Test public void navigationClicks() {
-    RecordingObserver<Object> o = new RecordingObserver<>();
+    RecordingObserver<Void> o = new RecordingObserver<>();
     Subscription subscription = RxToolbar.navigationClicks(view)
         .subscribeOn(AndroidSchedulers.mainThread())
         .subscribe(o);
     o.assertNoMoreEvents(); // No initial value.
 
     onView(withContentDescription(NAVIGATION_CONTENT_DESCRIPTION)).perform(click());
-    assertThat(o.takeNext()).isNotNull();
+    assertThat(o.takeNext()).isNull();
 
     onView(withContentDescription(NAVIGATION_CONTENT_DESCRIPTION)).perform(click());
-    assertThat(o.takeNext()).isNotNull();
+    assertThat(o.takeNext()).isNull();
 
     subscription.unsubscribe();
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/MenuItemClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/MenuItemClickOnSubscribe.java
@@ -8,8 +8,7 @@ import rx.functions.Func1;
 
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
-final class MenuItemClickOnSubscribe implements Observable.OnSubscribe<Object> {
-  private final Object event = new Object();
+final class MenuItemClickOnSubscribe implements Observable.OnSubscribe<Void> {
   private final MenuItem menuItem;
   private final Func1<? super MenuItem, Boolean> handled;
 
@@ -18,14 +17,14 @@ final class MenuItemClickOnSubscribe implements Observable.OnSubscribe<Object> {
     this.handled = handled;
   }
 
-  @Override public void call(final Subscriber<? super Object> subscriber) {
+  @Override public void call(final Subscriber<? super Void> subscriber) {
     checkUiThread();
 
     MenuItem.OnMenuItemClickListener listener = new MenuItem.OnMenuItemClickListener() {
       @Override public boolean onMenuItemClick(MenuItem item) {
         if (handled.call(menuItem)) {
           if (!subscriber.isUnsubscribed()) {
-            subscriber.onNext(event);
+            subscriber.onNext(null);
           }
           return true;
         }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/RxMenuItem.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/RxMenuItem.java
@@ -26,7 +26,7 @@ public final class RxMenuItem {
    * observe clicks. Only one observable can be used for a menu item at a time.
    */
   @CheckResult @NonNull
-  public static Observable<Object> clicks(@NonNull MenuItem menuItem) {
+  public static Observable<Void> clicks(@NonNull MenuItem menuItem) {
     return Observable.create(new MenuItemClickOnSubscribe(menuItem, Functions.FUNC1_ALWAYS_TRUE));
   }
 
@@ -44,7 +44,7 @@ public final class RxMenuItem {
    * underlying {@link MenuItem.OnMenuItemClickListener}.
    */
   @CheckResult @NonNull
-  public static Observable<Object> clicks(@NonNull MenuItem menuItem,
+  public static Observable<Void> clicks(@NonNull MenuItem menuItem,
       @NonNull Func1<? super MenuItem, Boolean> handled) {
     return Observable.create(new MenuItemClickOnSubscribe(menuItem, handled));
   }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/RxView.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/RxView.java
@@ -29,7 +29,7 @@ public final class RxView {
    * to free this reference.
    */
   @CheckResult @NonNull
-  public static Observable<Object> attaches(@NonNull View view) {
+  public static Observable<Void> attaches(@NonNull View view) {
     return Observable.create(new ViewAttachesOnSubscribe(view, true));
   }
 
@@ -52,7 +52,7 @@ public final class RxView {
    * to free this reference.
    */
   @CheckResult @NonNull
-  public static Observable<Object> detaches(@NonNull View view) {
+  public static Observable<Void> detaches(@NonNull View view) {
     return Observable.create(new ViewAttachesOnSubscribe(view, false));
   }
 
@@ -67,7 +67,7 @@ public final class RxView {
    * clicks. Only one observable can be used for a view at a time.
    */
   @CheckResult @NonNull
-  public static Observable<Object> clicks(@NonNull View view) {
+  public static Observable<Void> clicks(@NonNull View view) {
     return Observable.create(new ViewClickOnSubscribe(view));
   }
 
@@ -113,7 +113,7 @@ public final class RxView {
    * draws. Multiple observables can be used for a view at a time.
    */
   @CheckResult @NonNull
-  public static Observable<Object> draws(@NonNull View view) {
+  public static Observable<Void> draws(@NonNull View view) {
     return Observable.create(new ViewTreeObserverDrawOnSubscribe(view));
   }
 
@@ -144,7 +144,7 @@ public final class RxView {
    * globalLayouts. Multiple observables can be used for a view at a time.
    */
   @CheckResult @NonNull
-  public static Observable<Object> globalLayouts(@NonNull View view) {
+  public static Observable<Void> globalLayouts(@NonNull View view) {
     return Observable.create(new ViewTreeObserverGlobalLayoutOnSubscribe(view));
   }
 
@@ -188,7 +188,7 @@ public final class RxView {
    * to free this reference.
    */
   @CheckResult @NonNull
-  public static Observable<Object> layoutChanges(@NonNull View view) {
+  public static Observable<Void> layoutChanges(@NonNull View view) {
     return Observable.create(new ViewLayoutChangeOnSubscribe(view));
   }
 
@@ -214,7 +214,7 @@ public final class RxView {
    * long clicks. Only one observable can be used for a view at a time.
    */
   @CheckResult @NonNull
-  public static Observable<Object> longClicks(@NonNull View view) {
+  public static Observable<Void> longClicks(@NonNull View view) {
     return Observable.create(new ViewLongClickOnSubscribe(view, Functions.FUNC0_ALWAYS_TRUE));
   }
 
@@ -232,7 +232,7 @@ public final class RxView {
    * underlying {@link View.OnLongClickListener}.
    */
   @CheckResult @NonNull
-  public static Observable<Object> longClicks(@NonNull View view, @NonNull Func0<Boolean> handled) {
+  public static Observable<Void> longClicks(@NonNull View view, @NonNull Func0<Boolean> handled) {
     return Observable.create(new ViewLongClickOnSubscribe(view, handled));
   }
 
@@ -246,8 +246,8 @@ public final class RxView {
    * preDraws. Multiple observables can be used for a view at a time.
    */
   @CheckResult @NonNull
-  public static Observable<Object> preDraws(@NonNull View view,
-      @NonNull Func1<? super Object, Boolean> proceedDrawingPass) {
+  public static Observable<Void> preDraws(@NonNull View view,
+      @NonNull Func0<Boolean> proceedDrawingPass) {
     return Observable.create(new ViewTreeObserverPreDrawOnSubscribe(view, proceedDrawingPass));
   }
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewAttachesOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewAttachesOnSubscribe.java
@@ -10,8 +10,7 @@ import rx.Subscriber;
 
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
-final class ViewAttachesOnSubscribe implements Observable.OnSubscribe<Object> {
-  private final Object event = new Object();
+final class ViewAttachesOnSubscribe implements Observable.OnSubscribe<Void> {
   private final boolean callOnAttach;
   private final View view;
 
@@ -20,19 +19,19 @@ final class ViewAttachesOnSubscribe implements Observable.OnSubscribe<Object> {
     this.callOnAttach = callOnAttach;
   }
 
-  @Override public void call(final Subscriber<? super Object> subscriber) {
+  @Override public void call(final Subscriber<? super Void> subscriber) {
     checkUiThread();
 
     final View.OnAttachStateChangeListener listener = new View.OnAttachStateChangeListener() {
       @Override public void onViewAttachedToWindow(@NonNull final View v) {
         if (callOnAttach && !subscriber.isUnsubscribed()) {
-          subscriber.onNext(event);
+          subscriber.onNext(null);
         }
       }
 
       @Override public void onViewDetachedFromWindow(@NonNull final View v) {
         if (!callOnAttach && !subscriber.isUnsubscribed()) {
-          subscriber.onNext(event);
+          subscriber.onNext(null);
         }
       }
     };

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewClickOnSubscribe.java
@@ -7,21 +7,20 @@ import rx.Subscriber;
 
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
-final class ViewClickOnSubscribe implements Observable.OnSubscribe<Object> {
-  private final Object event = new Object();
+final class ViewClickOnSubscribe implements Observable.OnSubscribe<Void> {
   private final View view;
 
   ViewClickOnSubscribe(View view) {
     this.view = view;
   }
 
-  @Override public void call(final Subscriber<? super Object> subscriber) {
+  @Override public void call(final Subscriber<? super Void> subscriber) {
     checkUiThread();
 
     View.OnClickListener listener = new View.OnClickListener() {
       @Override public void onClick(View v) {
         if (!subscriber.isUnsubscribed()) {
-          subscriber.onNext(event);
+          subscriber.onNext(null);
         }
       }
     };

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewLayoutChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewLayoutChangeOnSubscribe.java
@@ -7,22 +7,21 @@ import rx.Subscriber;
 
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
-final class ViewLayoutChangeOnSubscribe implements Observable.OnSubscribe<Object> {
-  private final Object event = new Object();
+final class ViewLayoutChangeOnSubscribe implements Observable.OnSubscribe<Void> {
   private final View view;
 
   ViewLayoutChangeOnSubscribe(View view) {
     this.view = view;
   }
 
-  @Override public void call(final Subscriber<? super Object> subscriber) {
+  @Override public void call(final Subscriber<? super Void> subscriber) {
     checkUiThread();
 
     final View.OnLayoutChangeListener listener = new View.OnLayoutChangeListener() {
       @Override public void onLayoutChange(View v, int left, int top, int right, int bottom,
           int oldLeft, int oldTop, int oldRight, int oldBottom) {
         if (!subscriber.isUnsubscribed()) {
-          subscriber.onNext(event);
+          subscriber.onNext(null);
         }
       }
     };

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewLongClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewLongClickOnSubscribe.java
@@ -8,8 +8,7 @@ import rx.functions.Func0;
 
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
-final class ViewLongClickOnSubscribe implements Observable.OnSubscribe<Object> {
-  private final Object event = new Object();
+final class ViewLongClickOnSubscribe implements Observable.OnSubscribe<Void> {
   private final View view;
   private final Func0<Boolean> handled;
 
@@ -18,14 +17,14 @@ final class ViewLongClickOnSubscribe implements Observable.OnSubscribe<Object> {
     this.handled = handled;
   }
 
-  @Override public void call(final Subscriber<? super Object> subscriber) {
+  @Override public void call(final Subscriber<? super Void> subscriber) {
     checkUiThread();
 
     View.OnLongClickListener listener = new View.OnLongClickListener() {
       @Override public boolean onLongClick(View v) {
         if (handled.call()) {
           if (!subscriber.isUnsubscribed()) {
-            subscriber.onNext(event);
+            subscriber.onNext(null);
           }
           return true;
         }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTreeObserverDrawOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTreeObserverDrawOnSubscribe.java
@@ -11,22 +11,20 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 import static android.os.Build.VERSION_CODES.JELLY_BEAN;
 
 @TargetApi(JELLY_BEAN)
-final class ViewTreeObserverDrawOnSubscribe
-    implements Observable.OnSubscribe<Object> {
-  private final Object event = new Object();
+final class ViewTreeObserverDrawOnSubscribe implements Observable.OnSubscribe<Void> {
   private final View view;
 
   public ViewTreeObserverDrawOnSubscribe(View view) {
     this.view = view;
   }
 
-  @Override public void call(final Subscriber<? super Object> subscriber) {
+  @Override public void call(final Subscriber<? super Void> subscriber) {
     checkUiThread();
 
     final ViewTreeObserver.OnDrawListener listener = new ViewTreeObserver.OnDrawListener() {
       @Override public void onDraw() {
         if (!subscriber.isUnsubscribed()) {
-          subscriber.onNext(event);
+          subscriber.onNext(null);
         }
       }
     };

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTreeObserverGlobalLayoutOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTreeObserverGlobalLayoutOnSubscribe.java
@@ -9,21 +9,20 @@ import rx.Subscriber;
 
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
-final class ViewTreeObserverGlobalLayoutOnSubscribe implements Observable.OnSubscribe<Object> {
-  private final Object event = new Object();
+final class ViewTreeObserverGlobalLayoutOnSubscribe implements Observable.OnSubscribe<Void> {
   private final View view;
 
   ViewTreeObserverGlobalLayoutOnSubscribe(View view) {
     this.view = view;
   }
 
-  @Override public void call(final Subscriber<? super Object> subscriber) {
+  @Override public void call(final Subscriber<? super Void> subscriber) {
     checkUiThread();
 
     final ViewTreeObserver.OnGlobalLayoutListener listener = new ViewTreeObserver.OnGlobalLayoutListener() {
       @Override public void onGlobalLayout() {
         if (!subscriber.isUnsubscribed()) {
-          subscriber.onNext(event);
+          subscriber.onNext(null);
         }
       }
     };

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTreeObserverPreDrawOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTreeObserverPreDrawOnSubscribe.java
@@ -5,30 +5,27 @@ import android.view.ViewTreeObserver;
 import com.jakewharton.rxbinding.internal.MainThreadSubscription;
 import rx.Observable;
 import rx.Subscriber;
-import rx.functions.Func1;
+import rx.functions.Func0;
 
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
-final class ViewTreeObserverPreDrawOnSubscribe
-    implements Observable.OnSubscribe<Object> {
-  private final Object event = new Object();
+final class ViewTreeObserverPreDrawOnSubscribe implements Observable.OnSubscribe<Void> {
   private final View view;
-  private final Func1<? super Object, Boolean> proceedDrawingPass;
+  private final Func0<Boolean> proceedDrawingPass;
 
-  public ViewTreeObserverPreDrawOnSubscribe(View view,
-      Func1<? super Object, Boolean> proceedDrawingPass) {
+  ViewTreeObserverPreDrawOnSubscribe(View view, Func0<Boolean> proceedDrawingPass) {
     this.view = view;
     this.proceedDrawingPass = proceedDrawingPass;
   }
 
-  @Override public void call(final Subscriber<? super Object> subscriber) {
+  @Override public void call(final Subscriber<? super Void> subscriber) {
     checkUiThread();
 
     final ViewTreeObserver.OnPreDrawListener listener = new ViewTreeObserver.OnPreDrawListener() {
       @Override public boolean onPreDraw() {
         if (!subscriber.isUnsubscribed()) {
-          subscriber.onNext(event);
-          return proceedDrawingPass.call(event);
+          subscriber.onNext(null);
+          return proceedDrawingPass.call();
         }
         return true;
       }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RxToolbar.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RxToolbar.java
@@ -38,7 +38,7 @@ public final class RxToolbar {
    * to observe clicks. Only one observable can be used for a view at a time.
    */
   @CheckResult @NonNull
-  public static Observable<Object> navigationClicks(@NonNull Toolbar view) {
+  public static Observable<Void> navigationClicks(@NonNull Toolbar view) {
     return Observable.create(new ToolbarNavigationClickOnSubscribe(view));
   }
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/ToolbarNavigationClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/ToolbarNavigationClickOnSubscribe.java
@@ -11,21 +11,20 @@ import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 @TargetApi(LOLLIPOP)
-final class ToolbarNavigationClickOnSubscribe implements Observable.OnSubscribe<Object> {
-  private final Object event = new Object();
+final class ToolbarNavigationClickOnSubscribe implements Observable.OnSubscribe<Void> {
   private final Toolbar view;
 
   public ToolbarNavigationClickOnSubscribe(Toolbar view) {
     this.view = view;
   }
 
-  @Override public void call(final Subscriber<? super Object> subscriber) {
+  @Override public void call(final Subscriber<? super Void> subscriber) {
     checkUiThread();
 
     View.OnClickListener listener = new View.OnClickListener() {
       @Override public void onClick(View v) {
         if (!subscriber.isUnsubscribed()) {
-          subscriber.onNext(event);
+          subscriber.onNext(null);
         }
       }
     };


### PR DESCRIPTION
Closes #180. 