### PR TITLE
Remove creation of synthetic accessor method.

### DIFF
--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/SearchViewQueryTextChangeEventsOnSubscribe.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/SearchViewQueryTextChangeEventsOnSubscribe.java
@@ -9,7 +9,7 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class SearchViewQueryTextChangeEventsOnSubscribe
     implements Observable.OnSubscribe<SearchViewQueryTextEvent> {
-  private final SearchView view;
+  final SearchView view;
 
   SearchViewQueryTextChangeEventsOnSubscribe(SearchView view) {
     this.view = view;

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/SearchViewQueryTextChangesOnSubscribe.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/SearchViewQueryTextChangesOnSubscribe.java
@@ -8,7 +8,7 @@ import rx.android.MainThreadSubscription;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class SearchViewQueryTextChangesOnSubscribe implements Observable.OnSubscribe<CharSequence> {
-  private final SearchView view;
+  final SearchView view;
 
   SearchViewQueryTextChangesOnSubscribe(SearchView view) {
     this.view = view;

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/ToolbarItemClickOnSubscribe.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/ToolbarItemClickOnSubscribe.java
@@ -9,9 +9,9 @@ import rx.android.MainThreadSubscription;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class ToolbarItemClickOnSubscribe implements Observable.OnSubscribe<MenuItem> {
-  private final Toolbar view;
+  final Toolbar view;
 
-  public ToolbarItemClickOnSubscribe(Toolbar view) {
+  ToolbarItemClickOnSubscribe(Toolbar view) {
     this.view = view;
   }
 

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/ToolbarNavigationClickOnSubscribe.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/ToolbarNavigationClickOnSubscribe.java
@@ -9,9 +9,9 @@ import rx.android.MainThreadSubscription;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class ToolbarNavigationClickOnSubscribe implements Observable.OnSubscribe<Void> {
-  private final Toolbar view;
+  final Toolbar view;
 
-  public ToolbarNavigationClickOnSubscribe(Toolbar view) {
+  ToolbarNavigationClickOnSubscribe(Toolbar view) {
     this.view = view;
   }
 

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/AppBarLayoutOffsetChangeOnSubscribe.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/AppBarLayoutOffsetChangeOnSubscribe.java
@@ -8,9 +8,9 @@ import rx.android.MainThreadSubscription;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class AppBarLayoutOffsetChangeOnSubscribe implements Observable.OnSubscribe<Integer> {
-  private final AppBarLayout view;
+  final AppBarLayout view;
 
-  public AppBarLayoutOffsetChangeOnSubscribe(AppBarLayout view) {
+  AppBarLayoutOffsetChangeOnSubscribe(AppBarLayout view) {
     this.view = view;
   }
 

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/NavigationViewItemSelectionsOnSubscribe.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/NavigationViewItemSelectionsOnSubscribe.java
@@ -10,9 +10,9 @@ import rx.android.MainThreadSubscription;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class NavigationViewItemSelectionsOnSubscribe implements Observable.OnSubscribe<MenuItem> {
-  private final NavigationView view;
+  final NavigationView view;
 
-  public NavigationViewItemSelectionsOnSubscribe(NavigationView view) {
+  NavigationViewItemSelectionsOnSubscribe(NavigationView view) {
     this.view = view;
   }
 

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/SnackbarDismissesOnSubscribe.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/SnackbarDismissesOnSubscribe.java
@@ -8,9 +8,9 @@ import rx.android.MainThreadSubscription;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class SnackbarDismissesOnSubscribe implements Observable.OnSubscribe<Integer> {
-  private final Snackbar view;
+  final Snackbar view;
 
-  public SnackbarDismissesOnSubscribe(Snackbar view) {
+  SnackbarDismissesOnSubscribe(Snackbar view) {
     this.view = view;
   }
 

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/TabLayoutSelectionEventOnSubscribe.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/TabLayoutSelectionEventOnSubscribe.java
@@ -11,9 +11,9 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class TabLayoutSelectionEventOnSubscribe
     implements Observable.OnSubscribe<TabLayoutSelectionEvent> {
-  private final TabLayout view;
+  final TabLayout view;
 
-  public TabLayoutSelectionEventOnSubscribe(TabLayout view) {
+  TabLayoutSelectionEventOnSubscribe(TabLayout view) {
     this.view = view;
   }
 

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/TabLayoutSelectionsOnSubscribe.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/TabLayoutSelectionsOnSubscribe.java
@@ -9,9 +9,9 @@ import rx.android.MainThreadSubscription;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class TabLayoutSelectionsOnSubscribe implements Observable.OnSubscribe<Tab> {
-  private final TabLayout view;
+  final TabLayout view;
 
-  public TabLayoutSelectionsOnSubscribe(TabLayout view) {
+  TabLayoutSelectionsOnSubscribe(TabLayout view) {
     this.view = view;
   }
 

--- a/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding/support/v17/leanback/widget/SearchBarSearchQueryChangeEventsOnSubscribe.java
+++ b/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding/support/v17/leanback/widget/SearchBarSearchQueryChangeEventsOnSubscribe.java
@@ -10,7 +10,7 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class SearchBarSearchQueryChangeEventsOnSubscribe
     implements Observable.OnSubscribe<SearchBarSearchQueryEvent> {
-  private final SearchBar view;
+  final SearchBar view;
 
   SearchBarSearchQueryChangeEventsOnSubscribe(SearchBar view) {
     this.view = view;

--- a/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding/support/v17/leanback/widget/SearchBarSearchQueryChangesOnSubscribe.java
+++ b/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding/support/v17/leanback/widget/SearchBarSearchQueryChangesOnSubscribe.java
@@ -8,7 +8,7 @@ import rx.android.MainThreadSubscription;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class SearchBarSearchQueryChangesOnSubscribe implements Observable.OnSubscribe<String> {
-  private final SearchBar view;
+  final SearchBar view;
 
   SearchBarSearchQueryChangesOnSubscribe(SearchBar view) {
     this.view = view;

--- a/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding/support/v17/leanback/widget/SearchEditTextKeyboardDismissOnSubscribe.java
+++ b/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding/support/v17/leanback/widget/SearchEditTextKeyboardDismissOnSubscribe.java
@@ -9,7 +9,7 @@ import rx.android.MainThreadSubscription;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class SearchEditTextKeyboardDismissOnSubscribe implements Observable.OnSubscribe<Void> {
-  private final SearchEditText view;
+  final SearchEditText view;
 
   public SearchEditTextKeyboardDismissOnSubscribe(SearchEditText view) {
     this.view = view;

--- a/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RecyclerAdapterDataChangeOnSubscribe.java
+++ b/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RecyclerAdapterDataChangeOnSubscribe.java
@@ -11,7 +11,7 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class RecyclerAdapterDataChangeOnSubscribe<T extends Adapter<? extends ViewHolder>>
     implements Observable.OnSubscribe<T> {
-  private final T adapter;
+  final T adapter;
 
   RecyclerAdapterDataChangeOnSubscribe(T adapter) {
     this.adapter = adapter;

--- a/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RecyclerViewChildAttachStateChangeEventOnSubscribe.java
+++ b/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RecyclerViewChildAttachStateChangeEventOnSubscribe.java
@@ -11,7 +11,7 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class RecyclerViewChildAttachStateChangeEventOnSubscribe
     implements Observable.OnSubscribe<RecyclerViewChildAttachStateChangeEvent> {
-  private final RecyclerView recyclerView;
+  final RecyclerView recyclerView;
 
   public RecyclerViewChildAttachStateChangeEventOnSubscribe(RecyclerView recyclerView) {
     this.recyclerView = recyclerView;

--- a/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RecyclerViewScrollEventOnSubscribe.java
+++ b/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RecyclerViewScrollEventOnSubscribe.java
@@ -9,8 +9,7 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class RecyclerViewScrollEventOnSubscribe
     implements Observable.OnSubscribe<RecyclerViewScrollEvent> {
-
-  private final RecyclerView recyclerView;
+  final RecyclerView recyclerView;
 
   public RecyclerViewScrollEventOnSubscribe(RecyclerView recyclerView) {
     this.recyclerView = recyclerView;

--- a/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RecyclerViewScrollStateChangeOnSubscribe.java
+++ b/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RecyclerViewScrollStateChangeOnSubscribe.java
@@ -8,7 +8,7 @@ import rx.android.MainThreadSubscription;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class RecyclerViewScrollStateChangeOnSubscribe implements Observable.OnSubscribe<Integer> {
-  private final RecyclerView recyclerView;
+  final RecyclerView recyclerView;
 
   public RecyclerViewScrollStateChangeOnSubscribe(RecyclerView recyclerView) {
     this.recyclerView = recyclerView;

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/view/ViewPagerPageSelectedOnSubscribe.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/view/ViewPagerPageSelectedOnSubscribe.java
@@ -8,7 +8,7 @@ import rx.android.MainThreadSubscription;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class ViewPagerPageSelectedOnSubscribe implements Observable.OnSubscribe<Integer> {
-  private final ViewPager view;
+  final ViewPager view;
 
   ViewPagerPageSelectedOnSubscribe(ViewPager view) {
     this.view = view;

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/DrawerLayoutDrawerOpenedOnSubscribe.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/DrawerLayoutDrawerOpenedOnSubscribe.java
@@ -10,8 +10,8 @@ import rx.android.MainThreadSubscription;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class DrawerLayoutDrawerOpenedOnSubscribe implements Observable.OnSubscribe<Boolean> {
-  private final DrawerLayout view;
-  private final int gravity;
+  final DrawerLayout view;
+  final int gravity;
 
   DrawerLayoutDrawerOpenedOnSubscribe(DrawerLayout view, int gravity) {
     this.view = view;

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/SwipeRefreshLayoutRefreshOnSubscribe.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/SwipeRefreshLayoutRefreshOnSubscribe.java
@@ -8,7 +8,7 @@ import rx.android.MainThreadSubscription;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class SwipeRefreshLayoutRefreshOnSubscribe implements Observable.OnSubscribe<Void> {
-  private final SwipeRefreshLayout view;
+  final SwipeRefreshLayout view;
 
   SwipeRefreshLayoutRefreshOnSubscribe(SwipeRefreshLayout view) {
     this.view = view;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/internal/Functions.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/internal/Functions.java
@@ -11,7 +11,7 @@ public final class Functions {
   private static final class Always<T> implements Func1<Object, T>, Func0<T> {
     private final T value;
 
-    private Always(T value) {
+    Always(T value) {
       this.value = value;
     }
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/MenuItemActionViewEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/MenuItemActionViewEventOnSubscribe.java
@@ -11,8 +11,8 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class MenuItemActionViewEventOnSubscribe
     implements Observable.OnSubscribe<MenuItemActionViewEvent> {
-  private final MenuItem menuItem;
-  private final Func1<? super MenuItemActionViewEvent, Boolean> handled;
+  final MenuItem menuItem;
+  final Func1<? super MenuItemActionViewEvent, Boolean> handled;
 
   MenuItemActionViewEventOnSubscribe(MenuItem menuItem,
       Func1<? super MenuItemActionViewEvent, Boolean> handled) {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/MenuItemClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/MenuItemClickOnSubscribe.java
@@ -9,8 +9,8 @@ import rx.functions.Func1;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class MenuItemClickOnSubscribe implements Observable.OnSubscribe<Void> {
-  private final MenuItem menuItem;
-  private final Func1<? super MenuItem, Boolean> handled;
+  final MenuItem menuItem;
+  final Func1<? super MenuItem, Boolean> handled;
 
   MenuItemClickOnSubscribe(MenuItem menuItem, Func1<? super MenuItem, Boolean> handled) {
     this.menuItem = menuItem;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewAttachEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewAttachEventOnSubscribe.java
@@ -11,7 +11,7 @@ import static com.jakewharton.rxbinding.view.ViewAttachEvent.Kind.ATTACH;
 import static com.jakewharton.rxbinding.view.ViewAttachEvent.Kind.DETACH;
 
 final class ViewAttachEventOnSubscribe implements Observable.OnSubscribe<ViewAttachEvent> {
-  private final View view;
+  final View view;
 
   ViewAttachEventOnSubscribe(View view) {
     this.view = view;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewAttachesOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewAttachesOnSubscribe.java
@@ -9,8 +9,8 @@ import rx.android.MainThreadSubscription;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class ViewAttachesOnSubscribe implements Observable.OnSubscribe<Void> {
-  private final boolean callOnAttach;
-  private final View view;
+  final boolean callOnAttach;
+  final View view;
 
   ViewAttachesOnSubscribe(View view, boolean callOnAttach) {
     this.view = view;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewClickOnSubscribe.java
@@ -8,7 +8,7 @@ import rx.android.MainThreadSubscription;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class ViewClickOnSubscribe implements Observable.OnSubscribe<Void> {
-  private final View view;
+  final View view;
 
   ViewClickOnSubscribe(View view) {
     this.view = view;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewDragOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewDragOnSubscribe.java
@@ -10,8 +10,8 @@ import rx.functions.Func1;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class ViewDragOnSubscribe implements Observable.OnSubscribe<DragEvent> {
-  private final View view;
-  private final Func1<? super DragEvent, Boolean> handled;
+  final View view;
+  final Func1<? super DragEvent, Boolean> handled;
 
   ViewDragOnSubscribe(View view, Func1<? super DragEvent, Boolean> handled) {
     this.view = view;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewFocusChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewFocusChangeOnSubscribe.java
@@ -8,9 +8,9 @@ import rx.android.MainThreadSubscription;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class ViewFocusChangeOnSubscribe implements Observable.OnSubscribe<Boolean> {
-  private final View view;
+  final View view;
 
-  public ViewFocusChangeOnSubscribe(View view) {
+  ViewFocusChangeOnSubscribe(View view) {
     this.view = view;
   }
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewGroupHierarchyChangeEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewGroupHierarchyChangeEventOnSubscribe.java
@@ -10,7 +10,7 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class ViewGroupHierarchyChangeEventOnSubscribe
     implements Observable.OnSubscribe<ViewGroupHierarchyChangeEvent> {
-  private final ViewGroup viewGroup;
+  final ViewGroup viewGroup;
 
   ViewGroupHierarchyChangeEventOnSubscribe(ViewGroup viewGroup) {
     this.viewGroup = viewGroup;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewHoverOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewHoverOnSubscribe.java
@@ -11,10 +11,10 @@ import rx.functions.Func1;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class ViewHoverOnSubscribe implements Observable.OnSubscribe<MotionEvent> {
-  private final View view;
-  private final Func1<? super MotionEvent, Boolean> handled;
+  final View view;
+  final Func1<? super MotionEvent, Boolean> handled;
 
-  public ViewHoverOnSubscribe(View view, Func1<? super MotionEvent, Boolean> handled) {
+  ViewHoverOnSubscribe(View view, Func1<? super MotionEvent, Boolean> handled) {
     this.view = view;
     this.handled = handled;
   }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewLayoutChangeEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewLayoutChangeEventOnSubscribe.java
@@ -9,7 +9,7 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class ViewLayoutChangeEventOnSubscribe
     implements Observable.OnSubscribe<ViewLayoutChangeEvent> {
-  private final View view;
+  final View view;
 
   ViewLayoutChangeEventOnSubscribe(View view) {
     this.view = view;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewLayoutChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewLayoutChangeOnSubscribe.java
@@ -8,7 +8,7 @@ import rx.android.MainThreadSubscription;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class ViewLayoutChangeOnSubscribe implements Observable.OnSubscribe<Void> {
-  private final View view;
+  final View view;
 
   ViewLayoutChangeOnSubscribe(View view) {
     this.view = view;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewLongClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewLongClickOnSubscribe.java
@@ -9,8 +9,8 @@ import rx.functions.Func0;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class ViewLongClickOnSubscribe implements Observable.OnSubscribe<Void> {
-  private final View view;
-  private final Func0<Boolean> handled;
+  final View view;
+  final Func0<Boolean> handled;
 
   ViewLongClickOnSubscribe(View view, Func0<Boolean> handled) {
     this.view = view;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewScrollChangeEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewScrollChangeEventOnSubscribe.java
@@ -12,7 +12,7 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 @TargetApi(M)
 final class ViewScrollChangeEventOnSubscribe
     implements Observable.OnSubscribe<ViewScrollChangeEvent> {
-  private final View view;
+  final View view;
 
   ViewScrollChangeEventOnSubscribe(View view) {
     this.view = view;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewSystemUiVisibilityChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewSystemUiVisibilityChangeOnSubscribe.java
@@ -8,9 +8,9 @@ import rx.android.MainThreadSubscription;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class ViewSystemUiVisibilityChangeOnSubscribe implements Observable.OnSubscribe<Integer> {
-  private final View view;
+  final View view;
 
-  public ViewSystemUiVisibilityChangeOnSubscribe(View view) {
+  ViewSystemUiVisibilityChangeOnSubscribe(View view) {
     this.view = view;
   }
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTouchOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTouchOnSubscribe.java
@@ -11,10 +11,10 @@ import rx.functions.Func1;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class ViewTouchOnSubscribe implements Observable.OnSubscribe<MotionEvent> {
-  private final View view;
-  private final Func1<? super MotionEvent, Boolean> handled;
+  final View view;
+  final Func1<? super MotionEvent, Boolean> handled;
 
-  public ViewTouchOnSubscribe(View view, Func1<? super MotionEvent, Boolean> handled) {
+  ViewTouchOnSubscribe(View view, Func1<? super MotionEvent, Boolean> handled) {
     this.view = view;
     this.handled = handled;
   }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTreeObserverDrawOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTreeObserverDrawOnSubscribe.java
@@ -12,9 +12,9 @@ import static android.os.Build.VERSION_CODES.JELLY_BEAN;
 
 @TargetApi(JELLY_BEAN)
 final class ViewTreeObserverDrawOnSubscribe implements Observable.OnSubscribe<Void> {
-  private final View view;
+  final View view;
 
-  public ViewTreeObserverDrawOnSubscribe(View view) {
+  ViewTreeObserverDrawOnSubscribe(View view) {
     this.view = view;
   }
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTreeObserverGlobalLayoutOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTreeObserverGlobalLayoutOnSubscribe.java
@@ -10,7 +10,7 @@ import rx.android.MainThreadSubscription;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class ViewTreeObserverGlobalLayoutOnSubscribe implements Observable.OnSubscribe<Void> {
-  private final View view;
+  final View view;
 
   ViewTreeObserverGlobalLayoutOnSubscribe(View view) {
     this.view = view;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTreeObserverPreDrawOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTreeObserverPreDrawOnSubscribe.java
@@ -10,8 +10,8 @@ import rx.functions.Func0;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class ViewTreeObserverPreDrawOnSubscribe implements Observable.OnSubscribe<Void> {
-  private final View view;
-  private final Func0<Boolean> proceedDrawingPass;
+  final View view;
+  final Func0<Boolean> proceedDrawingPass;
 
   ViewTreeObserverPreDrawOnSubscribe(View view, Func0<Boolean> proceedDrawingPass) {
     this.view = view;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterDataChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterDataChangeOnSubscribe.java
@@ -10,7 +10,7 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class AdapterDataChangeOnSubscribe<T extends Adapter>
     implements Observable.OnSubscribe<T> {
-  private final T adapter;
+  final T adapter;
 
   public AdapterDataChangeOnSubscribe(T adapter) {
     this.adapter = adapter;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemClickEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemClickEventOnSubscribe.java
@@ -10,7 +10,7 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class AdapterViewItemClickEventOnSubscribe
     implements Observable.OnSubscribe<AdapterViewItemClickEvent> {
-  private final AdapterView<?> view;
+  final AdapterView<?> view;
 
   public AdapterViewItemClickEventOnSubscribe(AdapterView<?> view) {
     this.view = view;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemClickOnSubscribe.java
@@ -9,7 +9,7 @@ import rx.android.MainThreadSubscription;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class AdapterViewItemClickOnSubscribe implements Observable.OnSubscribe<Integer> {
-  private final AdapterView<?> view;
+  final AdapterView<?> view;
 
   public AdapterViewItemClickOnSubscribe(AdapterView<?> view) {
     this.view = view;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemLongClickEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemLongClickEventOnSubscribe.java
@@ -11,8 +11,8 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class AdapterViewItemLongClickEventOnSubscribe
     implements Observable.OnSubscribe<AdapterViewItemLongClickEvent> {
-  private final AdapterView<?> view;
-  private final Func1<? super AdapterViewItemLongClickEvent, Boolean> handled;
+  final AdapterView<?> view;
+  final Func1<? super AdapterViewItemLongClickEvent, Boolean> handled;
 
   public AdapterViewItemLongClickEventOnSubscribe(AdapterView<?> view,
       Func1<? super AdapterViewItemLongClickEvent, Boolean> handled) {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemLongClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemLongClickOnSubscribe.java
@@ -10,8 +10,8 @@ import rx.functions.Func0;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class AdapterViewItemLongClickOnSubscribe implements Observable.OnSubscribe<Integer> {
-  private final AdapterView<?> view;
-  private final Func0<Boolean> handled;
+  final AdapterView<?> view;
+  final Func0<Boolean> handled;
 
   public AdapterViewItemLongClickOnSubscribe(AdapterView<?> view, Func0<Boolean> handled) {
     this.view = view;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemSelectionOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemSelectionOnSubscribe.java
@@ -10,7 +10,7 @@ import static android.widget.AdapterView.INVALID_POSITION;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class AdapterViewItemSelectionOnSubscribe implements Observable.OnSubscribe<Integer> {
-  private final AdapterView<?> view;
+  final AdapterView<?> view;
 
   public AdapterViewItemSelectionOnSubscribe(AdapterView<?> view) {
     this.view = view;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewSelectionOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewSelectionOnSubscribe.java
@@ -11,7 +11,7 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class AdapterViewSelectionOnSubscribe
     implements Observable.OnSubscribe<AdapterViewSelectionEvent> {
-  private final AdapterView<?> view;
+  final AdapterView<?> view;
 
   public AdapterViewSelectionOnSubscribe(AdapterView<?> view) {
     this.view = view;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AutoCompleteTextViewItemClickEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AutoCompleteTextViewItemClickEventOnSubscribe.java
@@ -11,7 +11,7 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class AutoCompleteTextViewItemClickEventOnSubscribe
     implements Observable.OnSubscribe<AdapterViewItemClickEvent> {
-  private final AutoCompleteTextView view;
+  final AutoCompleteTextView view;
 
   public AutoCompleteTextViewItemClickEventOnSubscribe(AutoCompleteTextView view) {
     this.view = view;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/CompoundButtonCheckedChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/CompoundButtonCheckedChangeOnSubscribe.java
@@ -8,7 +8,7 @@ import rx.android.MainThreadSubscription;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class CompoundButtonCheckedChangeOnSubscribe implements Observable.OnSubscribe<Boolean> {
-  private final CompoundButton view;
+  final CompoundButton view;
 
   public CompoundButtonCheckedChangeOnSubscribe(CompoundButton view) {
     this.view = view;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RadioGroupCheckedChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RadioGroupCheckedChangeOnSubscribe.java
@@ -8,7 +8,7 @@ import rx.android.MainThreadSubscription;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class RadioGroupCheckedChangeOnSubscribe implements Observable.OnSubscribe<Integer> {
-  private final RadioGroup view;
+  final RadioGroup view;
 
   public RadioGroupCheckedChangeOnSubscribe(RadioGroup view) {
     this.view = view;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RatingBarRatingChangeEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RatingBarRatingChangeEventOnSubscribe.java
@@ -9,7 +9,7 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class RatingBarRatingChangeEventOnSubscribe
     implements Observable.OnSubscribe<RatingBarChangeEvent> {
-  private final RatingBar view;
+  final RatingBar view;
 
   public RatingBarRatingChangeEventOnSubscribe(RatingBar view) {
     this.view = view;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RatingBarRatingChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RatingBarRatingChangeOnSubscribe.java
@@ -8,7 +8,7 @@ import rx.android.MainThreadSubscription;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class RatingBarRatingChangeOnSubscribe implements Observable.OnSubscribe<Float> {
-  private final RatingBar view;
+  final RatingBar view;
 
   public RatingBarRatingChangeOnSubscribe(RatingBar view) {
     this.view = view;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewQueryTextChangeEventsOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewQueryTextChangeEventsOnSubscribe.java
@@ -9,7 +9,7 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class SearchViewQueryTextChangeEventsOnSubscribe
     implements Observable.OnSubscribe<SearchViewQueryTextEvent> {
-  private final SearchView view;
+  final SearchView view;
 
   SearchViewQueryTextChangeEventsOnSubscribe(SearchView view) {
     this.view = view;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewQueryTextChangesOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewQueryTextChangesOnSubscribe.java
@@ -8,7 +8,7 @@ import rx.android.MainThreadSubscription;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class SearchViewQueryTextChangesOnSubscribe implements Observable.OnSubscribe<CharSequence> {
-  private final SearchView view;
+  final SearchView view;
 
   SearchViewQueryTextChangesOnSubscribe(SearchView view) {
     this.view = view;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SeekBarChangeEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SeekBarChangeEventOnSubscribe.java
@@ -9,7 +9,7 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class SeekBarChangeEventOnSubscribe
     implements Observable.OnSubscribe<SeekBarChangeEvent> {
-  private final SeekBar view;
+  final SeekBar view;
 
   public SeekBarChangeEventOnSubscribe(SeekBar view) {
     this.view = view;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SeekBarChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SeekBarChangeOnSubscribe.java
@@ -9,9 +9,8 @@ import rx.android.MainThreadSubscription;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class SeekBarChangeOnSubscribe implements Observable.OnSubscribe<Integer> {
-  private final SeekBar view;
-
-  @Nullable private final Boolean shouldBeFromUser;
+  final SeekBar view;
+  @Nullable final Boolean shouldBeFromUser;
 
   public SeekBarChangeOnSubscribe(SeekBar view, @Nullable Boolean shouldBeFromUser) {
     this.view = view;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewAfterTextChangeEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewAfterTextChangeEventOnSubscribe.java
@@ -11,9 +11,9 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class TextViewAfterTextChangeEventOnSubscribe
     implements Observable.OnSubscribe<TextViewAfterTextChangeEvent> {
-  private final TextView view;
+  final TextView view;
 
-  public TextViewAfterTextChangeEventOnSubscribe(TextView view) {
+  TextViewAfterTextChangeEventOnSubscribe(TextView view) {
     this.view = view;
   }
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewBeforeTextChangeEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewBeforeTextChangeEventOnSubscribe.java
@@ -11,9 +11,9 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class TextViewBeforeTextChangeEventOnSubscribe
     implements Observable.OnSubscribe<TextViewBeforeTextChangeEvent> {
-  private final TextView view;
+  final TextView view;
 
-  public TextViewBeforeTextChangeEventOnSubscribe(TextView view) {
+  TextViewBeforeTextChangeEventOnSubscribe(TextView view) {
     this.view = view;
   }
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewEditorActionEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewEditorActionEventOnSubscribe.java
@@ -11,10 +11,10 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class TextViewEditorActionEventOnSubscribe
     implements Observable.OnSubscribe<TextViewEditorActionEvent> {
-  private final TextView view;
-  private final Func1<? super TextViewEditorActionEvent, Boolean> handled;
+  final TextView view;
+  final Func1<? super TextViewEditorActionEvent, Boolean> handled;
 
-  public TextViewEditorActionEventOnSubscribe(TextView view,
+  TextViewEditorActionEventOnSubscribe(TextView view,
       Func1<? super TextViewEditorActionEvent, Boolean> handled) {
     this.view = view;
     this.handled = handled;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewEditorActionOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewEditorActionOnSubscribe.java
@@ -10,10 +10,10 @@ import rx.functions.Func1;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class TextViewEditorActionOnSubscribe implements Observable.OnSubscribe<Integer> {
-  private final TextView view;
-  private final Func1<? super Integer, Boolean> handled;
+  final TextView view;
+  final Func1<? super Integer, Boolean> handled;
 
-  public TextViewEditorActionOnSubscribe(TextView view, Func1<? super Integer, Boolean> handled) {
+  TextViewEditorActionOnSubscribe(TextView view, Func1<? super Integer, Boolean> handled) {
     this.view = view;
     this.handled = handled;
   }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewTextChangeEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewTextChangeEventOnSubscribe.java
@@ -11,9 +11,9 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class TextViewTextChangeEventOnSubscribe
     implements Observable.OnSubscribe<TextViewTextChangeEvent> {
-  private final TextView view;
+  final TextView view;
 
-  public TextViewTextChangeEventOnSubscribe(TextView view) {
+  TextViewTextChangeEventOnSubscribe(TextView view) {
     this.view = view;
   }
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewTextOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewTextOnSubscribe.java
@@ -10,9 +10,9 @@ import rx.android.MainThreadSubscription;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 final class TextViewTextOnSubscribe implements Observable.OnSubscribe<CharSequence> {
-  private final TextView view;
+  final TextView view;
 
-  public TextViewTextOnSubscribe(TextView view) {
+  TextViewTextOnSubscribe(TextView view) {
     this.view = view;
   }
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/ToolbarItemClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/ToolbarItemClickOnSubscribe.java
@@ -12,9 +12,9 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 @TargetApi(LOLLIPOP)
 final class ToolbarItemClickOnSubscribe implements Observable.OnSubscribe<MenuItem> {
-  private final Toolbar view;
+  final Toolbar view;
 
-  public ToolbarItemClickOnSubscribe(Toolbar view) {
+  ToolbarItemClickOnSubscribe(Toolbar view) {
     this.view = view;
   }
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/ToolbarNavigationClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/ToolbarNavigationClickOnSubscribe.java
@@ -12,7 +12,7 @@ import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
 
 @TargetApi(LOLLIPOP)
 final class ToolbarNavigationClickOnSubscribe implements Observable.OnSubscribe<Void> {
-  private final Toolbar view;
+  final Toolbar view;
 
   public ToolbarNavigationClickOnSubscribe(Toolbar view) {
     this.view = view;


### PR DESCRIPTION
* `rxbinding`: Removes 56 methods to 853 from 909.
* `rxbinding-appcompat-v7`: Removes 4 methods to 72 from 76.
* `rxbinding-design`: Removes 5 methods to 140 from 145.
* `rxbinding-leanback-v17`: Removes 3 methods to 74 from 77.
* `rxbinding-recyclerview-v7`: Removes 4 methods to 86 from 90.
* `rxbinding-support-v4`: Removes 4 methods to 63 from 67.

Total removed: 76 methods. Easy win, every bit counts.