### PR TITLE
Add support RxMenuItem and more SearchView observables

### DIFF
--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RxSearchView.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RxSearchView.java
@@ -91,7 +91,8 @@ public final class RxSearchView {
   @CheckResult @NonNull
   public static Observable<Integer> suggestionClick(@NonNull SearchView view) {
     checkNotNull(view, "view == null");
-    return Observable.create(new SearchViewSuggestionClickOnSubscribe(view, Functions.FUNC1_ALWAYS_TRUE));
+    return Observable.create(new SearchViewSuggestionClickOnSubscribe(view,
+            Functions.FUNC1_ALWAYS_TRUE));
   }
 
   /**
@@ -108,8 +109,9 @@ public final class RxSearchView {
    */
   @CheckResult @NonNull
   public static Observable<Integer> suggestionClick(@NonNull SearchView view,
-                                                    Func1<? super Integer, Boolean> handled) {
+      @NonNull Func1<? super Integer, Boolean> handled) {
     checkNotNull(view, "view == null");
+    checkNotNull(handled, "handled == null");
     return Observable.create(new SearchViewSuggestionClickOnSubscribe(view, handled));
   }
 

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RxSearchView.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RxSearchView.java
@@ -3,8 +3,12 @@ package com.jakewharton.rxbinding.support.v7.widget;
 import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.SearchView;
+
+import com.jakewharton.rxbinding.internal.Functions;
+
 import rx.Observable;
 import rx.functions.Action1;
+import rx.functions.Func1;
 
 import static com.jakewharton.rxbinding.internal.Preconditions.checkNotNull;
 
@@ -60,6 +64,53 @@ public final class RxSearchView {
         view.setQuery(text, submit);
       }
     };
+  }
+
+  /**
+   * Create an observable of booleans representing the focus of the query text field.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+   * to free this reference.
+   * <p>
+   */
+  @CheckResult @NonNull
+  public static Observable<Boolean> queryTextFocusChange(@NonNull SearchView view) {
+    checkNotNull(view, "view == null");
+    return Observable.create(new SearchViewQueryTextFocusChangeOnSubscribe(view));
+  }
+
+  /**
+   * Create an observable of the absolute position of the clicked item in the list of suggestions
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+   * to free this reference.
+   * <p>
+   * <em>Warning:</em> The created observable uses {@link SearchView#setOnSuggestionListener} to
+   * observe search view events. Only one observable can be used for a search view at a time.
+   */
+  @CheckResult @NonNull
+  public static Observable<Integer> suggestionClick(@NonNull SearchView view) {
+    checkNotNull(view, "view == null");
+    return Observable.create(new SearchViewSuggestionClickOnSubscribe(view, Functions.FUNC1_ALWAYS_TRUE));
+  }
+
+  /**
+   * Create an observable of the absolute position of the clicked item in the list of suggestions
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+   * to free this reference.
+   * <p>
+   * <em>Warning:</em> The created observable uses {@link SearchView#setOnSuggestionListener} to
+   * observe search view events. Only one observable can be used for a search view at a time.
+   *
+   * @param handled Function invoked with each value to determine the return value of the
+   * underlying {@link SearchView.OnSuggestionListener}.
+   */
+  @CheckResult @NonNull
+  public static Observable<Integer> suggestionClick(@NonNull SearchView view,
+                                                    Func1<? super Integer, Boolean> handled) {
+    checkNotNull(view, "view == null");
+    return Observable.create(new SearchViewSuggestionClickOnSubscribe(view, handled));
   }
 
   private RxSearchView() {

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/SearchViewQueryTextFocusChangeOnSubscribe.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/SearchViewQueryTextFocusChangeOnSubscribe.java
@@ -1,0 +1,35 @@
+package com.jakewharton.rxbinding.support.v7.widget;
+
+import android.support.v7.widget.SearchView;
+import android.view.View;
+
+import rx.Observable;
+import rx.Subscriber;
+import rx.android.MainThreadSubscription;
+
+final class SearchViewQueryTextFocusChangeOnSubscribe
+        implements Observable.OnSubscribe<Boolean> {
+    final SearchView view;
+
+    SearchViewQueryTextFocusChangeOnSubscribe(SearchView view) {
+        this.view = view;
+    }
+
+    @Override public void call(final Subscriber<? super Boolean> subscriber) {
+        View.OnFocusChangeListener onFocusChangeListener = new View.OnFocusChangeListener() {
+            @Override public void onFocusChange(View v, boolean hasFocus) {
+                if (!subscriber.isUnsubscribed()) {
+                    subscriber.onNext(hasFocus);
+                }
+            }
+        };
+
+        view.setOnQueryTextFocusChangeListener(onFocusChangeListener);
+
+        subscriber.add(new MainThreadSubscription() {
+            @Override protected void onUnsubscribe() {
+                view.setOnQueryTextFocusChangeListener(null);
+            }
+        });
+    }
+}

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/SearchViewSuggestionClickOnSubscribe.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/SearchViewSuggestionClickOnSubscribe.java
@@ -1,0 +1,46 @@
+package com.jakewharton.rxbinding.support.v7.widget;
+
+import android.support.v7.widget.SearchView;
+
+import rx.Observable;
+import rx.Subscriber;
+import rx.android.MainThreadSubscription;
+import rx.functions.Func1;
+
+final class SearchViewSuggestionClickOnSubscribe
+        implements Observable.OnSubscribe<Integer> {
+  final SearchView view;
+  final Func1<? super Integer, Boolean> handled;
+
+  SearchViewSuggestionClickOnSubscribe(SearchView view,
+                                       Func1<? super Integer, Boolean> handled) {
+    this.view = view;
+    this.handled = handled;
+  }
+
+  @Override public void call(final Subscriber<? super Integer> subscriber) {
+    SearchView.OnSuggestionListener listener = new SearchView.OnSuggestionListener() {
+      @Override public boolean onSuggestionSelect(int position) {
+        return false;
+      }
+
+      @Override public boolean onSuggestionClick(int position) {
+        if (handled.call(position)) {
+          if (!subscriber.isUnsubscribed()) {
+            subscriber.onNext(position);
+          }
+          return true;
+        }
+        return false;
+      }
+    };
+
+    view.setOnSuggestionListener(listener);
+
+    subscriber.add(new MainThreadSubscription() {
+      @Override protected void onUnsubscribe() {
+        view.setOnSuggestionListener(null);
+      }
+    });
+  }
+}

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/view/MenuItemActionViewEventOnSubscribe.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/view/MenuItemActionViewEventOnSubscribe.java
@@ -1,0 +1,60 @@
+package com.jakewharton.rxbinding.support.v4.view;
+
+import android.support.v4.view.MenuItemCompat;
+import android.view.MenuItem;
+
+import com.jakewharton.rxbinding.view.MenuItemActionViewEvent;
+import com.jakewharton.rxbinding.view.MenuItemActionViewEvent.Kind;
+
+import rx.Observable;
+import rx.Subscriber;
+import rx.android.MainThreadSubscription;
+import rx.functions.Func1;
+
+import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
+
+final class MenuItemActionViewEventOnSubscribe
+    implements Observable.OnSubscribe<MenuItemActionViewEvent> {
+  final MenuItem menuItem;
+  final Func1<? super MenuItemActionViewEvent, Boolean> handled;
+
+  MenuItemActionViewEventOnSubscribe(MenuItem menuItem,
+                                     Func1<? super MenuItemActionViewEvent, Boolean> handled) {
+    this.menuItem = menuItem;
+    this.handled = handled;
+  }
+
+  @Override public void call(final Subscriber<? super MenuItemActionViewEvent> subscriber) {
+    checkUiThread();
+
+    MenuItemCompat.OnActionExpandListener listener = new MenuItemCompat.OnActionExpandListener() {
+      @Override public boolean onMenuItemActionExpand(MenuItem item) {
+        MenuItemActionViewEvent event = MenuItemActionViewEvent.create(menuItem, Kind.EXPAND);
+        return onEvent(event);
+      }
+
+      @Override public boolean onMenuItemActionCollapse(MenuItem item) {
+        MenuItemActionViewEvent event = MenuItemActionViewEvent.create(menuItem, Kind.COLLAPSE);
+        return onEvent(event);
+      }
+
+      private boolean onEvent(MenuItemActionViewEvent event) {
+        if (handled.call(event)) {
+          if (!subscriber.isUnsubscribed()) {
+            subscriber.onNext(event);
+          }
+          return true;
+        }
+        return false;
+      }
+    };
+
+    MenuItemCompat.setOnActionExpandListener(menuItem, listener);
+
+    subscriber.add(new MainThreadSubscription() {
+      @Override protected void onUnsubscribe() {
+        MenuItemCompat.setOnActionExpandListener(menuItem, null);
+      }
+    });
+  }
+}

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/view/RxMenuItem.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/view/RxMenuItem.java
@@ -1,0 +1,183 @@
+package com.jakewharton.rxbinding.support.v4.view;
+
+import android.graphics.drawable.Drawable;
+import android.support.annotation.CheckResult;
+import android.support.annotation.NonNull;
+import android.view.MenuItem;
+
+import com.jakewharton.rxbinding.internal.Functions;
+import com.jakewharton.rxbinding.view.MenuItemActionViewEvent;
+
+import rx.Observable;
+import rx.functions.Action1;
+import rx.functions.Func1;
+
+import static com.jakewharton.rxbinding.internal.Preconditions.checkNotNull;
+
+/**
+ * Static factory methods for creating {@linkplain Observable observables} and {@linkplain Action1
+ * actions} for {@link MenuItem}.
+ */
+public final class RxMenuItem {
+
+  /**
+   * Create an observable which emits on {@code menuItem} click events. The emitted value is
+   * unspecified and should only be used as notification.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code menuItem}.
+   * Unsubscribe to free this reference.
+   * <p>
+   * <em>Warning:</em> The created observable uses {@link MenuItem#setOnMenuItemClickListener} to
+   * observe clicks. Only one observable can be used for a menu item at a time.
+   */
+  @CheckResult @NonNull
+  public static Observable<Void> clicks(@NonNull MenuItem menuItem) {
+    checkNotNull(menuItem, "menuItem == null");
+    return com.jakewharton.rxbinding.view.RxMenuItem.clicks(menuItem);
+  }
+
+  /**
+   * Create an observable which emits on {@code menuItem} click events. The emitted value is
+   * unspecified and should only be used as notification.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code menuItem}.
+   * Unsubscribe to free this reference.
+   * <p>
+   * <em>Warning:</em> The created observable uses {@link MenuItem#setOnMenuItemClickListener} to
+   * observe clicks. Only one observable can be used for a menu item at a time.
+   *
+   * @param handled Function invoked with each value to determine the return value of the
+   * underlying {@link MenuItem.OnMenuItemClickListener}.
+   */
+  @CheckResult @NonNull
+  public static Observable<Void> clicks(@NonNull MenuItem menuItem,
+      @NonNull Func1<? super MenuItem, Boolean> handled) {
+    checkNotNull(menuItem, "menuItem == null");
+    checkNotNull(handled, "handled == null");
+    return com.jakewharton.rxbinding.view.RxMenuItem.clicks(menuItem, handled);
+  }
+
+  /**
+   * Create an observable of action view events for {@code menuItem}.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code menuItem}.
+   * Unsubscribe to free this reference.
+   * <p>
+   * <em>Warning:</em> The created observable uses {@link MenuItem#setOnActionExpandListener} to
+   * observe action view events. Only one observable can be used for a menu item at a time.
+   */
+  @CheckResult @NonNull
+  public static Observable<MenuItemActionViewEvent> actionViewEvents(@NonNull MenuItem menuItem) {
+    checkNotNull(menuItem, "menuItem == null");
+    return Observable.create(new MenuItemActionViewEventOnSubscribe(menuItem,
+        Functions.FUNC1_ALWAYS_TRUE));
+  }
+
+  /**
+   * Create an observable of action view events for {@code menuItem}.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code menuItem}.
+   * Unsubscribe to free this reference.
+   * <p>
+   * <em>Warning:</em> The created observable uses {@link MenuItem#setOnActionExpandListener} to
+   * observe action view events. Only one observable can be used for a menu item at a time.
+   *
+   * @param handled Function invoked with each value to determine the return value of the
+   * underlying {@link MenuItem.OnActionExpandListener}.
+   */
+  @CheckResult @NonNull
+  public static Observable<MenuItemActionViewEvent> actionViewEvents(@NonNull MenuItem menuItem,
+      @NonNull Func1<? super MenuItemActionViewEvent, Boolean> handled) {
+    checkNotNull(menuItem, "menuItem == null");
+    checkNotNull(handled, "handled == null");
+    return Observable.create(new MenuItemActionViewEventOnSubscribe(menuItem, handled));
+  }
+
+  /**
+   * An action which sets the checked property of {@code menuItem}.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code menuItem}.
+   * Unsubscribe to free this reference.
+   */
+  @CheckResult @NonNull
+  public static Action1<? super Boolean> checked(@NonNull final MenuItem menuItem) {
+    checkNotNull(menuItem, "menuItem == null");
+    return com.jakewharton.rxbinding.view.RxMenuItem.checked(menuItem);
+  }
+
+  /**
+   * An action which sets the enabled property of {@code menuItem}.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code menuItem}.
+   * Unsubscribe to free this reference.
+   */
+  @CheckResult @NonNull
+  public static Action1<? super Boolean> enabled(@NonNull final MenuItem menuItem) {
+    checkNotNull(menuItem, "menuItem == null");
+    return com.jakewharton.rxbinding.view.RxMenuItem.enabled(menuItem);
+  }
+
+  /**
+   * An action which sets the icon property of {@code menuItem}.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code menuItem}.
+   * Unsubscribe to free this reference.
+   */
+  @CheckResult @NonNull
+  public static Action1<? super Drawable> icon(@NonNull final MenuItem menuItem) {
+    checkNotNull(menuItem, "menuItem == null");
+    return com.jakewharton.rxbinding.view.RxMenuItem.icon(menuItem);
+  }
+
+  /**
+   * An action which sets the icon property of {@code menuItem}.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code menuItem}.
+   * Unsubscribe to free this reference.
+   */
+  @CheckResult @NonNull
+  public static Action1<? super Integer> iconRes(@NonNull final MenuItem menuItem) {
+    checkNotNull(menuItem, "menuItem == null");
+    return com.jakewharton.rxbinding.view.RxMenuItem.iconRes(menuItem);
+  }
+
+  /**
+   * An action which sets the title property of {@code menuItem}.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code menuItem}.
+   * Unsubscribe to free this reference.
+   */
+  @CheckResult @NonNull
+  public static Action1<? super CharSequence> title(@NonNull final MenuItem menuItem) {
+    checkNotNull(menuItem, "menuItem == null");
+    return com.jakewharton.rxbinding.view.RxMenuItem.title(menuItem);
+  }
+
+  /**
+   * An action which sets the title property of {@code menuItem}.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code menuItem}.
+   * Unsubscribe to free this reference.
+   */
+  @CheckResult @NonNull
+  public static Action1<? super Integer> titleRes(@NonNull final MenuItem menuItem) {
+    checkNotNull(menuItem, "menuItem == null");
+    return com.jakewharton.rxbinding.view.RxMenuItem.titleRes(menuItem);
+  }
+
+  /**
+   * An action which sets the visibility property of {@code menuItem}.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code menuItem}.
+   * Unsubscribe to free this reference.
+   */
+  @CheckResult @NonNull
+  public static Action1<? super Boolean> visible(@NonNull final MenuItem menuItem) {
+    checkNotNull(menuItem, "menuItem == null");
+    return com.jakewharton.rxbinding.view.RxMenuItem.visible(menuItem);
+  }
+
+  private RxMenuItem() {
+    throw new AssertionError("No instances.");
+  }
+}

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RxSearchView.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RxSearchView.java
@@ -3,8 +3,12 @@ package com.jakewharton.rxbinding.widget;
 import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.widget.SearchView;
+
+import com.jakewharton.rxbinding.internal.Functions;
+
 import rx.Observable;
 import rx.functions.Action1;
+import rx.functions.Func1;
 
 import static com.jakewharton.rxbinding.internal.Preconditions.checkNotNull;
 
@@ -60,6 +64,53 @@ public final class RxSearchView {
         view.setQuery(text, submit);
       }
     };
+  }
+
+  /**
+   * Create an observable of booleans representing the focus of the query text field.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+   * to free this reference.
+   * <p>
+   */
+  @CheckResult @NonNull
+  public static Observable<Boolean> queryTextFocusChange(@NonNull SearchView view) {
+    checkNotNull(view, "view == null");
+    return Observable.create(new SearchViewQueryTextFocusChangeOnSubscribe(view));
+  }
+
+  /**
+   * Create an observable of the absolute position of the clicked item in the list of suggestions
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+   * to free this reference.
+   * <p>
+   * <em>Warning:</em> The created observable uses {@link SearchView#setOnSuggestionListener} to
+   * observe search view events. Only one observable can be used for a search view at a time.
+   */
+  @CheckResult @NonNull
+  public static Observable<Integer> suggestionClick(@NonNull SearchView view) {
+    checkNotNull(view, "view == null");
+    return Observable.create(new SearchViewSuggestionClickOnSubscribe(view, Functions.FUNC1_ALWAYS_TRUE));
+  }
+
+  /**
+   * Create an observable of the absolute position of the clicked item in the list of suggestions
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+   * to free this reference.
+   * <p>
+   * <em>Warning:</em> The created observable uses {@link SearchView#setOnSuggestionListener} to
+   * observe search view events. Only one observable can be used for a search view at a time.
+   *
+   * @param handled Function invoked with each value to determine the return value of the
+   * underlying {@link SearchView.OnSuggestionListener}.
+   */
+  @CheckResult @NonNull
+  public static Observable<Integer> suggestionClick(@NonNull SearchView view,
+                                                    Func1<? super Integer, Boolean> handled) {
+    checkNotNull(view, "view == null");
+    return Observable.create(new SearchViewSuggestionClickOnSubscribe(view, handled));
   }
 
   private RxSearchView() {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RxSearchView.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RxSearchView.java
@@ -91,7 +91,8 @@ public final class RxSearchView {
   @CheckResult @NonNull
   public static Observable<Integer> suggestionClick(@NonNull SearchView view) {
     checkNotNull(view, "view == null");
-    return Observable.create(new SearchViewSuggestionClickOnSubscribe(view, Functions.FUNC1_ALWAYS_TRUE));
+    return Observable.create(new SearchViewSuggestionClickOnSubscribe(view,
+            Functions.FUNC1_ALWAYS_TRUE));
   }
 
   /**
@@ -108,8 +109,9 @@ public final class RxSearchView {
    */
   @CheckResult @NonNull
   public static Observable<Integer> suggestionClick(@NonNull SearchView view,
-                                                    Func1<? super Integer, Boolean> handled) {
+      @NonNull Func1<? super Integer, Boolean> handled) {
     checkNotNull(view, "view == null");
+    checkNotNull(handled, "handled == null");
     return Observable.create(new SearchViewSuggestionClickOnSubscribe(view, handled));
   }
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewQueryTextFocusChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewQueryTextFocusChangeOnSubscribe.java
@@ -1,0 +1,35 @@
+package com.jakewharton.rxbinding.widget;
+
+import android.view.View;
+import android.widget.SearchView;
+
+import rx.Observable;
+import rx.Subscriber;
+import rx.android.MainThreadSubscription;
+
+final class SearchViewQueryTextFocusChangeOnSubscribe
+        implements Observable.OnSubscribe<Boolean> {
+    final SearchView view;
+
+    SearchViewQueryTextFocusChangeOnSubscribe(SearchView view) {
+        this.view = view;
+    }
+
+    @Override public void call(final Subscriber<? super Boolean> subscriber) {
+        View.OnFocusChangeListener onFocusChangeListener = new View.OnFocusChangeListener() {
+            @Override public void onFocusChange(View v, boolean hasFocus) {
+                if (!subscriber.isUnsubscribed()) {
+                    subscriber.onNext(hasFocus);
+                }
+            }
+        };
+
+        view.setOnQueryTextFocusChangeListener(onFocusChangeListener);
+
+        subscriber.add(new MainThreadSubscription() {
+            @Override protected void onUnsubscribe() {
+                view.setOnQueryTextFocusChangeListener(null);
+            }
+        });
+    }
+}

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewSuggestionClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewSuggestionClickOnSubscribe.java
@@ -1,0 +1,46 @@
+package com.jakewharton.rxbinding.widget;
+
+import android.widget.SearchView;
+
+import rx.Observable;
+import rx.Subscriber;
+import rx.android.MainThreadSubscription;
+import rx.functions.Func1;
+
+final class SearchViewSuggestionClickOnSubscribe
+        implements Observable.OnSubscribe<Integer> {
+  final SearchView view;
+  final Func1<? super Integer, Boolean> handled;
+
+  SearchViewSuggestionClickOnSubscribe(SearchView view,
+                                       Func1<? super Integer, Boolean> handled) {
+    this.view = view;
+    this.handled = handled;
+  }
+
+  @Override public void call(final Subscriber<? super Integer> subscriber) {
+    SearchView.OnSuggestionListener listener = new SearchView.OnSuggestionListener() {
+      @Override public boolean onSuggestionSelect(int position) {
+        return false;
+      }
+
+      @Override public boolean onSuggestionClick(int position) {
+        if (handled.call(position)) {
+          if (!subscriber.isUnsubscribed()) {
+            subscriber.onNext(position);
+          }
+          return true;
+        }
+        return false;
+      }
+    };
+
+    view.setOnSuggestionListener(listener);
+
+    subscriber.add(new MainThreadSubscription() {
+      @Override protected void onUnsubscribe() {
+        view.setOnSuggestionListener(null);
+      }
+    });
+  }
+}


### PR DESCRIPTION
Add RxMenuItem in rxbinding-support-v4. App crashes, when regular RxMenuItem is used with support Toolbar. Exception "This is not supported, use MenuItemCompat.setOnActionExpandListener()" is thrown.

Add extra observable in RxSearchView both rxbinding and rxbinding-appcompat-v7: queryTextFocusChange, suggestionClick.