### PR TITLE
Add RxMenuItemCompat

### DIFF
--- a/rxbinding-support-v4-kotlin/src/main/kotlin/com/jakewharton/rxbinding/support/v4/view/RxMenuItemCompat.kt
+++ b/rxbinding-support-v4-kotlin/src/main/kotlin/com/jakewharton/rxbinding/support/v4/view/RxMenuItemCompat.kt
@@ -1,0 +1,33 @@
+package com.jakewharton.rxbinding.support.v4.view
+
+import android.view.MenuItem
+import com.jakewharton.rxbinding.internal.Functions
+import com.jakewharton.rxbinding.view.MenuItemActionViewEvent
+import rx.Observable
+import rx.functions.Action1
+import rx.functions.Func1
+
+/**
+ * Create an observable of action view events for `menuItem`.
+ * 
+ * *Warning:* The created observable keeps a strong reference to `menuItem`.
+ * Unsubscribe to free this reference.
+ * 
+ * *Warning:* The created observable uses [MenuItem.setOnActionExpandListener] to
+ * observe action view events. Only one observable can be used for a menu item at a time.
+ */
+public inline fun MenuItem.actionViewEvents(): Observable<MenuItemActionViewEvent> = RxMenuItemCompat.actionViewEvents(this)
+
+/**
+ * Create an observable of action view events for `menuItem`.
+ * 
+ * *Warning:* The created observable keeps a strong reference to `menuItem`.
+ * Unsubscribe to free this reference.
+ * 
+ * *Warning:* The created observable uses [MenuItem.setOnActionExpandListener] to
+ * observe action view events. Only one observable can be used for a menu item at a time.
+ *
+ * @param handled Function invoked with each value to determine the return value of the
+ * underlying [MenuItem.OnActionExpandListener].
+ */
+public inline fun MenuItem.actionViewEvents(handled: Func1<in MenuItemActionViewEvent, Boolean>): Observable<MenuItemActionViewEvent> = RxMenuItemCompat.actionViewEvents(this, handled)

--- a/rxbinding-support-v4-kotlin/src/main/kotlin/com/jakewharton/rxbinding/support/v4/view/RxMenuItemCompat.kt
+++ b/rxbinding-support-v4-kotlin/src/main/kotlin/com/jakewharton/rxbinding/support/v4/view/RxMenuItemCompat.kt
@@ -4,7 +4,6 @@ import android.view.MenuItem
 import com.jakewharton.rxbinding.internal.Functions
 import com.jakewharton.rxbinding.view.MenuItemActionViewEvent
 import rx.Observable
-import rx.functions.Action1
 import rx.functions.Func1
 
 /**

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/view/MenuItemActionViewEventOnSubscribe.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/view/MenuItemActionViewEventOnSubscribe.java
@@ -1,0 +1,60 @@
+package com.jakewharton.rxbinding.support.v4.view;
+
+import android.support.v4.view.MenuItemCompat;
+import android.view.MenuItem;
+
+import com.jakewharton.rxbinding.view.MenuItemActionViewEvent;
+import com.jakewharton.rxbinding.view.MenuItemActionViewEvent.Kind;
+
+import rx.Observable;
+import rx.Subscriber;
+import rx.android.MainThreadSubscription;
+import rx.functions.Func1;
+
+import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
+
+final class MenuItemActionViewEventOnSubscribe
+    implements Observable.OnSubscribe<MenuItemActionViewEvent> {
+  final MenuItem menuItem;
+  final Func1<? super MenuItemActionViewEvent, Boolean> handled;
+
+  MenuItemActionViewEventOnSubscribe(MenuItem menuItem,
+                                     Func1<? super MenuItemActionViewEvent, Boolean> handled) {
+    this.menuItem = menuItem;
+    this.handled = handled;
+  }
+
+  @Override public void call(final Subscriber<? super MenuItemActionViewEvent> subscriber) {
+    checkUiThread();
+
+    MenuItemCompat.OnActionExpandListener listener = new MenuItemCompat.OnActionExpandListener() {
+      @Override public boolean onMenuItemActionExpand(MenuItem item) {
+        MenuItemActionViewEvent event = MenuItemActionViewEvent.create(menuItem, Kind.EXPAND);
+        return onEvent(event);
+      }
+
+      @Override public boolean onMenuItemActionCollapse(MenuItem item) {
+        MenuItemActionViewEvent event = MenuItemActionViewEvent.create(menuItem, Kind.COLLAPSE);
+        return onEvent(event);
+      }
+
+      private boolean onEvent(MenuItemActionViewEvent event) {
+        if (handled.call(event)) {
+          if (!subscriber.isUnsubscribed()) {
+            subscriber.onNext(event);
+          }
+          return true;
+        }
+        return false;
+      }
+    };
+
+    MenuItemCompat.setOnActionExpandListener(menuItem, listener);
+
+    subscriber.add(new MainThreadSubscription() {
+      @Override protected void onUnsubscribe() {
+        MenuItemCompat.setOnActionExpandListener(menuItem, null);
+      }
+    });
+  }
+}

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/view/RxMenuItemCompat.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/view/RxMenuItemCompat.java
@@ -1,0 +1,61 @@
+package com.jakewharton.rxbinding.support.v4.view;
+
+import android.support.annotation.CheckResult;
+import android.support.annotation.NonNull;
+import android.view.MenuItem;
+
+import com.jakewharton.rxbinding.internal.Functions;
+import com.jakewharton.rxbinding.view.MenuItemActionViewEvent;
+
+import rx.Observable;
+import rx.functions.Action1;
+import rx.functions.Func1;
+
+import static com.jakewharton.rxbinding.internal.Preconditions.checkNotNull;
+
+/**
+ * Static factory methods for creating {@linkplain Observable observables} and {@linkplain Action1
+ * actions} for {@link MenuItem}.
+ */
+public final class RxMenuItemCompat {
+
+  /**
+   * Create an observable of action view events for {@code menuItem}.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code menuItem}.
+   * Unsubscribe to free this reference.
+   * <p>
+   * <em>Warning:</em> The created observable uses {@link MenuItem#setOnActionExpandListener} to
+   * observe action view events. Only one observable can be used for a menu item at a time.
+   */
+  @CheckResult @NonNull
+  public static Observable<MenuItemActionViewEvent> actionViewEvents(@NonNull MenuItem menuItem) {
+    checkNotNull(menuItem, "menuItem == null");
+    return Observable.create(new MenuItemActionViewEventOnSubscribe(menuItem,
+        Functions.FUNC1_ALWAYS_TRUE));
+  }
+
+  /**
+   * Create an observable of action view events for {@code menuItem}.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code menuItem}.
+   * Unsubscribe to free this reference.
+   * <p>
+   * <em>Warning:</em> The created observable uses {@link MenuItem#setOnActionExpandListener} to
+   * observe action view events. Only one observable can be used for a menu item at a time.
+   *
+   * @param handled Function invoked with each value to determine the return value of the
+   * underlying {@link MenuItem.OnActionExpandListener}.
+   */
+  @CheckResult @NonNull
+  public static Observable<MenuItemActionViewEvent> actionViewEvents(@NonNull MenuItem menuItem,
+      @NonNull Func1<? super MenuItemActionViewEvent, Boolean> handled) {
+    checkNotNull(menuItem, "menuItem == null");
+    checkNotNull(handled, "handled == null");
+    return Observable.create(new MenuItemActionViewEventOnSubscribe(menuItem, handled));
+  }
+
+  private RxMenuItemCompat() {
+    throw new AssertionError("No instances.");
+  }
+}

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/view/RxMenuItemCompat.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/view/RxMenuItemCompat.java
@@ -8,14 +8,13 @@ import com.jakewharton.rxbinding.internal.Functions;
 import com.jakewharton.rxbinding.view.MenuItemActionViewEvent;
 
 import rx.Observable;
-import rx.functions.Action1;
 import rx.functions.Func1;
 
 import static com.jakewharton.rxbinding.internal.Preconditions.checkNotNull;
 
 /**
- * Static factory methods for creating {@linkplain Observable observables} and {@linkplain Action1
- * actions} for {@link MenuItem}.
+ * Static factory methods for creating {@linkplain Observable observables}
+ * for {@link android.support.v4.view.MenuItemCompat}.
  */
 public final class RxMenuItemCompat {
 


### PR DESCRIPTION
Add RxMenuItemCompat in rxbinding-support-v4. App crashes, when regular RxMenuItem is used with support Toolbar. Exception "This is not supported, use MenuItemCompat.setOnActionExpandListener()" is thrown.

It's updated version of my previous pull request #208 with Kotlin bindings