### PR TITLE
Add RxPopupMenu

### DIFF
--- a/rxbinding-appcompat-v7-kotlin/src/main/kotlin/com/jakewharton/rxbinding/support/v7/widget/RxPopupMenu.kt
+++ b/rxbinding-appcompat-v7-kotlin/src/main/kotlin/com/jakewharton/rxbinding/support/v7/widget/RxPopupMenu.kt
@@ -1,0 +1,28 @@
+package com.jakewharton.rxbinding.support.v7.widget
+
+import android.support.v7.widget.PopupMenu
+import android.view.MenuItem
+import rx.Observable
+
+/**
+ * Create an observable which emits the clicked item in `view`'s menu.
+ *
+ * *Warning:* The created observable keeps a strong reference to `view`.
+ * Unsubscribe to free this reference.
+ *
+ * *Warning:* The created observable uses [PopupMenu.setOnMenuItemClickListener]
+ * to observe dismiss change. Only one observable can be used for a view at a time.
+ */
+public inline fun PopupMenu.itemClicks(): Observable<MenuItem> = RxPopupMenu.itemClicks(this)
+
+/**
+ * Create an observable which emits on `view` dismiss events. The emitted value is
+ * unspecified and should only be used as notification.
+ *
+ * *Warning:* The created observable keeps a strong reference to `view`.
+ * Unsubscribe to free this reference.
+ *
+ * *Warning:* The created observable uses [PopupMenu.setOnDismissListener] to
+ * observe dismiss change. Only one observable can be used for a view at a time.
+ */
+public inline fun PopupMenu.dismisses(): Observable<Unit> = RxPopupMenu.dismisses(this).map { Unit }

--- a/rxbinding-appcompat-v7/src/androidTest/AndroidManifest.xml
+++ b/rxbinding-appcompat-v7/src/androidTest/AndroidManifest.xml
@@ -8,5 +8,9 @@
         android:name="com.jakewharton.rxbinding.support.v7.widget.RxToolbarTestActivity"
         android:theme="@style/Theme.AppCompat"
         />
+    <activity
+        android:name="com.jakewharton.rxbinding.support.v7.widget.RxPopupMenuTestActivity"
+        android:theme="@style/Theme.AppCompat"
+        />
   </application>
 </manifest>

--- a/rxbinding-appcompat-v7/src/androidTest/java/com/jakewharton/rxbinding/support/v7/widget/RxPopupMenuTest.java
+++ b/rxbinding-appcompat-v7/src/androidTest/java/com/jakewharton/rxbinding/support/v7/widget/RxPopupMenuTest.java
@@ -1,0 +1,88 @@
+package com.jakewharton.rxbinding.support.v7.widget;
+
+import android.app.Instrumentation;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.annotation.UiThreadTest;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.support.v7.widget.PopupMenu;
+import android.view.Menu;
+import android.view.MenuItem;
+import com.jakewharton.rxbinding.RecordingObserver;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import rx.Subscription;
+import rx.android.schedulers.AndroidSchedulers;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(AndroidJUnit4.class) public final class RxPopupMenuTest {
+  @Rule public final ActivityTestRule<RxPopupMenuTestActivity> activityRule =
+      new ActivityTestRule<>(RxPopupMenuTestActivity.class);
+
+  private final Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
+
+  private PopupMenu view;
+
+  @Before public void setUp() {
+    view = activityRule.getActivity().popupMenu;
+  }
+
+  @Test @UiThreadTest public void itemClicks() {
+    Menu menu = view.getMenu();
+    MenuItem item1 = menu.add(0, 1, 0, "Hi");
+    MenuItem item2 = menu.add(0, 2, 0, "Hey");
+
+    RecordingObserver<MenuItem> o = new RecordingObserver<>();
+    Subscription subscription = RxPopupMenu.itemClicks(view).subscribe(o);
+    o.assertNoMoreEvents();
+
+    menu.performIdentifierAction(2, 0);
+    assertThat(o.takeNext()).isSameAs(item2);
+
+    menu.performIdentifierAction(1, 0);
+    assertThat(o.takeNext()).isSameAs(item1);
+
+    subscription.unsubscribe();
+
+    menu.performIdentifierAction(2, 0);
+    o.assertNoMoreEvents();
+  }
+
+  @Test public void dismisses() {
+    RecordingObserver<Void> o = new RecordingObserver<>();
+    Subscription subscription =
+        RxPopupMenu.dismisses(view).subscribeOn(AndroidSchedulers.mainThread()).subscribe(o);
+    o.assertNoMoreEvents(); // No initial value.
+
+    instrumentation.runOnMainSync(new Runnable() {
+      @Override public void run() {
+        view.show();
+      }
+    });
+    o.assertNoMoreEvents();
+
+    instrumentation.runOnMainSync(new Runnable() {
+      @Override public void run() {
+        view.dismiss();
+      }
+    });
+    assertThat(o.takeNext()).isNull();
+
+    subscription.unsubscribe();
+    instrumentation.runOnMainSync(new Runnable() {
+      @Override public void run() {
+        view.show();
+      }
+    });
+    instrumentation.runOnMainSync(new Runnable() {
+      @Override public void run() {
+        view.dismiss();
+      }
+    });
+
+    o.assertNoMoreEvents();
+  }
+}

--- a/rxbinding-appcompat-v7/src/androidTest/java/com/jakewharton/rxbinding/support/v7/widget/RxPopupMenuTestActivity.java
+++ b/rxbinding-appcompat-v7/src/androidTest/java/com/jakewharton/rxbinding/support/v7/widget/RxPopupMenuTestActivity.java
@@ -1,0 +1,19 @@
+package com.jakewharton.rxbinding.support.v7.widget;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.support.v7.widget.PopupMenu;
+import android.view.View;
+
+public final class RxPopupMenuTestActivity extends Activity {
+
+  PopupMenu popupMenu;
+
+  @Override protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    View anchor = new View(this);
+    setContentView(anchor);
+    popupMenu = new PopupMenu(this, anchor);
+  }
+}

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/PopupMenuDismissOnSubscribe.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/PopupMenuDismissOnSubscribe.java
@@ -1,0 +1,37 @@
+package com.jakewharton.rxbinding.support.v7.widget;
+
+import android.support.v7.widget.PopupMenu;
+import rx.Observable;
+import rx.Subscriber;
+import rx.android.MainThreadSubscription;
+
+import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
+
+final class PopupMenuDismissOnSubscribe implements Observable.OnSubscribe<Void> {
+
+  final PopupMenu view;
+
+  public PopupMenuDismissOnSubscribe(PopupMenu view) {
+    this.view = view;
+  }
+
+  @Override public void call(final Subscriber<? super Void> subscriber) {
+    checkUiThread();
+
+    PopupMenu.OnDismissListener listener = new PopupMenu.OnDismissListener() {
+      @Override public void onDismiss(PopupMenu menu) {
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(null);
+        }
+      }
+    };
+
+    view.setOnDismissListener(listener);
+
+    subscriber.add(new MainThreadSubscription() {
+      @Override protected void onUnsubscribe() {
+        view.setOnDismissListener(null);
+      }
+    });
+  }
+}

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/PopupMenuItemClickOnSubscribe.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/PopupMenuItemClickOnSubscribe.java
@@ -1,0 +1,39 @@
+package com.jakewharton.rxbinding.support.v7.widget;
+
+import android.support.v7.widget.PopupMenu;
+import android.view.MenuItem;
+import rx.Observable;
+import rx.Subscriber;
+import rx.android.MainThreadSubscription;
+
+import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
+
+final class PopupMenuItemClickOnSubscribe implements Observable.OnSubscribe<MenuItem> {
+
+  final PopupMenu view;
+
+  public PopupMenuItemClickOnSubscribe(PopupMenu view) {
+    this.view = view;
+  }
+
+  @Override public void call(final Subscriber<? super MenuItem> subscriber) {
+    checkUiThread();
+
+    PopupMenu.OnMenuItemClickListener listener = new PopupMenu.OnMenuItemClickListener() {
+      @Override public boolean onMenuItemClick(MenuItem item) {
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(item);
+        }
+        return true;
+      }
+    };
+
+    view.setOnMenuItemClickListener(listener);
+
+    subscriber.add(new MainThreadSubscription() {
+      @Override protected void onUnsubscribe() {
+        view.setOnMenuItemClickListener(null);
+      }
+    });
+  }
+}

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RxPopupMenu.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RxPopupMenu.java
@@ -1,0 +1,49 @@
+package com.jakewharton.rxbinding.support.v7.widget;
+
+import android.support.annotation.CheckResult;
+import android.support.annotation.NonNull;
+import android.support.v7.widget.PopupMenu;
+import android.view.MenuItem;
+import rx.Observable;
+
+import static com.jakewharton.rxbinding.internal.Preconditions.checkNotNull;
+
+/**
+ * Static factory methods for creating {@linkplain Observable observables} for {@link PopupMenu}.
+ */
+public final class RxPopupMenu {
+  /**
+   * Create an observable which emits the clicked item in {@code view}'s menu.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code view}.
+   * Unsubscribe to free this reference.
+   * <p>
+   * <em>Warning:</em> The created observable uses {@link PopupMenu#setOnMenuItemClickListener}
+   * to observe dismiss change. Only one observable can be used for a view at a time.
+   */
+  @CheckResult @NonNull
+  public static Observable<MenuItem> itemClicks(@NonNull PopupMenu view) {
+    checkNotNull(view, "view == null");
+    return Observable.create(new PopupMenuItemClickOnSubscribe(view));
+  }
+
+  /**
+   * Create an observable which emits on {@code view} dismiss events. The emitted value is
+   * unspecified and should only be used as notification.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code view}.
+   * Unsubscribe to free this reference.
+   * <p>
+   * <em>Warning:</em> The created observable uses {@link PopupMenu#setOnDismissListener} to
+   * observe dismiss change. Only one observable can be used for a view at a time.
+   */
+  @CheckResult @NonNull
+  public static Observable<Void> dismisses(@NonNull PopupMenu view) {
+    checkNotNull(view, "view == null");
+    return Observable.create(new PopupMenuDismissOnSubscribe(view));
+  }
+
+  private RxPopupMenu() {
+    throw new AssertionError("No instances.");
+  }
+}

--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/widget/RxPopupMenu.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/widget/RxPopupMenu.kt
@@ -1,0 +1,28 @@
+package com.jakewharton.rxbinding.widget
+
+import android.view.MenuItem
+import android.widget.PopupMenu
+import rx.Observable
+
+/**
+ * Create an observable which emits the clicked item in `view`'s menu.
+ *
+ * *Warning:* The created observable keeps a strong reference to `view`.
+ * Unsubscribe to free this reference.
+ *
+ * *Warning:* The created observable uses [PopupMenu.setOnMenuItemClickListener]
+ * to observe dismiss change. Only one observable can be used for a view at a time.
+ */
+public inline fun PopupMenu.itemClicks(): Observable<MenuItem> = RxPopupMenu.itemClicks(this)
+
+/**
+ * Create an observable which emits on `view` dismiss events. The emitted value is
+ * unspecified and should only be used as notification.
+ *
+ * *Warning:* The created observable keeps a strong reference to `view`.
+ * Unsubscribe to free this reference.
+ *
+ * *Warning:* The created observable uses [PopupMenu.setOnDismissListener] to
+ * observe dismiss change. Only one observable can be used for a view at a time.
+ */
+public inline fun PopupMenu.dismisses(): Observable<Unit> = RxPopupMenu.dismisses(this).map { Unit }

--- a/rxbinding/src/androidTest/AndroidManifest.xml
+++ b/rxbinding/src/androidTest/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <activity android:name=".widget.RxAutoCompleteTextViewTestActivity"/>
     <activity android:name=".widget.RxRatingBarTestActivity"/>
     <activity android:name=".widget.RxSeekBarTestActivity"/>
+    <activity android:name=".widget.RxPopupMenuTestActivity"/>
     <activity
         android:name=".widget.RxToolbarTestActivity"
         android:theme="@android:style/Theme.Material"

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/widget/RxPopupMenuTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/widget/RxPopupMenuTest.java
@@ -1,0 +1,88 @@
+package com.jakewharton.rxbinding.widget;
+
+import android.app.Instrumentation;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.annotation.UiThreadTest;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.widget.PopupMenu;
+import com.jakewharton.rxbinding.RecordingObserver;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import rx.Subscription;
+import rx.android.schedulers.AndroidSchedulers;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(AndroidJUnit4.class) public final class RxPopupMenuTest {
+  @Rule public final ActivityTestRule<RxPopupMenuTestActivity> activityRule =
+      new ActivityTestRule<>(RxPopupMenuTestActivity.class);
+
+  private final Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
+
+  private PopupMenu view;
+
+  @Before public void setUp() {
+    view = activityRule.getActivity().popupMenu;
+  }
+
+  @Test @UiThreadTest public void itemClicks() {
+    Menu menu = view.getMenu();
+    MenuItem item1 = menu.add(0, 1, 0, "Hi");
+    MenuItem item2 = menu.add(0, 2, 0, "Hey");
+
+    RecordingObserver<MenuItem> o = new RecordingObserver<>();
+    Subscription subscription = RxPopupMenu.itemClicks(view).subscribe(o);
+    o.assertNoMoreEvents();
+
+    menu.performIdentifierAction(2, 0);
+    assertThat(o.takeNext()).isSameAs(item2);
+
+    menu.performIdentifierAction(1, 0);
+    assertThat(o.takeNext()).isSameAs(item1);
+
+    subscription.unsubscribe();
+
+    menu.performIdentifierAction(2, 0);
+    o.assertNoMoreEvents();
+  }
+
+  @Test public void dismisses() {
+    RecordingObserver<Void> o = new RecordingObserver<>();
+    Subscription subscription =
+        RxPopupMenu.dismisses(view).subscribeOn(AndroidSchedulers.mainThread()).subscribe(o);
+    o.assertNoMoreEvents(); // No initial value.
+
+    instrumentation.runOnMainSync(new Runnable() {
+      @Override public void run() {
+        view.show();
+      }
+    });
+    o.assertNoMoreEvents();
+
+    instrumentation.runOnMainSync(new Runnable() {
+      @Override public void run() {
+        view.dismiss();
+      }
+    });
+    assertThat(o.takeNext()).isNull();
+
+    subscription.unsubscribe();
+    instrumentation.runOnMainSync(new Runnable() {
+      @Override public void run() {
+        view.show();
+      }
+    });
+    instrumentation.runOnMainSync(new Runnable() {
+      @Override public void run() {
+        view.dismiss();
+      }
+    });
+
+    o.assertNoMoreEvents();
+  }
+}

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/widget/RxPopupMenuTestActivity.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/widget/RxPopupMenuTestActivity.java
@@ -1,0 +1,19 @@
+package com.jakewharton.rxbinding.widget;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.PopupMenu;
+
+public final class RxPopupMenuTestActivity extends Activity {
+
+  PopupMenu popupMenu;
+
+  @Override protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    View anchor = new View(this);
+    setContentView(anchor);
+    popupMenu = new PopupMenu(this, anchor);
+  }
+}

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/PopupMenuDismissOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/PopupMenuDismissOnSubscribe.java
@@ -1,0 +1,37 @@
+package com.jakewharton.rxbinding.widget;
+
+import android.widget.PopupMenu;
+import rx.Observable;
+import rx.Subscriber;
+import rx.android.MainThreadSubscription;
+
+import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
+
+final class PopupMenuDismissOnSubscribe implements Observable.OnSubscribe<Void> {
+
+  final PopupMenu view;
+
+  public PopupMenuDismissOnSubscribe(PopupMenu view) {
+    this.view = view;
+  }
+
+  @Override public void call(final Subscriber<? super Void> subscriber) {
+    checkUiThread();
+
+    PopupMenu.OnDismissListener listener = new PopupMenu.OnDismissListener() {
+      @Override public void onDismiss(PopupMenu menu) {
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(null);
+        }
+      }
+    };
+
+    view.setOnDismissListener(listener);
+
+    subscriber.add(new MainThreadSubscription() {
+      @Override protected void onUnsubscribe() {
+        view.setOnDismissListener(null);
+      }
+    });
+  }
+}

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/PopupMenuItemClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/PopupMenuItemClickOnSubscribe.java
@@ -1,0 +1,39 @@
+package com.jakewharton.rxbinding.widget;
+
+import android.view.MenuItem;
+import android.widget.PopupMenu;
+import rx.Observable;
+import rx.Subscriber;
+import rx.android.MainThreadSubscription;
+
+import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
+
+final class PopupMenuItemClickOnSubscribe implements Observable.OnSubscribe<MenuItem> {
+
+  final PopupMenu view;
+
+  public PopupMenuItemClickOnSubscribe(PopupMenu view) {
+    this.view = view;
+  }
+
+  @Override public void call(final Subscriber<? super MenuItem> subscriber) {
+    checkUiThread();
+
+    PopupMenu.OnMenuItemClickListener listener = new PopupMenu.OnMenuItemClickListener() {
+      @Override public boolean onMenuItemClick(MenuItem item) {
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(item);
+        }
+        return true;
+      }
+    };
+
+    view.setOnMenuItemClickListener(listener);
+
+    subscriber.add(new MainThreadSubscription() {
+      @Override protected void onUnsubscribe() {
+        view.setOnMenuItemClickListener(null);
+      }
+    });
+  }
+}

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RxPopupMenu.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RxPopupMenu.java
@@ -1,0 +1,49 @@
+package com.jakewharton.rxbinding.widget;
+
+import android.support.annotation.CheckResult;
+import android.support.annotation.NonNull;
+import android.view.MenuItem;
+import android.widget.PopupMenu;
+import rx.Observable;
+
+import static com.jakewharton.rxbinding.internal.Preconditions.checkNotNull;
+
+/**
+ * Static factory methods for creating {@linkplain Observable observables} for {@link PopupMenu}.
+ */
+public final class RxPopupMenu {
+  /**
+   * Create an observable which emits the clicked item in {@code view}'s menu.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code view}.
+   * Unsubscribe to free this reference.
+   * <p>
+   * <em>Warning:</em> The created observable uses {@link PopupMenu#setOnMenuItemClickListener}
+   * to observe dismiss change. Only one observable can be used for a view at a time.
+   */
+  @CheckResult @NonNull
+  public static Observable<MenuItem> itemClicks(@NonNull PopupMenu view) {
+    checkNotNull(view, "view == null");
+    return Observable.create(new PopupMenuItemClickOnSubscribe(view));
+  }
+
+  /**
+   * Create an observable which emits on {@code view} dismiss events. The emitted value is
+   * unspecified and should only be used as notification.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code view}.
+   * Unsubscribe to free this reference.
+   * <p>
+   * <em>Warning:</em> The created observable uses {@link PopupMenu#setOnDismissListener} to
+   * observe dismiss change. Only one observable can be used for a view at a time.
+   */
+  @CheckResult @NonNull
+  public static Observable<Void> dismisses(@NonNull PopupMenu view) {
+    checkNotNull(view, "view == null");
+    return Observable.create(new PopupMenuDismissOnSubscribe(view));
+  }
+
+  private RxPopupMenu() {
+    throw new AssertionError("No instances.");
+  }
+}


### PR DESCRIPTION
Added bindings for the platform and Appcompat versions of PopupMenu. Closes #222. 

I wasn't sure if `show` and `dismiss` should have `Action1` bindings. I imagine have a single `Action1<? super Boolean>` binding to both show and dismiss is preferable? 