### PR TITLE
Add support for ListView Scroll events

### DIFF
--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/widget/RxAbsListView.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/widget/RxAbsListView.kt
@@ -1,0 +1,17 @@
+package com.jakewharton.rxbinding.widget
+
+import android.widget.AbsListView
+import rx.Observable
+
+/**
+ * Create an observable of scroll events on `listView`.
+ *
+ * *Warning:* The created observable keeps a strong reference to `listView`.
+ * Unsubscribe to free this reference.
+ * *
+ * *Warning:* The created observable uses
+ * {@link AbsListView#setOnScrollListener(AbsListView.OnScrollListener)}  to observe scroll
+ * changes. Only one observable can be used for a view at a time.
+ *
+ */
+public inline fun AbsListView.scrollEvents(): Observable<AbsListViewScrollEvent> = RxAbsListView.scrollEvents(this)

--- a/rxbinding/src/androidTest/AndroidManifest.xml
+++ b/rxbinding/src/androidTest/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <activity android:name=".view.RxViewAttachTestActivity"/>
     <activity android:name=".view.RxViewSystemUiVisibilityTestActivity"/>
     <activity android:name=".widget.RxAdapterViewTestActivity"/>
+    <activity android:name=".widget.RxAbsListViewTestActivity"/>
     <activity android:name=".widget.RxAutoCompleteTextViewTestActivity"/>
     <activity android:name=".widget.RxRatingBarTestActivity"/>
     <activity android:name=".widget.RxSeekBarTestActivity"/>

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/widget/RxAbsListViewTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/widget/RxAbsListViewTest.java
@@ -1,0 +1,61 @@
+package com.jakewharton.rxbinding.widget;
+
+import android.app.Instrumentation;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.widget.ListView;
+import com.jakewharton.rxbinding.RecordingObserver;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import rx.Subscription;
+import rx.android.schedulers.AndroidSchedulers;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(AndroidJUnit4.class) public final class RxAbsListViewTest {
+
+  @Rule public final ActivityTestRule<RxAbsListViewTestActivity> activityRule =
+      new ActivityTestRule<>(RxAbsListViewTestActivity.class);
+
+  private Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
+
+  private RxAbsListViewTestActivity activity;
+  private ListView listView;
+
+  @Before public void setUp() {
+    activity = activityRule.getActivity();
+    listView = activity.listView;
+  }
+
+  @Test public void scrollEvents() {
+    RecordingObserver<AbsListViewScrollEvent> o = new RecordingObserver<>();
+    Subscription subscription = RxAbsListView.scrollEvents(listView) //
+        .subscribeOn(AndroidSchedulers.mainThread()) //
+        .subscribe(o);
+    AbsListViewScrollEvent event = o.takeNext();
+    assertThat(event.totalItemCount()).isEqualTo(100);
+    assertThat(event.firstVisibleItem()).isEqualTo(0);
+    assertThat(event.scrollState()).isEqualTo(0);
+
+    instrumentation.runOnMainSync(new Runnable() {
+      @Override public void run() {
+        listView.smoothScrollToPosition(50);
+      }
+    });
+    AbsListViewScrollEvent event1 = o.takeNext();
+    assertThat(event1.view()).isEqualTo(listView);
+    assertThat(event1.totalItemCount()).isEqualTo(100);
+
+    subscription.unsubscribe();
+
+    instrumentation.runOnMainSync(new Runnable() {
+      @Override public void run() {
+        listView.smoothScrollToPosition(100);
+      }
+    });
+    o.assertNoMoreEvents();
+  }
+}

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/widget/RxAbsListViewTestActivity.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/widget/RxAbsListViewTestActivity.java
@@ -1,0 +1,38 @@
+package com.jakewharton.rxbinding.widget;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.widget.ArrayAdapter;
+import android.widget.FrameLayout;
+import android.widget.ListView;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class RxAbsListViewTestActivity extends Activity {
+  ListView listView;
+
+  List<String> values;
+  ArrayAdapter<String> adapter;
+
+  @Override protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    values = createValues(100);
+    adapter = new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, values);
+
+    listView = new ListView(this);
+    listView.setAdapter(adapter);
+
+    FrameLayout layout = new FrameLayout(this);
+    layout.addView(listView);
+    setContentView(layout);
+  }
+
+  private static List<String> createValues(int count) {
+    final List<String> values = new ArrayList<String>(count);
+    for (int i = 0; i < count; i++) {
+      values.add(String.valueOf(i));
+    }
+    return values;
+  }
+}

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AbsListViewScrollEvent.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AbsListViewScrollEvent.java
@@ -1,0 +1,79 @@
+package com.jakewharton.rxbinding.widget;
+
+import android.support.annotation.CheckResult;
+import android.support.annotation.NonNull;
+import android.widget.AbsListView;
+import com.jakewharton.rxbinding.view.ViewEvent;
+
+public final class AbsListViewScrollEvent extends ViewEvent<AbsListView> {
+
+  @CheckResult @NonNull
+  public static AbsListViewScrollEvent create(AbsListView listView, int scrollState,
+      int firstVisibleItem, int visibleItemCount, int totalItemCount) {
+    return new AbsListViewScrollEvent(listView, scrollState, firstVisibleItem, visibleItemCount,
+        totalItemCount);
+  }
+
+  private final int scrollState;
+  private final int firstVisibleItem;
+  private final int visibleItemCount;
+  private final int totalItemCount;
+
+  private AbsListViewScrollEvent(@NonNull AbsListView view, int scrollState, int firstVisibleItem,
+      int visibleItemCount, int totalItemCount) {
+    super(view);
+    this.scrollState = scrollState;
+    this.firstVisibleItem = firstVisibleItem;
+    this.visibleItemCount = visibleItemCount;
+    this.totalItemCount = totalItemCount;
+  }
+
+  public int scrollState() {
+    return scrollState;
+  }
+
+  public int firstVisibleItem() {
+    return firstVisibleItem;
+  }
+
+  public int visibleItemCount() {
+    return visibleItemCount;
+  }
+
+  public int totalItemCount() {
+    return totalItemCount;
+  }
+
+  @Override public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    AbsListViewScrollEvent that = (AbsListViewScrollEvent) o;
+
+    if (scrollState != that.scrollState) return false;
+    if (firstVisibleItem != that.firstVisibleItem) return false;
+    if (visibleItemCount != that.visibleItemCount) return false;
+    return totalItemCount == that.totalItemCount;
+  }
+
+  @Override public int hashCode() {
+    int result = scrollState;
+    result = 31 * result + firstVisibleItem;
+    result = 31 * result + visibleItemCount;
+    result = 31 * result + totalItemCount;
+    return result;
+  }
+
+  @Override public String toString() {
+    return "AbsListViewScrollEvent{"
+        + "scrollState="
+        + scrollState
+        + ", firstVisibleItem="
+        + firstVisibleItem
+        + ", visibleItemCount="
+        + visibleItemCount
+        + ", totalItemCount="
+        + totalItemCount
+        + '}';
+  }
+}

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AbsListViewScrollEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AbsListViewScrollEventOnSubscribe.java
@@ -1,0 +1,54 @@
+package com.jakewharton.rxbinding.widget;
+
+import android.widget.AbsListView;
+import rx.Observable;
+import rx.Subscriber;
+import rx.android.MainThreadSubscription;
+
+import static com.jakewharton.rxbinding.internal.Preconditions.checkUiThread;
+
+final class AbsListViewScrollEventOnSubscribe
+    implements Observable.OnSubscribe<AbsListViewScrollEvent> {
+
+  final AbsListView view;
+
+  public AbsListViewScrollEventOnSubscribe(AbsListView view) {
+    this.view = view;
+  }
+
+  @Override public void call(final Subscriber<? super AbsListViewScrollEvent> subscriber) {
+    checkUiThread();
+
+    final AbsListView.OnScrollListener listener = new AbsListView.OnScrollListener() {
+      int currentScrollState = SCROLL_STATE_IDLE;
+
+      @Override public void onScrollStateChanged(AbsListView view, int scrollState) {
+        this.currentScrollState = scrollState;
+        if (!subscriber.isUnsubscribed()) {
+          AbsListViewScrollEvent event =
+              AbsListViewScrollEvent.create(view, scrollState, view.getFirstVisiblePosition(),
+                  view.getChildCount(), view.getCount());
+          subscriber.onNext(event);
+        }
+      }
+
+      @Override public void onScroll(AbsListView view, int firstVisibleItem, int visibleItemCount,
+          int totalItemCount) {
+        if (!subscriber.isUnsubscribed()) {
+          AbsListViewScrollEvent event =
+              AbsListViewScrollEvent.create(view, this.currentScrollState, firstVisibleItem,
+                  visibleItemCount, totalItemCount);
+          subscriber.onNext(event);
+        }
+      }
+    };
+
+    view.setOnScrollListener(listener);
+
+    subscriber.add(new MainThreadSubscription() {
+      @Override protected void onUnsubscribe() {
+        view.setOnScrollListener(null);
+      }
+    });
+  }
+}

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RxAbsListView.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RxAbsListView.java
@@ -1,0 +1,32 @@
+package com.jakewharton.rxbinding.widget;
+
+import android.support.annotation.CheckResult;
+import android.support.annotation.NonNull;
+import android.widget.AbsListView;
+import rx.Observable;
+
+import static com.jakewharton.rxbinding.internal.Preconditions.checkNotNull;
+
+public final class RxAbsListView {
+  /**
+   * Create an observable of scroll events on {@code listView}.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code listView}.
+   * Unsubscribe to free this reference.
+   * * <p>
+   * <em>Warning:</em> The created observable uses
+   * {@link AbsListView#setOnScrollListener(AbsListView.OnScrollListener)}  to observe scroll
+   * changes. Only one observable can be used for a view at a time.
+   * <p>
+   */
+  @CheckResult @NonNull public static Observable<AbsListViewScrollEvent> scrollEvents(
+      @NonNull AbsListView listView) {
+    checkNotNull(listView, "listView == null");
+
+    return Observable.create(new AbsListViewScrollEventOnSubscribe(listView));
+  }
+
+  private RxAbsListView() {
+    throw new AssertionError("No instances.");
+  }
+}


### PR DESCRIPTION
Add custom `ListViewScrollEvent` and `ListViewScrollEventOnSubscribe` along with `RxListView` to add support for `ListView` scroll events in RxBindings. This addresses #80 

The tests might need some love. There are some limitations of `AbsListView` that make testing difficult. For example, `AbsListView.OnScrollListener` always returns `0` for `firstVisibleItem`. 

Additional note: in `AbsListView.setOnScrollListener` the `AbsListView` calls `mOnScrollListener.onScroll()` in addition to just setting the listener. This becomes the initial value emitted `OnSubscribe`