### PR TITLE
Added property disabled on view to negate the enabled property

### DIFF
--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/view/RxView.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding/view/RxView.kt
@@ -284,6 +284,14 @@ public inline fun View.clickable(): Action1<in Boolean> = RxView.clickable(this)
 public inline fun View.enabled(): Action1<in Boolean> = RxView.enabled(this)
 
 /**
+ * An action which sets to negate the enabled property of `view`.
+ *
+ * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
+ * to free this reference.
+ */
+public inline fun View.disabled(): Action1<in Boolean> = RxView.disabled(this)
+
+/**
  * An action which sets the pressed property of `view`.
  *
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/view/RxViewTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/view/RxViewTest.java
@@ -296,6 +296,15 @@ public final class RxViewTest {
     assertThat(view.isEnabled()).isTrue();
   }
 
+  @Test @UiThreadTest public void disabled() {
+    view.setEnabled(true);
+    Action1<? super Boolean> action = RxView.disabled(view);
+    action.call(false);
+    assertThat(view.isEnabled()).isTrue();
+    action.call(true);
+    assertThat(view.isEnabled()).isFalse();
+  }
+
   @Test @UiThreadTest public void pressed() {
     view.setPressed(true);
     Action1<? super Boolean> action = RxView.pressed(view);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/RxView.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/RxView.java
@@ -412,6 +412,22 @@ public final class RxView {
   }
 
   /**
+   * An action which sets to negate the enabled property of {@code view}.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+   * to free this reference.
+   */
+  @CheckResult @NonNull
+  public static Action1<? super Boolean> disabled(@NonNull final View view) {
+    checkNotNull(view, "view == null");
+    return new Action1<Boolean>() {
+      @Override public void call(Boolean value) {
+        view.setEnabled(!value);
+      }
+    };
+  }
+
+  /**
    * An action which sets the pressed property of {@code view}.
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe


### PR DESCRIPTION
Added property disabled on view to negate the enabled property. Can be useful in some cases, instead of mapping enabled -> !enabled, just use disabled property.