### PR TITLE
KeyEvent is nullable in TextViewEditorActionEvent

### DIFF
--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewEditorActionEvent.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewEditorActionEvent.java
@@ -2,6 +2,7 @@ package com.jakewharton.rxbinding.widget;
 
 import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.view.KeyEvent;
 import android.widget.TextView;
 import com.jakewharton.rxbinding.view.ViewEvent;
@@ -9,15 +10,15 @@ import com.jakewharton.rxbinding.view.ViewEvent;
 public final class TextViewEditorActionEvent extends ViewEvent<TextView> {
   @CheckResult @NonNull
   public static TextViewEditorActionEvent create(@NonNull TextView view, int actionId,
-      @NonNull KeyEvent keyEvent) {
+      @Nullable KeyEvent keyEvent) {
     return new TextViewEditorActionEvent(view, actionId, keyEvent);
   }
 
   private final int actionId;
-  private final KeyEvent keyEvent;
+  @Nullable private final KeyEvent keyEvent;
 
   private TextViewEditorActionEvent(@NonNull TextView view, int actionId,
-      @NonNull KeyEvent keyEvent) {
+      @Nullable KeyEvent keyEvent) {
     super(view);
     this.actionId = actionId;
     this.keyEvent = keyEvent;
@@ -27,23 +28,29 @@ public final class TextViewEditorActionEvent extends ViewEvent<TextView> {
     return actionId;
   }
 
-  @NonNull
-  public KeyEvent keyEvent() {
+  /**
+   * If triggered by an enter key, this is the event, otherwise {@code null}.
+   *
+   * @see TextView.OnEditorActionListener#onEditorAction(android.widget.TextView, int,
+   * android.view.KeyEvent)
+   */
+  @Nullable public KeyEvent keyEvent() {
     return keyEvent;
   }
 
   @Override public boolean equals(Object o) {
-    if (o == this) return true;
+    if (this == o) return true;
     if (!(o instanceof TextViewEditorActionEvent)) return false;
     TextViewEditorActionEvent other = (TextViewEditorActionEvent) o;
-    return other.view() == view() && other.actionId == actionId && other.keyEvent.equals(keyEvent);
+    if (actionId != other.actionId) return false;
+    if (keyEvent != null ? !keyEvent.equals(other.keyEvent) : other.keyEvent != null) return false;
+    return view() == other.view();
   }
 
   @Override public int hashCode() {
-    int result = 17;
-    result = result * 37 + view().hashCode();
-    result = result * 37 + actionId;
-    result = result * 37 + keyEvent.hashCode();
+    int result = actionId;
+    result = 31 * result + (keyEvent != null ? keyEvent.hashCode() : 0);
+    result = 31 * result + view().hashCode();
     return result;
   }
 


### PR DESCRIPTION
We've faced NPE in production because `keyEvent()` marked as `@NonNull` and Kotlin inferred non-null type from it.

According to [javadoc of `TextView.OnEditorActionListener`](https://developer.android.com/reference/android/widget/TextView.OnEditorActionListener.html#onEditorAction(android.widget.TextView,%20int,%20android.view.KeyEvent)), `keyEvent` can be `null`:

```java
/**
 * Interface definition for a callback to be invoked when an action is
 * performed on the editor.
 */
public interface OnEditorActionListener {
    /**
     * Called when an action is being performed.
     *
     * @param v The view that was clicked.
     * @param actionId Identifier of the action.  This will be either the
     * identifier you supplied, or {@link EditorInfo#IME_NULL
     * EditorInfo.IME_NULL} if being called due to the enter key
     * being pressed.
     * @param event If triggered by an enter key, this is the event;
     * otherwise, this is null.
     * @return Return true if you have consumed the action, else false.
     */
    boolean onEditorAction(TextView v, int actionId, KeyEvent event);
}
```

There is even [test in RxBinding](https://github.com/JakeWharton/RxBinding/blob/cf23c63f660b5cc797ad58ba54d76d5ba17f93da/rxbinding/src/androidTest/java/com/jakewharton/rxbinding/widget/RxTextViewTest.java#L55) that checks that `keyEvent()` is `null`.

Code was formatted with SquareAndroid codestyle, `equals()` and `hashCode()` were deleted and generated in AS.