### PR TITLE
Fixed RxSwipeRefreshLayoutTest test

### DIFF
--- a/rxbinding-support-v4/src/androidTest/java/com/jakewharton/rxbinding/support/v4/widget/RxSwipeRefreshLayoutTest.java
+++ b/rxbinding-support-v4/src/androidTest/java/com/jakewharton/rxbinding/support/v4/widget/RxSwipeRefreshLayoutTest.java
@@ -11,13 +11,13 @@ import android.support.test.runner.AndroidJUnit4;
 import android.support.v4.widget.SwipeRefreshLayout;
 import com.jakewharton.rxbinding.RecordingObserver;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import rx.Subscription;
 import rx.android.schedulers.AndroidSchedulers;
 import rx.functions.Action1;
+import com.jakewharton.rxbinding.support.v4.test.R;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
@@ -35,19 +35,18 @@ public final class RxSwipeRefreshLayoutTest {
     view = activity.swipeRefreshLayout;
   }
 
-  @Ignore("https://github.com/JakeWharton/RxBinding/issues/72")
-  @Test public void refreshes() {
+  @Test public void refreshes() throws InterruptedException {
     RecordingObserver<Void> o = new RecordingObserver<>();
     Subscription subscription = RxSwipeRefreshLayout.refreshes(view)
         .subscribeOn(AndroidSchedulers.mainThread())
         .subscribe(o);
     o.assertNoMoreEvents();
 
-    onView(withId(1)).perform(swipeDown());
+    onView(withId(R.id.swipe_refresh_layout)).perform(swipeDown());
     o.takeNext();
 
     subscription.unsubscribe();
-    onView(withId(1)).perform(swipeDown());
+    onView(withId(R.id.swipe_refresh_layout)).perform(swipeDown());
     o.assertNoMoreEvents();
   }
 

--- a/rxbinding-support-v4/src/androidTest/java/com/jakewharton/rxbinding/support/v4/widget/RxSwipeRefreshLayoutTestActivity.java
+++ b/rxbinding-support-v4/src/androidTest/java/com/jakewharton/rxbinding/support/v4/widget/RxSwipeRefreshLayoutTestActivity.java
@@ -4,10 +4,14 @@ import android.app.Activity;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.support.v4.view.MotionEventCompat;
 import android.support.v4.widget.SwipeRefreshLayout;
+import android.view.MotionEvent;
+import android.view.View;
 import android.view.ViewGroup.LayoutParams;
 import android.widget.FrameLayout;
 import android.widget.ScrollView;
+import com.jakewharton.rxbinding.support.v4.test.R;
 
 import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
 
@@ -18,7 +22,6 @@ public final class RxSwipeRefreshLayoutTestActivity extends Activity {
   private final Runnable stopRefreshing = new Runnable() {
     @Override public void run() {
       swipeRefreshLayout.setRefreshing(false);
-      handler.postDelayed(this, 500);
     }
   };
 
@@ -26,7 +29,16 @@ public final class RxSwipeRefreshLayoutTestActivity extends Activity {
     super.onCreate(savedInstanceState);
 
     swipeRefreshLayout = new SwipeRefreshLayout(this);
-    swipeRefreshLayout.setId(1);
+    swipeRefreshLayout.setId(R.id.swipe_refresh_layout);
+    swipeRefreshLayout.setOnTouchListener(new View.OnTouchListener() {
+      @Override public boolean onTouch(View v, MotionEvent event) {
+        if (MotionEventCompat.getActionMasked(event) == MotionEvent.ACTION_UP) {
+          handler.removeCallbacks(stopRefreshing);
+          handler.postDelayed(stopRefreshing, 300);
+        }
+        return false;
+      }
+    });
 
     ScrollView scrollView = new ScrollView(this);
     LayoutParams scrollParams = new LayoutParams(MATCH_PARENT, MATCH_PARENT);
@@ -37,8 +49,6 @@ public final class RxSwipeRefreshLayoutTestActivity extends Activity {
     scrollView.addView(emptyView, emptyParams);
 
     setContentView(swipeRefreshLayout);
-
-    handler.postDelayed(stopRefreshing, 500);
   }
 
   @Override protected void onPause() {

--- a/rxbinding-support-v4/src/androidTest/res/values/ids.xml
+++ b/rxbinding-support-v4/src/androidTest/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <item type="id" name="swipe_refresh_layout"/>
+</resources>

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/SwipeRefreshLayoutRefreshOnSubscribe.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/SwipeRefreshLayoutRefreshOnSubscribe.java
@@ -19,7 +19,9 @@ final class SwipeRefreshLayoutRefreshOnSubscribe implements Observable.OnSubscri
 
     SwipeRefreshLayout.OnRefreshListener listener = new SwipeRefreshLayout.OnRefreshListener() {
       @Override public void onRefresh() {
-        subscriber.onNext(null);
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(null);
+        }
       }
     };
     view.setOnRefreshListener(listener);


### PR DESCRIPTION
After examining `RxSwipeRefreshLayoutTest`, it seems that the automatically ran `.setRefresh(false)` (which performs stopping the refresh animation) could happen to be called between the swipe release and the actual loading/refreshing animation, causing the animation to stop and listener never to be called, thus not recorded.

So the solution I did was to post refresh stop 2 seconds after the first touch on a view happens (which is enough time for the swipe - 1500ms and the recorder to catch up the listener). This should avoid flakyness in this test.

Fixes #72.