### PR TITLE
Fix typo in TabLayoutSelectionEvent.toString()

### DIFF
--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/TabLayoutSelectionEvent.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/TabLayoutSelectionEvent.java
@@ -56,6 +56,6 @@ public final class TabLayoutSelectionEvent extends ViewEvent<TabLayout> {
   }
 
   @Override public String toString() {
-    return "ViewTouchEvent{view=" + view() + ", kind=" + kind + ", tab=" + tab + '}';
+    return "TabLayoutSelectionEvent{view=" + view() + ", kind=" + kind + ", tab=" + tab + '}';
   }
 }


### PR DESCRIPTION
Minor typo fix in TabLayoutSelectionEvent#toString()