### PR TITLE
add new SlidingPaneLayout bindings

### DIFF
--- a/rxbinding-support-v4-kotlin/src/main/kotlin/com/jakewharton/rxbinding/support/v4/widget/RxSlidingPaneLayout.kt
+++ b/rxbinding-support-v4-kotlin/src/main/kotlin/com/jakewharton/rxbinding/support/v4/widget/RxSlidingPaneLayout.kt
@@ -1,0 +1,37 @@
+package com.jakewharton.rxbinding.support.v4.widget
+
+import android.support.v4.widget.SlidingPaneLayout
+import rx.Observable
+import rx.functions.Action1
+
+/**
+ * Create an observable of the open state of the pane of `view`
+ *
+ * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
+ * to free this reference.
+ *
+ * *Warning:* The created observable uses [SlidingPaneLayout.setPanelSlideListener]
+ * to observe dismiss change. Only one observable can be used for a view at a time.
+ *
+ * *Note:* A value will be emitted immediately on subscribe.
+ */
+public inline fun SlidingPaneLayout.paneOpen(): Observable<Boolean> = RxSlidingPaneLayout.paneOpen(this)
+
+/**
+ * Create an observable of the slide offset of the pane of `view`
+ *
+ * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
+ * to free this reference.
+ *
+ * *Warning:* The created observable uses [SlidingPaneLayout.setPanelSlideListener]
+ * to observe dismiss change. Only one observable can be used for a view at a time.
+ */
+public inline fun SlidingPaneLayout.slides(): Observable<Float> = RxSlidingPaneLayout.slides(this)
+
+/**
+ * An action which sets whether the pane of `view` is open.
+ *
+ * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
+ * to free this reference.
+ */
+public inline fun SlidingPaneLayout.open(): Action1<in Boolean> = RxSlidingPaneLayout.open(this)

--- a/rxbinding-support-v4-kotlin/src/main/kotlin/com/jakewharton/rxbinding/support/v4/widget/RxSlidingPaneLayout.kt
+++ b/rxbinding-support-v4-kotlin/src/main/kotlin/com/jakewharton/rxbinding/support/v4/widget/RxSlidingPaneLayout.kt
@@ -15,7 +15,7 @@ import rx.functions.Action1
  *
  * *Note:* A value will be emitted immediately on subscribe.
  */
-public inline fun SlidingPaneLayout.paneOpens(): Observable<Boolean> = RxSlidingPaneLayout.paneOpens(this)
+public inline fun SlidingPaneLayout.panelOpens(): Observable<Boolean> = RxSlidingPaneLayout.panelOpens(this)
 
 /**
  * Create an observable of the slide offset of the pane of `view`
@@ -26,7 +26,7 @@ public inline fun SlidingPaneLayout.paneOpens(): Observable<Boolean> = RxSliding
  * *Warning:* The created observable uses [SlidingPaneLayout.setPanelSlideListener]
  * to observe dismiss change. Only one observable can be used for a view at a time.
  */
-public inline fun SlidingPaneLayout.paneSlides(): Observable<Float> = RxSlidingPaneLayout.paneSlides(this)
+public inline fun SlidingPaneLayout.panelSlides(): Observable<Float> = RxSlidingPaneLayout.panelSlides(this)
 
 /**
  * An action which sets whether the pane of `view` is open.

--- a/rxbinding-support-v4-kotlin/src/main/kotlin/com/jakewharton/rxbinding/support/v4/widget/RxSlidingPaneLayout.kt
+++ b/rxbinding-support-v4-kotlin/src/main/kotlin/com/jakewharton/rxbinding/support/v4/widget/RxSlidingPaneLayout.kt
@@ -15,7 +15,7 @@ import rx.functions.Action1
  *
  * *Note:* A value will be emitted immediately on subscribe.
  */
-public inline fun SlidingPaneLayout.paneOpen(): Observable<Boolean> = RxSlidingPaneLayout.paneOpen(this)
+public inline fun SlidingPaneLayout.paneOpens(): Observable<Boolean> = RxSlidingPaneLayout.paneOpens(this)
 
 /**
  * Create an observable of the slide offset of the pane of `view`
@@ -26,7 +26,7 @@ public inline fun SlidingPaneLayout.paneOpen(): Observable<Boolean> = RxSlidingP
  * *Warning:* The created observable uses [SlidingPaneLayout.setPanelSlideListener]
  * to observe dismiss change. Only one observable can be used for a view at a time.
  */
-public inline fun SlidingPaneLayout.slides(): Observable<Float> = RxSlidingPaneLayout.slides(this)
+public inline fun SlidingPaneLayout.paneSlides(): Observable<Float> = RxSlidingPaneLayout.paneSlides(this)
 
 /**
  * An action which sets whether the pane of `view` is open.

--- a/rxbinding-support-v4/src/androidTest/AndroidManifest.xml
+++ b/rxbinding-support-v4/src/androidTest/AndroidManifest.xml
@@ -7,5 +7,6 @@
     <activity android:name=".widget.RxDrawerLayoutTestActivity"/>
     <activity android:name=".widget.RxNestedScrollViewTestActivity"/>
     <activity android:name=".widget.RxSwipeRefreshLayoutTestActivity"/>
+    <activity android:name=".widget.RxSlidingPaneLayoutTestActivity"/>
   </application>
 </manifest>

--- a/rxbinding-support-v4/src/androidTest/java/com/jakewharton/rxbinding/support/v4/widget/RxSlidingPaneLayoutTest.java
+++ b/rxbinding-support-v4/src/androidTest/java/com/jakewharton/rxbinding/support/v4/widget/RxSlidingPaneLayoutTest.java
@@ -51,7 +51,7 @@ import static com.google.common.truth.Truth.assertThat;
   @Test public void paneOpen() {
     RecordingObserver<Boolean> o = new RecordingObserver<>();
     Subscription subscription =
-        RxSlidingPaneLayout.paneOpens(view).subscribeOn(AndroidSchedulers.mainThread()).subscribe(o);
+        RxSlidingPaneLayout.panelOpens(view).subscribeOn(AndroidSchedulers.mainThread()).subscribe(o);
     assertThat(o.takeNext()).isFalse();
 
     instrumentation.runOnMainSync(new Runnable() {
@@ -81,7 +81,7 @@ import static com.google.common.truth.Truth.assertThat;
   @Test public void slides() {
     RecordingObserver<Float> o1 = new RecordingObserver<>();
     Subscription subscription1 =
-        RxSlidingPaneLayout.paneSlides(view).subscribeOn(AndroidSchedulers.mainThread()).subscribe(o1);
+        RxSlidingPaneLayout.panelSlides(view).subscribeOn(AndroidSchedulers.mainThread()).subscribe(o1);
     o1.assertNoMoreEvents();
 
     instrumentation.runOnMainSync(new Runnable() {
@@ -97,7 +97,7 @@ import static com.google.common.truth.Truth.assertThat;
 
     RecordingObserver<Float> o2 = new RecordingObserver<>();
     Subscription subscription2 =
-        RxSlidingPaneLayout.paneSlides(view).subscribeOn(AndroidSchedulers.mainThread()).subscribe(o2);
+        RxSlidingPaneLayout.panelSlides(view).subscribeOn(AndroidSchedulers.mainThread()).subscribe(o2);
     o2.assertNoMoreEvents();
 
     instrumentation.runOnMainSync(new Runnable() {

--- a/rxbinding-support-v4/src/androidTest/java/com/jakewharton/rxbinding/support/v4/widget/RxSlidingPaneLayoutTest.java
+++ b/rxbinding-support-v4/src/androidTest/java/com/jakewharton/rxbinding/support/v4/widget/RxSlidingPaneLayoutTest.java
@@ -1,0 +1,173 @@
+package com.jakewharton.rxbinding.support.v4.widget;
+
+import android.app.Instrumentation;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.espresso.Espresso;
+import android.support.test.espresso.contrib.CountingIdlingResource;
+import android.support.test.espresso.matcher.BoundedMatcher;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.support.v4.widget.SlidingPaneLayout;
+import android.view.View;
+import com.jakewharton.rxbinding.RecordingObserver;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import rx.Subscription;
+import rx.android.schedulers.AndroidSchedulers;
+import rx.functions.Action1;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(AndroidJUnit4.class) public class RxSlidingPaneLayoutTest {
+  @Rule public final ActivityTestRule<RxSlidingPaneLayoutTestActivity> activityRule =
+      new ActivityTestRule<>(RxSlidingPaneLayoutTestActivity.class);
+
+  private final Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
+
+  private SlidingPaneLayout view;
+
+  private CountingIdlingResource idler;
+
+  @Before public void setUp() {
+    RxSlidingPaneLayoutTestActivity activity = activityRule.getActivity();
+    view = activity.slidingPaneLayout;
+
+    idler = new CountingIdlingResource("counting idler");
+    Espresso.registerIdlingResources(idler);
+  }
+
+  @After public void teardown() {
+    Espresso.unregisterIdlingResources(idler);
+  }
+
+  @Test public void paneOpen() {
+    RecordingObserver<Boolean> o = new RecordingObserver<>();
+    Subscription subscription =
+        RxSlidingPaneLayout.paneOpen(view).subscribeOn(AndroidSchedulers.mainThread()).subscribe(o);
+    assertThat(o.takeNext()).isFalse();
+
+    instrumentation.runOnMainSync(new Runnable() {
+      @Override public void run() {
+        view.openPane();
+      }
+    });
+    assertThat(o.takeNext()).isTrue();
+
+    instrumentation.runOnMainSync(new Runnable() {
+      @Override public void run() {
+        view.closePane();
+      }
+    });
+    assertThat(o.takeNext()).isFalse();
+
+    subscription.unsubscribe();
+
+    instrumentation.runOnMainSync(new Runnable() {
+      @Override public void run() {
+        view.openPane();
+      }
+    });
+    o.assertNoMoreEvents();
+  }
+
+  @Test public void slides() {
+    RecordingObserver<Float> o1 = new RecordingObserver<>();
+    Subscription subscription1 =
+        RxSlidingPaneLayout.slides(view).subscribeOn(AndroidSchedulers.mainThread()).subscribe(o1);
+    o1.assertNoMoreEvents();
+
+    instrumentation.runOnMainSync(new Runnable() {
+      @Override public void run() {
+        view.openPane();
+      }
+    });
+    instrumentation.waitForIdleSync();
+    assertThat(o1.takeNext()).isGreaterThan(0f);
+
+    subscription1.unsubscribe();
+    o1.assertNoMoreEvents();
+
+    RecordingObserver<Float> o2 = new RecordingObserver<>();
+    Subscription subscription2 =
+        RxSlidingPaneLayout.slides(view).subscribeOn(AndroidSchedulers.mainThread()).subscribe(o2);
+    o2.assertNoMoreEvents();
+
+    instrumentation.runOnMainSync(new Runnable() {
+      @Override public void run() {
+        view.closePane();
+      }
+    });
+    instrumentation.waitForIdleSync();
+    assertThat(o2.takeNext()).isLessThan(1.0f);
+
+    subscription2.unsubscribe();
+    o2.assertNoMoreEvents();
+  }
+
+  @Test public void open() {
+    final Action1<? super Boolean> open = RxSlidingPaneLayout.open(view);
+
+    view.setPanelSlideListener(new SlidingPaneLayout.SimplePanelSlideListener() {
+      @Override public void onPanelOpened(View panel) {
+        idler.decrement();
+      }
+
+      @Override public void onPanelClosed(View panel) {
+        idler.decrement();
+      }
+    });
+
+    idler.increment();
+    instrumentation.runOnMainSync(new Runnable() {
+      @Override public void run() {
+        open.call(true);
+      }
+    });
+    instrumentation.waitForIdleSync();
+    onView(withId(view.getId())).check(matches(isOpen()));
+
+
+    idler.increment();
+    instrumentation.runOnMainSync(new Runnable() {
+      @Override public void run() {
+        open.call(false);
+      }
+    });
+    instrumentation.waitForIdleSync();
+    onView(withId(view.getId())).check(matches(isClosed()));
+
+    view.setPanelSlideListener(null);
+  }
+
+  private static Matcher<View> isOpen() {
+    return new BoundedMatcher<View, SlidingPaneLayout>(SlidingPaneLayout.class) {
+      @Override public void describeTo(Description description) {
+        description.appendText("is pane open");
+      }
+
+      @Override public boolean matchesSafely(SlidingPaneLayout slidingPaneLayout) {
+        return slidingPaneLayout.isOpen();
+      }
+    };
+  }
+
+  private static Matcher<View> isClosed() {
+    return new BoundedMatcher<View, SlidingPaneLayout>(SlidingPaneLayout.class) {
+      @Override public void describeTo(Description description) {
+        description.appendText("is pane closed");
+      }
+
+      @Override public boolean matchesSafely(SlidingPaneLayout slidingPaneLayout) {
+        return !slidingPaneLayout.isOpen();
+      }
+    };
+  }
+}

--- a/rxbinding-support-v4/src/androidTest/java/com/jakewharton/rxbinding/support/v4/widget/RxSlidingPaneLayoutTest.java
+++ b/rxbinding-support-v4/src/androidTest/java/com/jakewharton/rxbinding/support/v4/widget/RxSlidingPaneLayoutTest.java
@@ -51,7 +51,7 @@ import static com.google.common.truth.Truth.assertThat;
   @Test public void paneOpen() {
     RecordingObserver<Boolean> o = new RecordingObserver<>();
     Subscription subscription =
-        RxSlidingPaneLayout.paneOpen(view).subscribeOn(AndroidSchedulers.mainThread()).subscribe(o);
+        RxSlidingPaneLayout.paneOpens(view).subscribeOn(AndroidSchedulers.mainThread()).subscribe(o);
     assertThat(o.takeNext()).isFalse();
 
     instrumentation.runOnMainSync(new Runnable() {
@@ -81,7 +81,7 @@ import static com.google.common.truth.Truth.assertThat;
   @Test public void slides() {
     RecordingObserver<Float> o1 = new RecordingObserver<>();
     Subscription subscription1 =
-        RxSlidingPaneLayout.slides(view).subscribeOn(AndroidSchedulers.mainThread()).subscribe(o1);
+        RxSlidingPaneLayout.paneSlides(view).subscribeOn(AndroidSchedulers.mainThread()).subscribe(o1);
     o1.assertNoMoreEvents();
 
     instrumentation.runOnMainSync(new Runnable() {
@@ -97,7 +97,7 @@ import static com.google.common.truth.Truth.assertThat;
 
     RecordingObserver<Float> o2 = new RecordingObserver<>();
     Subscription subscription2 =
-        RxSlidingPaneLayout.slides(view).subscribeOn(AndroidSchedulers.mainThread()).subscribe(o2);
+        RxSlidingPaneLayout.paneSlides(view).subscribeOn(AndroidSchedulers.mainThread()).subscribe(o2);
     o2.assertNoMoreEvents();
 
     instrumentation.runOnMainSync(new Runnable() {

--- a/rxbinding-support-v4/src/androidTest/java/com/jakewharton/rxbinding/support/v4/widget/RxSlidingPaneLayoutTestActivity.java
+++ b/rxbinding-support-v4/src/androidTest/java/com/jakewharton/rxbinding/support/v4/widget/RxSlidingPaneLayoutTestActivity.java
@@ -1,0 +1,34 @@
+package com.jakewharton.rxbinding.support.v4.widget;
+
+import android.app.Activity;
+import android.graphics.Color;
+import android.os.Bundle;
+import android.support.v4.widget.SlidingPaneLayout;
+import android.support.v4.widget.SlidingPaneLayout.LayoutParams;
+import android.widget.FrameLayout;
+
+import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
+
+public final class RxSlidingPaneLayoutTestActivity extends Activity {
+  SlidingPaneLayout slidingPaneLayout;
+
+  @Override protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    slidingPaneLayout = new SlidingPaneLayout(this);
+    slidingPaneLayout.setId(android.R.id.primary);
+
+    FrameLayout paneOne = new FrameLayout(this);
+    LayoutParams paneOneParams = new LayoutParams(300, MATCH_PARENT);
+    slidingPaneLayout.addView(paneOne, paneOneParams);
+
+    FrameLayout paneTwo = new FrameLayout(this);
+    paneTwo.setBackgroundColor(Color.WHITE);
+    LayoutParams paneTwoParams = new LayoutParams(MATCH_PARENT, MATCH_PARENT);
+    paneTwoParams.leftMargin = 50;
+    slidingPaneLayout.addView(paneTwo, paneTwoParams);
+
+
+    setContentView(slidingPaneLayout);
+  }
+}

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/RxSlidingPaneLayout.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/RxSlidingPaneLayout.java
@@ -24,7 +24,7 @@ public final class RxSlidingPaneLayout {
    * <p>
    * <em>Note:</em> A value will be emitted immediately on subscribe.
    */
-  @CheckResult @NonNull public static Observable<Boolean> paneOpens(
+  @CheckResult @NonNull public static Observable<Boolean> panelOpens(
       @NonNull SlidingPaneLayout view) {
     checkNotNull(view, "view == null");
     return Observable.create(new SlidingPaneLayoutPaneOpenedOnSubscribe(view));
@@ -39,7 +39,7 @@ public final class RxSlidingPaneLayout {
    * <em>Warning:</em> The created observable uses {@link SlidingPaneLayout#setPanelSlideListener}
    * to observe dismiss change. Only one observable can be used for a view at a time.
    */
-  @CheckResult @NonNull public static Observable<Float> paneSlides(@NonNull SlidingPaneLayout view) {
+  @CheckResult @NonNull public static Observable<Float> panelSlides(@NonNull SlidingPaneLayout view) {
     checkNotNull(view, "view == null");
     return Observable.create(new SlidingPaneLayoutSlideOnSubscribe(view));
   }

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/RxSlidingPaneLayout.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/RxSlidingPaneLayout.java
@@ -24,7 +24,7 @@ public final class RxSlidingPaneLayout {
    * <p>
    * <em>Note:</em> A value will be emitted immediately on subscribe.
    */
-  @CheckResult @NonNull public static Observable<Boolean> paneOpen(
+  @CheckResult @NonNull public static Observable<Boolean> paneOpens(
       @NonNull SlidingPaneLayout view) {
     checkNotNull(view, "view == null");
     return Observable.create(new SlidingPaneLayoutPaneOpenedOnSubscribe(view));
@@ -39,7 +39,7 @@ public final class RxSlidingPaneLayout {
    * <em>Warning:</em> The created observable uses {@link SlidingPaneLayout#setPanelSlideListener}
    * to observe dismiss change. Only one observable can be used for a view at a time.
    */
-  @CheckResult @NonNull public static Observable<Float> slides(@NonNull SlidingPaneLayout view) {
+  @CheckResult @NonNull public static Observable<Float> paneSlides(@NonNull SlidingPaneLayout view) {
     checkNotNull(view, "view == null");
     return Observable.create(new SlidingPaneLayoutSlideOnSubscribe(view));
   }
@@ -54,8 +54,8 @@ public final class RxSlidingPaneLayout {
       @NonNull final SlidingPaneLayout view) {
     checkNotNull(view, "view == null");
     return new Action1<Boolean>() {
-      @Override public void call(Boolean aBoolean) {
-        if (aBoolean) {
+      @Override public void call(Boolean value) {
+        if (value) {
           view.openPane();
         } else {
           view.closePane();

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/RxSlidingPaneLayout.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/RxSlidingPaneLayout.java
@@ -1,0 +1,67 @@
+package com.jakewharton.rxbinding.support.v4.widget;
+
+import android.support.annotation.CheckResult;
+import android.support.annotation.NonNull;
+import android.support.v4.widget.SlidingPaneLayout;
+import rx.Observable;
+import rx.functions.Action1;
+
+import static com.jakewharton.rxbinding.internal.Preconditions.checkNotNull;
+
+/**
+ * Static factory methods for creating {@linkplain Observable observables} for {@link SlidingPaneLayout}
+ */
+public final class RxSlidingPaneLayout {
+  /**
+   * Create an observable of the open state of the pane of {@code view}
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+   * to free this reference.
+   * <p>
+   * <em>Warning:</em> The created observable uses {@link SlidingPaneLayout#setPanelSlideListener}
+   * to observe dismiss change. Only one observable can be used for a view at a time.
+   * <p>
+   * <em>Note:</em> A value will be emitted immediately on subscribe.
+   */
+  @CheckResult @NonNull public static Observable<Boolean> paneOpen(@NonNull SlidingPaneLayout view) {
+    checkNotNull(view, "view == null");
+    return Observable.create(new SlidingPaneLayoutPaneOpenedOnSubscribe(view));
+  }
+
+  /**
+   * Create an observable of the slide offset of the pane of {@code view}
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+   * to free this reference.
+   * <p>
+   * <em>Warning:</em> The created observable uses {@link SlidingPaneLayout#setPanelSlideListener}
+   * to observe dismiss change. Only one observable can be used for a view at a time.
+   */
+  @CheckResult @NonNull public static Observable<Float> slides(@NonNull SlidingPaneLayout view) {
+    checkNotNull(view, "view == null");
+    return Observable.create(new SlidingPaneLayoutSlideOnSubscribe(view));
+  }
+
+  /**
+   * An action which sets whether the pane of {@code view} is open.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+   * to free this reference.
+   */
+  @CheckResult @NonNull public static Action1<? super Boolean> open(@NonNull final SlidingPaneLayout view) {
+    checkNotNull(view, "view == null");
+    return new Action1<Boolean>() {
+      @Override public void call(Boolean aBoolean) {
+        if (aBoolean) {
+          view.openPane();
+        } else {
+          view.closePane();
+        }
+      }
+    };
+  }
+
+  private RxSlidingPaneLayout() {
+    throw new AssertionError("No instances.");
+  }
+}

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/RxSlidingPaneLayout.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/RxSlidingPaneLayout.java
@@ -39,7 +39,8 @@ public final class RxSlidingPaneLayout {
    * <em>Warning:</em> The created observable uses {@link SlidingPaneLayout#setPanelSlideListener}
    * to observe dismiss change. Only one observable can be used for a view at a time.
    */
-  @CheckResult @NonNull public static Observable<Float> panelSlides(@NonNull SlidingPaneLayout view) {
+  @CheckResult @NonNull public static Observable<Float> panelSlides(
+      @NonNull SlidingPaneLayout view) {
     checkNotNull(view, "view == null");
     return Observable.create(new SlidingPaneLayoutSlideOnSubscribe(view));
   }

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/RxSlidingPaneLayout.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/RxSlidingPaneLayout.java
@@ -9,7 +9,8 @@ import rx.functions.Action1;
 import static com.jakewharton.rxbinding.internal.Preconditions.checkNotNull;
 
 /**
- * Static factory methods for creating {@linkplain Observable observables} for {@link SlidingPaneLayout}
+ * Static factory methods for creating {@linkplain Observable observables}
+ * for {@link SlidingPaneLayout}
  */
 public final class RxSlidingPaneLayout {
   /**
@@ -23,7 +24,8 @@ public final class RxSlidingPaneLayout {
    * <p>
    * <em>Note:</em> A value will be emitted immediately on subscribe.
    */
-  @CheckResult @NonNull public static Observable<Boolean> paneOpen(@NonNull SlidingPaneLayout view) {
+  @CheckResult @NonNull public static Observable<Boolean> paneOpen(
+      @NonNull SlidingPaneLayout view) {
     checkNotNull(view, "view == null");
     return Observable.create(new SlidingPaneLayoutPaneOpenedOnSubscribe(view));
   }
@@ -48,7 +50,8 @@ public final class RxSlidingPaneLayout {
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
    * to free this reference.
    */
-  @CheckResult @NonNull public static Action1<? super Boolean> open(@NonNull final SlidingPaneLayout view) {
+  @CheckResult @NonNull public static Action1<? super Boolean> open(
+      @NonNull final SlidingPaneLayout view) {
     checkNotNull(view, "view == null");
     return new Action1<Boolean>() {
       @Override public void call(Boolean aBoolean) {

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/SlidingPaneLayoutPaneOpenedOnSubscribe.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/SlidingPaneLayoutPaneOpenedOnSubscribe.java
@@ -18,19 +18,20 @@ final class SlidingPaneLayoutPaneOpenedOnSubscribe implements Observable.OnSubsc
   @Override public void call(final Subscriber<? super Boolean> subscriber) {
     verifyMainThread();
 
-    final SlidingPaneLayout.PanelSlideListener listener = new SlidingPaneLayout.SimplePanelSlideListener() {
-      @Override public void onPanelOpened(View panel) {
-        if (!subscriber.isUnsubscribed()) {
-          subscriber.onNext(true);
-        }
-      }
+    final SlidingPaneLayout.PanelSlideListener listener =
+        new SlidingPaneLayout.SimplePanelSlideListener() {
+          @Override public void onPanelOpened(View panel) {
+            if (!subscriber.isUnsubscribed()) {
+              subscriber.onNext(true);
+            }
+          }
 
-      @Override public void onPanelClosed(View panel) {
-        if (!subscriber.isUnsubscribed()) {
-          subscriber.onNext(false);
-        }
-      }
-    };
+          @Override public void onPanelClosed(View panel) {
+            if (!subscriber.isUnsubscribed()) {
+              subscriber.onNext(false);
+            }
+          }
+        };
 
     view.setPanelSlideListener(listener);
 

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/SlidingPaneLayoutPaneOpenedOnSubscribe.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/SlidingPaneLayoutPaneOpenedOnSubscribe.java
@@ -1,0 +1,45 @@
+package com.jakewharton.rxbinding.support.v4.widget;
+
+import android.support.v4.widget.SlidingPaneLayout;
+import android.view.View;
+import rx.Observable;
+import rx.Subscriber;
+import rx.android.MainThreadSubscription;
+
+import static rx.android.MainThreadSubscription.verifyMainThread;
+
+final class SlidingPaneLayoutPaneOpenedOnSubscribe implements Observable.OnSubscribe<Boolean> {
+  final SlidingPaneLayout view;
+
+  SlidingPaneLayoutPaneOpenedOnSubscribe(SlidingPaneLayout view) {
+    this.view = view;
+  }
+
+  @Override public void call(final Subscriber<? super Boolean> subscriber) {
+    verifyMainThread();
+
+    final SlidingPaneLayout.PanelSlideListener listener = new SlidingPaneLayout.SimplePanelSlideListener() {
+      @Override public void onPanelOpened(View panel) {
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(true);
+        }
+      }
+
+      @Override public void onPanelClosed(View panel) {
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(false);
+        }
+      }
+    };
+
+    view.setPanelSlideListener(listener);
+
+    subscriber.add(new MainThreadSubscription() {
+      @Override protected void onUnsubscribe() {
+        view.setPanelSlideListener(null);
+      }
+    });
+
+    subscriber.onNext(view.isOpen());
+  }
+}

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/SlidingPaneLayoutSlideOnSubscribe.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/SlidingPaneLayoutSlideOnSubscribe.java
@@ -18,13 +18,14 @@ final class SlidingPaneLayoutSlideOnSubscribe implements Observable.OnSubscribe<
   @Override public void call(final Subscriber<? super Float> subscriber) {
     verifyMainThread();
 
-    final SlidingPaneLayout.PanelSlideListener listener = new SlidingPaneLayout.SimplePanelSlideListener() {
-      @Override public void onPanelSlide(View panel, float slideOffset) {
-        if (!subscriber.isUnsubscribed()) {
-          subscriber.onNext(slideOffset);
-        }
-      }
-    };
+    final SlidingPaneLayout.PanelSlideListener listener =
+        new SlidingPaneLayout.SimplePanelSlideListener() {
+          @Override public void onPanelSlide(View panel, float slideOffset) {
+            if (!subscriber.isUnsubscribed()) {
+              subscriber.onNext(slideOffset);
+            }
+          }
+        };
 
     view.setPanelSlideListener(listener);
 

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/SlidingPaneLayoutSlideOnSubscribe.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/SlidingPaneLayoutSlideOnSubscribe.java
@@ -1,0 +1,37 @@
+package com.jakewharton.rxbinding.support.v4.widget;
+
+import android.support.v4.widget.SlidingPaneLayout;
+import android.view.View;
+import rx.Observable;
+import rx.Subscriber;
+import rx.android.MainThreadSubscription;
+
+import static rx.android.MainThreadSubscription.verifyMainThread;
+
+final class SlidingPaneLayoutSlideOnSubscribe implements Observable.OnSubscribe<Float> {
+  final SlidingPaneLayout view;
+
+  SlidingPaneLayoutSlideOnSubscribe(SlidingPaneLayout view) {
+    this.view = view;
+  }
+
+  @Override public void call(final Subscriber<? super Float> subscriber) {
+    verifyMainThread();
+
+    final SlidingPaneLayout.PanelSlideListener listener = new SlidingPaneLayout.SimplePanelSlideListener() {
+      @Override public void onPanelSlide(View panel, float slideOffset) {
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(slideOffset);
+        }
+      }
+    };
+
+    view.setPanelSlideListener(listener);
+
+    subscriber.add(new MainThreadSubscription() {
+      @Override protected void onUnsubscribe() {
+        view.setPanelSlideListener(null);
+      }
+    });
+  }
+}


### PR DESCRIPTION
refs #270 

First pass of new bindings for SlidingPaneLayout:

- _RxSlidingPaneLayout.paneOpen(view)_: boolean emissions for open state
- _RxSlidingPaneLayout.slides(view)_: float emissions for slide offset
- _RxSlidingPaneLayout.open()_: boolean Action to open or close

Looking for comments especially on the tests since this is my first submission to the project.