### PR TITLE
Add listeners after setting the unsubscribe action.

### DIFF
--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/ActionMenuViewItemClickOnSubscribe.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/ActionMenuViewItemClickOnSubscribe.java
@@ -28,7 +28,6 @@ final class ActionMenuViewItemClickOnSubscribe implements Observable.OnSubscribe
           return true;
         }
       };
-    view.setOnMenuItemClickListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override
@@ -36,5 +35,7 @@ final class ActionMenuViewItemClickOnSubscribe implements Observable.OnSubscribe
         view.setOnMenuItemClickListener(null);
       }
     });
+
+    view.setOnMenuItemClickListener(listener);
   }
 }

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/PopupMenuDismissOnSubscribe.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/PopupMenuDismissOnSubscribe.java
@@ -26,12 +26,12 @@ final class PopupMenuDismissOnSubscribe implements Observable.OnSubscribe<Void> 
       }
     };
 
-    view.setOnDismissListener(listener);
-
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnDismissListener(null);
       }
     });
+
+    view.setOnDismissListener(listener);
   }
 }

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/PopupMenuItemClickOnSubscribe.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/PopupMenuItemClickOnSubscribe.java
@@ -28,12 +28,12 @@ final class PopupMenuItemClickOnSubscribe implements Observable.OnSubscribe<Menu
       }
     };
 
-    view.setOnMenuItemClickListener(listener);
-
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnMenuItemClickListener(null);
       }
     });
+
+    view.setOnMenuItemClickListener(listener);
   }
 }

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/SearchViewQueryTextChangeEventsOnSubscribe.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/SearchViewQueryTextChangeEventsOnSubscribe.java
@@ -36,13 +36,13 @@ final class SearchViewQueryTextChangeEventsOnSubscribe
       }
     };
 
-    view.setOnQueryTextListener(watcher);
-
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnQueryTextListener(null);
       }
     });
+
+    view.setOnQueryTextListener(watcher);
 
     // Emit initial value.
     subscriber.onNext(SearchViewQueryTextEvent.create(view, view.getQuery(), false));

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/SearchViewQueryTextChangesOnSubscribe.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/SearchViewQueryTextChangesOnSubscribe.java
@@ -31,13 +31,13 @@ final class SearchViewQueryTextChangesOnSubscribe implements Observable.OnSubscr
       }
     };
 
-    view.setOnQueryTextListener(watcher);
-
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnQueryTextListener(null);
       }
     });
+
+    view.setOnQueryTextListener(watcher);
 
     // Emit initial value.
     subscriber.onNext(view.getQuery());

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/ToolbarItemClickOnSubscribe.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/ToolbarItemClickOnSubscribe.java
@@ -26,12 +26,13 @@ final class ToolbarItemClickOnSubscribe implements Observable.OnSubscribe<MenuIt
         return true;
       }
     };
-    view.setOnMenuItemClickListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnMenuItemClickListener(null);
       }
     });
+
+    view.setOnMenuItemClickListener(listener);
   }
 }

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/ToolbarNavigationClickOnSubscribe.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/ToolbarNavigationClickOnSubscribe.java
@@ -25,12 +25,13 @@ final class ToolbarNavigationClickOnSubscribe implements Observable.OnSubscribe<
         }
       }
     };
-    view.setNavigationOnClickListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setNavigationOnClickListener(null);
       }
     });
+
+    view.setNavigationOnClickListener(listener);
   }
 }

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/AppBarLayoutOffsetChangeOnSubscribe.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/AppBarLayoutOffsetChangeOnSubscribe.java
@@ -25,12 +25,13 @@ final class AppBarLayoutOffsetChangeOnSubscribe implements Observable.OnSubscrib
             }
           }
         };
-    view.addOnOffsetChangedListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.removeOnOffsetChangedListener(listener);
       }
     });
+
+    view.addOnOffsetChangedListener(listener);
   }
 }

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/NavigationViewItemSelectionsOnSubscribe.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/NavigationViewItemSelectionsOnSubscribe.java
@@ -28,13 +28,14 @@ final class NavigationViewItemSelectionsOnSubscribe implements Observable.OnSubs
             return true;
           }
         };
-    view.setNavigationItemSelectedListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setNavigationItemSelectedListener(null);
       }
     });
+
+    view.setNavigationItemSelectedListener(listener);
 
     // Emit initial checked item, if one can be found.
     Menu menu = view.getMenu();

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/SnackbarDismissesOnSubscribe.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/SnackbarDismissesOnSubscribe.java
@@ -25,12 +25,12 @@ final class SnackbarDismissesOnSubscribe implements Observable.OnSubscribe<Integ
       }
     };
 
-    view.setCallback(callback);
-
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setCallback(null);
       }
     });
+
+    view.setCallback(callback);
   }
 }

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/SwipeDismissBehaviorOnSubscribe.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/SwipeDismissBehaviorOnSubscribe.java
@@ -38,12 +38,13 @@ final class SwipeDismissBehaviorOnSubscribe implements Observable.OnSubscribe<Vi
     if (behavior == null) {
       throw new IllegalStateException("There's no behavior set on this view.");
     }
-    behavior.setListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         behavior.setListener(null);
       }
     });
+
+    behavior.setListener(listener);
   }
 }

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/TabLayoutSelectionEventOnSubscribe.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/TabLayoutSelectionEventOnSubscribe.java
@@ -39,13 +39,14 @@ final class TabLayoutSelectionEventOnSubscribe
         }
       }
     };
-    view.setOnTabSelectedListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnTabSelectedListener(null);
       }
     });
+
+    view.setOnTabSelectedListener(listener);
 
     int index = view.getSelectedTabPosition();
     if (index != -1) {

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/TabLayoutSelectionsOnSubscribe.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/TabLayoutSelectionsOnSubscribe.java
@@ -31,13 +31,14 @@ final class TabLayoutSelectionsOnSubscribe implements Observable.OnSubscribe<Tab
       @Override public void onTabReselected(Tab tab) {
       }
     };
-    view.setOnTabSelectedListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnTabSelectedListener(null);
       }
     });
+
+    view.setOnTabSelectedListener(listener);
 
     int index = view.getSelectedTabPosition();
     if (index != -1) {

--- a/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding/support/v17/leanback/widget/SearchBarSearchQueryChangeEventsOnSubscribe.java
+++ b/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding/support/v17/leanback/widget/SearchBarSearchQueryChangeEventsOnSubscribe.java
@@ -40,13 +40,13 @@ final class SearchBarSearchQueryChangeEventsOnSubscribe
       }
     };
 
-    view.setSearchBarListener(listener);
-
     subscriber.add(new MainThreadSubscription() {
       @Override
       protected void onUnsubscribe() {
         view.setSearchBarListener(null);
       }
     });
+
+    view.setSearchBarListener(listener);
   }
 }

--- a/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding/support/v17/leanback/widget/SearchBarSearchQueryChangesOnSubscribe.java
+++ b/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding/support/v17/leanback/widget/SearchBarSearchQueryChangesOnSubscribe.java
@@ -32,12 +32,12 @@ final class SearchBarSearchQueryChangesOnSubscribe implements Observable.OnSubsc
       }
     };
 
-    view.setSearchBarListener(listener);
-
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setSearchBarListener(null);
       }
     });
+
+    view.setSearchBarListener(listener);
   }
 }

--- a/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding/support/v17/leanback/widget/SearchEditTextKeyboardDismissOnSubscribe.java
+++ b/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding/support/v17/leanback/widget/SearchEditTextKeyboardDismissOnSubscribe.java
@@ -27,8 +27,6 @@ final class SearchEditTextKeyboardDismissOnSubscribe implements Observable.OnSub
       }
     };
 
-    view.setOnKeyboardDismissListener(listener);
-
     subscriber.add(new MainThreadSubscription() {
       @Override
       protected void onUnsubscribe() {
@@ -40,5 +38,7 @@ final class SearchEditTextKeyboardDismissOnSubscribe implements Observable.OnSub
         });
       }
     });
+
+    view.setOnKeyboardDismissListener(listener);
   }
 }

--- a/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RecyclerAdapterDataChangeOnSubscribe.java
+++ b/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RecyclerAdapterDataChangeOnSubscribe.java
@@ -28,13 +28,13 @@ final class RecyclerAdapterDataChangeOnSubscribe<T extends Adapter<? extends Vie
       }
     };
 
-    adapter.registerAdapterDataObserver(observer);
-
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         adapter.unregisterAdapterDataObserver(observer);
       }
     });
+
+    adapter.registerAdapterDataObserver(observer);
 
     // Emit initial value.
     subscriber.onNext(adapter);

--- a/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RecyclerViewChildAttachStateChangeEventOnSubscribe.java
+++ b/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RecyclerViewChildAttachStateChangeEventOnSubscribe.java
@@ -35,12 +35,12 @@ final class RecyclerViewChildAttachStateChangeEventOnSubscribe
       }
     };
 
-    recyclerView.addOnChildAttachStateChangeListener(listener);
-
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         recyclerView.removeOnChildAttachStateChangeListener(listener);
       }
     });
+
+    recyclerView.addOnChildAttachStateChangeListener(listener);
   }
 }

--- a/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RecyclerViewScrollEventOnSubscribe.java
+++ b/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RecyclerViewScrollEventOnSubscribe.java
@@ -25,12 +25,13 @@ final class RecyclerViewScrollEventOnSubscribe
         }
       }
     };
-    recyclerView.addOnScrollListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         recyclerView.removeOnScrollListener(listener);
       }
     });
+
+    recyclerView.addOnScrollListener(listener);
   }
 }

--- a/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RecyclerViewScrollStateChangeOnSubscribe.java
+++ b/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding/support/v7/widget/RecyclerViewScrollStateChangeOnSubscribe.java
@@ -24,12 +24,13 @@ final class RecyclerViewScrollStateChangeOnSubscribe implements Observable.OnSub
         }
       }
     };
-    recyclerView.addOnScrollListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         recyclerView.removeOnScrollListener(listener);
       }
     });
+
+    recyclerView.addOnScrollListener(listener);
   }
 }

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/view/MenuItemActionViewEventOnSubscribe.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/view/MenuItemActionViewEventOnSubscribe.java
@@ -49,12 +49,12 @@ final class MenuItemActionViewEventOnSubscribe
       }
     };
 
-    MenuItemCompat.setOnActionExpandListener(menuItem, listener);
-
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         MenuItemCompat.setOnActionExpandListener(menuItem, null);
       }
     });
+
+    MenuItemCompat.setOnActionExpandListener(menuItem, listener);
   }
 }

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/view/ViewPagerPageScrollStateChangedOnSubscribe.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/view/ViewPagerPageScrollStateChangedOnSubscribe.java
@@ -31,12 +31,13 @@ final class ViewPagerPageScrollStateChangedOnSubscribe implements Observable.OnS
         }
       }
     };
-    view.addOnPageChangeListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.removeOnPageChangeListener(listener);
       }
     });
+
+    view.addOnPageChangeListener(listener);
   }
 }

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/view/ViewPagerPageSelectedOnSubscribe.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/view/ViewPagerPageSelectedOnSubscribe.java
@@ -24,13 +24,14 @@ final class ViewPagerPageSelectedOnSubscribe implements Observable.OnSubscribe<I
         }
       }
     };
-    view.addOnPageChangeListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.removeOnPageChangeListener(listener);
       }
     });
+
+    view.addOnPageChangeListener(listener);
 
     // Emit initial value.
     subscriber.onNext(view.getCurrentItem());

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/DrawerLayoutDrawerOpenedOnSubscribe.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/DrawerLayoutDrawerOpenedOnSubscribe.java
@@ -46,13 +46,14 @@ final class DrawerLayoutDrawerOpenedOnSubscribe implements Observable.OnSubscrib
         }
       }
     };
-    view.setDrawerListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setDrawerListener(null);
       }
     });
+
+    view.setDrawerListener(listener);
 
     // Emit initial value.
     subscriber.onNext(view.isDrawerOpen(gravity));

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/NestedScrollViewScrollChangeEventOnSubscribe.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/NestedScrollViewScrollChangeEventOnSubscribe.java
@@ -33,13 +33,14 @@ final class NestedScrollViewScrollChangeEventOnSubscribe
         }
       }
     };
-    nestedScrollView.setOnScrollChangeListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         nestedScrollView.setOnScrollChangeListener((OnScrollChangeListener) null);
       }
     });
+
+    nestedScrollView.setOnScrollChangeListener(listener);
   }
 }
 

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/SlidingPaneLayoutPaneOpenedOnSubscribe.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/SlidingPaneLayoutPaneOpenedOnSubscribe.java
@@ -33,13 +33,13 @@ final class SlidingPaneLayoutPaneOpenedOnSubscribe implements Observable.OnSubsc
           }
         };
 
-    view.setPanelSlideListener(listener);
-
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setPanelSlideListener(null);
       }
     });
+
+    view.setPanelSlideListener(listener);
 
     subscriber.onNext(view.isOpen());
   }

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/SlidingPaneLayoutSlideOnSubscribe.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/SlidingPaneLayoutSlideOnSubscribe.java
@@ -27,12 +27,12 @@ final class SlidingPaneLayoutSlideOnSubscribe implements Observable.OnSubscribe<
           }
         };
 
-    view.setPanelSlideListener(listener);
-
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setPanelSlideListener(null);
       }
     });
+
+    view.setPanelSlideListener(listener);
   }
 }

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/SwipeRefreshLayoutRefreshOnSubscribe.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding/support/v4/widget/SwipeRefreshLayoutRefreshOnSubscribe.java
@@ -24,12 +24,13 @@ final class SwipeRefreshLayoutRefreshOnSubscribe implements Observable.OnSubscri
         }
       }
     };
-    view.setOnRefreshListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnRefreshListener(null);
       }
     });
+
+    view.setOnRefreshListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/MenuItemActionViewEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/MenuItemActionViewEventOnSubscribe.java
@@ -45,12 +45,12 @@ final class MenuItemActionViewEventOnSubscribe
       }
     };
 
-    menuItem.setOnActionExpandListener(listener);
-
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         menuItem.setOnActionExpandListener(null);
       }
     });
+
+    menuItem.setOnActionExpandListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/MenuItemClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/MenuItemClickOnSubscribe.java
@@ -32,12 +32,12 @@ final class MenuItemClickOnSubscribe implements Observable.OnSubscribe<Void> {
       }
     };
 
-    menuItem.setOnMenuItemClickListener(listener);
-
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         menuItem.setOnMenuItemClickListener(null);
       }
     });
+
+    menuItem.setOnMenuItemClickListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewAttachEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewAttachEventOnSubscribe.java
@@ -33,12 +33,13 @@ final class ViewAttachEventOnSubscribe implements Observable.OnSubscribe<ViewAtt
         }
       }
     };
-    view.addOnAttachStateChangeListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.removeOnAttachStateChangeListener(listener);
       }
     });
+
+    view.addOnAttachStateChangeListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewAttachesOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewAttachesOnSubscribe.java
@@ -33,12 +33,13 @@ final class ViewAttachesOnSubscribe implements Observable.OnSubscribe<Void> {
         }
       }
     };
-    view.addOnAttachStateChangeListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.removeOnAttachStateChangeListener(listener);
       }
     });
+
+    view.addOnAttachStateChangeListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewClickOnSubscribe.java
@@ -24,12 +24,13 @@ final class ViewClickOnSubscribe implements Observable.OnSubscribe<Void> {
         }
       }
     };
-    view.setOnClickListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnClickListener(null);
       }
     });
+
+    view.setOnClickListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewDragOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewDragOnSubscribe.java
@@ -32,12 +32,13 @@ final class ViewDragOnSubscribe implements Observable.OnSubscribe<DragEvent> {
         return false;
       }
     };
-    view.setOnDragListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnDragListener(null);
       }
     });
+
+    view.setOnDragListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewFocusChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewFocusChangeOnSubscribe.java
@@ -24,13 +24,14 @@ final class ViewFocusChangeOnSubscribe implements Observable.OnSubscribe<Boolean
         }
       }
     };
-    view.setOnFocusChangeListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnFocusChangeListener(null);
       }
     });
+
+    view.setOnFocusChangeListener(listener);
 
     // Emit initial value.
     subscriber.onNext(view.hasFocus());

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewGroupHierarchyChangeEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewGroupHierarchyChangeEventOnSubscribe.java
@@ -35,12 +35,12 @@ final class ViewGroupHierarchyChangeEventOnSubscribe
       }
     };
 
-    viewGroup.setOnHierarchyChangeListener(listener);
-
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         viewGroup.setOnHierarchyChangeListener(null);
       }
     });
+
+    viewGroup.setOnHierarchyChangeListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewHoverOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewHoverOnSubscribe.java
@@ -33,12 +33,13 @@ final class ViewHoverOnSubscribe implements Observable.OnSubscribe<MotionEvent> 
         return false;
       }
     };
-    view.setOnHoverListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnHoverListener(null);
       }
     });
+
+    view.setOnHoverListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewKeyOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewKeyOnSubscribe.java
@@ -36,12 +36,13 @@ final class ViewKeyOnSubscribe implements Observable.OnSubscribe<KeyEvent> {
         }
       }
     };
-    view.setOnKeyListener(keyListener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnKeyListener(null);
       }
     });
+
+    view.setOnKeyListener(keyListener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewLayoutChangeEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewLayoutChangeEventOnSubscribe.java
@@ -27,12 +27,13 @@ final class ViewLayoutChangeEventOnSubscribe
         }
       }
     };
-    view.addOnLayoutChangeListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.removeOnLayoutChangeListener(listener);
       }
     });
+
+    view.addOnLayoutChangeListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewLayoutChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewLayoutChangeOnSubscribe.java
@@ -25,12 +25,13 @@ final class ViewLayoutChangeOnSubscribe implements Observable.OnSubscribe<Void> 
         }
       }
     };
-    view.addOnLayoutChangeListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.removeOnLayoutChangeListener(listener);
       }
     });
+
+    view.addOnLayoutChangeListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewLongClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewLongClickOnSubscribe.java
@@ -31,12 +31,13 @@ final class ViewLongClickOnSubscribe implements Observable.OnSubscribe<Void> {
         return false;
       }
     };
-    view.setOnLongClickListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnLongClickListener(null);
       }
     });
+
+    view.setOnLongClickListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewScrollChangeEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewScrollChangeEventOnSubscribe.java
@@ -30,12 +30,13 @@ final class ViewScrollChangeEventOnSubscribe
         }
       }
     };
-    view.setOnScrollChangeListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnScrollChangeListener(null);
       }
     });
+
+    view.setOnScrollChangeListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewSystemUiVisibilityChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewSystemUiVisibilityChangeOnSubscribe.java
@@ -25,12 +25,13 @@ final class ViewSystemUiVisibilityChangeOnSubscribe implements Observable.OnSubs
             }
           }
         };
-    view.setOnSystemUiVisibilityChangeListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnSystemUiVisibilityChangeListener(null);
       }
     });
+
+    view.setOnSystemUiVisibilityChangeListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTouchOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTouchOnSubscribe.java
@@ -33,12 +33,13 @@ final class ViewTouchOnSubscribe implements Observable.OnSubscribe<MotionEvent> 
         return false;
       }
     };
-    view.setOnTouchListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnTouchListener(null);
       }
     });
+
+    view.setOnTouchListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTreeObserverDrawOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTreeObserverDrawOnSubscribe.java
@@ -29,12 +29,12 @@ final class ViewTreeObserverDrawOnSubscribe implements Observable.OnSubscribe<Vo
       }
     };
 
-    view.getViewTreeObserver().addOnDrawListener(listener);
-
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.getViewTreeObserver().removeOnDrawListener(listener);
       }
     });
+
+    view.getViewTreeObserver().addOnDrawListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTreeObserverGlobalLayoutOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTreeObserverGlobalLayoutOnSubscribe.java
@@ -27,8 +27,6 @@ final class ViewTreeObserverGlobalLayoutOnSubscribe implements Observable.OnSubs
       }
     };
 
-    view.getViewTreeObserver().addOnGlobalLayoutListener(listener);
-
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
@@ -38,5 +36,7 @@ final class ViewTreeObserverGlobalLayoutOnSubscribe implements Observable.OnSubs
         }
       }
     });
+
+    view.getViewTreeObserver().addOnGlobalLayoutListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTreeObserverPreDrawOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/view/ViewTreeObserverPreDrawOnSubscribe.java
@@ -31,12 +31,12 @@ final class ViewTreeObserverPreDrawOnSubscribe implements Observable.OnSubscribe
       }
     };
 
-    view.getViewTreeObserver().addOnPreDrawListener(listener);
-
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.getViewTreeObserver().removeOnPreDrawListener(listener);
       }
     });
+
+    view.getViewTreeObserver().addOnPreDrawListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AbsListViewScrollEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AbsListViewScrollEventOnSubscribe.java
@@ -44,13 +44,13 @@ final class AbsListViewScrollEventOnSubscribe
       }
     };
 
-    // Setting the listener automatically triggers the initial value.
-    view.setOnScrollListener(listener);
-
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnScrollListener(null);
       }
     });
+
+    // Setting the listener automatically triggers the initial value.
+    view.setOnScrollListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterDataChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterDataChangeOnSubscribe.java
@@ -26,13 +26,14 @@ final class AdapterDataChangeOnSubscribe<T extends Adapter>
         }
       }
     };
-    adapter.registerDataSetObserver(observer);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         adapter.unregisterDataSetObserver(observer);
       }
     });
+
+    adapter.registerDataSetObserver(observer);
 
     // Emit initial value.
     subscriber.onNext(adapter);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemClickEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemClickEventOnSubscribe.java
@@ -26,12 +26,13 @@ final class AdapterViewItemClickEventOnSubscribe
         }
       }
     };
-    view.setOnItemClickListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnItemClickListener(null);
       }
     });
+
+    view.setOnItemClickListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemClickOnSubscribe.java
@@ -25,12 +25,13 @@ final class AdapterViewItemClickOnSubscribe implements Observable.OnSubscribe<In
         }
       }
     };
-    view.setOnItemClickListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnItemClickListener(null);
       }
     });
+
+    view.setOnItemClickListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemLongClickEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemLongClickEventOnSubscribe.java
@@ -37,12 +37,13 @@ final class AdapterViewItemLongClickEventOnSubscribe
         return false;
       }
     };
-    view.setOnItemLongClickListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnItemLongClickListener(null);
       }
     });
+
+    view.setOnItemLongClickListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemLongClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemLongClickOnSubscribe.java
@@ -33,12 +33,13 @@ final class AdapterViewItemLongClickOnSubscribe implements Observable.OnSubscrib
         return false;
       }
     };
-    view.setOnItemLongClickListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnItemLongClickListener(null);
       }
     });
+
+    view.setOnItemLongClickListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemSelectionOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewItemSelectionOnSubscribe.java
@@ -33,13 +33,14 @@ final class AdapterViewItemSelectionOnSubscribe implements Observable.OnSubscrib
         }
       }
     };
-    view.setOnItemSelectedListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnItemSelectedListener(null);
       }
     });
+
+    view.setOnItemSelectedListener(listener);
 
     // Emit initial value.
     subscriber.onNext(view.getSelectedItemPosition());

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewSelectionOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AdapterViewSelectionOnSubscribe.java
@@ -34,13 +34,14 @@ final class AdapterViewSelectionOnSubscribe
         }
       }
     };
-    view.setOnItemSelectedListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnItemSelectedListener(null);
       }
     });
+
+    view.setOnItemSelectedListener(listener);
 
     // Emit initial value.
     int selectedPosition = view.getSelectedItemPosition();

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AutoCompleteTextViewItemClickEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/AutoCompleteTextViewItemClickEventOnSubscribe.java
@@ -27,12 +27,13 @@ final class AutoCompleteTextViewItemClickEventOnSubscribe
         }
       }
     };
-    view.setOnItemClickListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnItemClickListener(null);
       }
     });
+
+    view.setOnItemClickListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/CompoundButtonCheckedChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/CompoundButtonCheckedChangeOnSubscribe.java
@@ -24,13 +24,14 @@ final class CompoundButtonCheckedChangeOnSubscribe implements Observable.OnSubsc
         }
       }
     };
-    view.setOnCheckedChangeListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnCheckedChangeListener(null);
       }
     });
+
+    view.setOnCheckedChangeListener(listener);
 
     // Emit initial value.
     subscriber.onNext(view.isChecked());

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/PopupMenuDismissOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/PopupMenuDismissOnSubscribe.java
@@ -26,12 +26,12 @@ final class PopupMenuDismissOnSubscribe implements Observable.OnSubscribe<Void> 
       }
     };
 
-    view.setOnDismissListener(listener);
-
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnDismissListener(null);
       }
     });
+
+    view.setOnDismissListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/PopupMenuItemClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/PopupMenuItemClickOnSubscribe.java
@@ -28,12 +28,12 @@ final class PopupMenuItemClickOnSubscribe implements Observable.OnSubscribe<Menu
       }
     };
 
-    view.setOnMenuItemClickListener(listener);
-
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnMenuItemClickListener(null);
       }
     });
+
+    view.setOnMenuItemClickListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RadioGroupCheckedChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RadioGroupCheckedChangeOnSubscribe.java
@@ -24,13 +24,14 @@ final class RadioGroupCheckedChangeOnSubscribe implements Observable.OnSubscribe
         }
       }
     };
-    view.setOnCheckedChangeListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnCheckedChangeListener(null);
       }
     });
+
+    view.setOnCheckedChangeListener(listener);
 
     // Emit initial value.
     subscriber.onNext(view.getCheckedRadioButtonId());

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RatingBarRatingChangeEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RatingBarRatingChangeEventOnSubscribe.java
@@ -25,13 +25,14 @@ final class RatingBarRatingChangeEventOnSubscribe
         }
       }
     };
-    view.setOnRatingBarChangeListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnRatingBarChangeListener(null);
       }
     });
+
+    view.setOnRatingBarChangeListener(listener);
 
     // Emit initial value.
     subscriber.onNext(RatingBarChangeEvent.create(view, view.getRating(), false));

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RatingBarRatingChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/RatingBarRatingChangeOnSubscribe.java
@@ -24,13 +24,14 @@ final class RatingBarRatingChangeOnSubscribe implements Observable.OnSubscribe<F
         }
       }
     };
-    view.setOnRatingBarChangeListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnRatingBarChangeListener(null);
       }
     });
+
+    view.setOnRatingBarChangeListener(listener);
 
     // Emit initial value.
     subscriber.onNext(view.getRating());

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewQueryTextChangeEventsOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewQueryTextChangeEventsOnSubscribe.java
@@ -36,13 +36,13 @@ final class SearchViewQueryTextChangeEventsOnSubscribe
       }
     };
 
-    view.setOnQueryTextListener(watcher);
-
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnQueryTextListener(null);
       }
     });
+
+    view.setOnQueryTextListener(watcher);
 
     // Emit initial value.
     subscriber.onNext(SearchViewQueryTextEvent.create(view, view.getQuery(), false));

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewQueryTextChangesOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SearchViewQueryTextChangesOnSubscribe.java
@@ -31,13 +31,13 @@ final class SearchViewQueryTextChangesOnSubscribe implements Observable.OnSubscr
       }
     };
 
-    view.setOnQueryTextListener(watcher);
-
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnQueryTextListener(null);
       }
     });
+
+    view.setOnQueryTextListener(watcher);
 
     // Emit initial value.
     subscriber.onNext(view.getQuery());

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SeekBarChangeEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SeekBarChangeEventOnSubscribe.java
@@ -37,13 +37,14 @@ final class SeekBarChangeEventOnSubscribe
         }
       }
     };
-    view.setOnSeekBarChangeListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnSeekBarChangeListener(null);
       }
     });
+
+    view.setOnSeekBarChangeListener(listener);
 
     // Emit initial value.
     subscriber.onNext(SeekBarProgressChangeEvent.create(view, view.getProgress(), false));

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SeekBarChangeOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/SeekBarChangeOnSubscribe.java
@@ -34,13 +34,14 @@ final class SeekBarChangeOnSubscribe implements Observable.OnSubscribe<Integer> 
       @Override public void onStopTrackingTouch(SeekBar seekBar) {
       }
     };
-    view.setOnSeekBarChangeListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnSeekBarChangeListener(null);
       }
     });
+
+    view.setOnSeekBarChangeListener(listener);
 
     // Emit initial value.
     subscriber.onNext(view.getProgress());

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewAfterTextChangeEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewAfterTextChangeEventOnSubscribe.java
@@ -33,13 +33,14 @@ final class TextViewAfterTextChangeEventOnSubscribe
         }
       }
     };
-    view.addTextChangedListener(watcher);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.removeTextChangedListener(watcher);
       }
     });
+
+    view.addTextChangedListener(watcher);
 
     // Emit initial value.
     subscriber.onNext(TextViewAfterTextChangeEvent.create(view, view.getEditableText()));

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewBeforeTextChangeEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewBeforeTextChangeEventOnSubscribe.java
@@ -33,13 +33,14 @@ final class TextViewBeforeTextChangeEventOnSubscribe
       @Override public void afterTextChanged(Editable s) {
       }
     };
-    view.addTextChangedListener(watcher);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.removeTextChangedListener(watcher);
       }
     });
+
+    view.addTextChangedListener(watcher);
 
     // Emit initial value.
     subscriber.onNext(TextViewBeforeTextChangeEvent.create(view, view.getText(), 0, 0, 0));

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewEditorActionEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewEditorActionEventOnSubscribe.java
@@ -35,12 +35,13 @@ final class TextViewEditorActionEventOnSubscribe
         return false;
       }
     };
-    view.setOnEditorActionListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnEditorActionListener(null);
       }
     });
+
+    view.setOnEditorActionListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewEditorActionOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewEditorActionOnSubscribe.java
@@ -32,12 +32,13 @@ final class TextViewEditorActionOnSubscribe implements Observable.OnSubscribe<In
         return false;
       }
     };
-    view.setOnEditorActionListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnEditorActionListener(null);
       }
     });
+
+    view.setOnEditorActionListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewTextChangeEventOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewTextChangeEventOnSubscribe.java
@@ -33,13 +33,14 @@ final class TextViewTextChangeEventOnSubscribe
       @Override public void afterTextChanged(Editable s) {
       }
     };
-    view.addTextChangedListener(watcher);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.removeTextChangedListener(watcher);
       }
     });
+
+    view.addTextChangedListener(watcher);
 
     // Emit initial value.
     subscriber.onNext(TextViewTextChangeEvent.create(view, view.getText(), 0, 0, 0));

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewTextOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/TextViewTextOnSubscribe.java
@@ -32,13 +32,14 @@ final class TextViewTextOnSubscribe implements Observable.OnSubscribe<CharSequen
       @Override public void afterTextChanged(Editable s) {
       }
     };
-    view.addTextChangedListener(watcher);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.removeTextChangedListener(watcher);
       }
     });
+
+    view.addTextChangedListener(watcher);
 
     // Emit initial value.
     subscriber.onNext(view.getText());

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/ToolbarItemClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/ToolbarItemClickOnSubscribe.java
@@ -29,12 +29,13 @@ final class ToolbarItemClickOnSubscribe implements Observable.OnSubscribe<MenuIt
         return true;
       }
     };
-    view.setOnMenuItemClickListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setOnMenuItemClickListener(null);
       }
     });
+
+    view.setOnMenuItemClickListener(listener);
   }
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/ToolbarNavigationClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/widget/ToolbarNavigationClickOnSubscribe.java
@@ -28,12 +28,13 @@ final class ToolbarNavigationClickOnSubscribe implements Observable.OnSubscribe<
         }
       }
     };
-    view.setNavigationOnClickListener(listener);
 
     subscriber.add(new MainThreadSubscription() {
       @Override protected void onUnsubscribe() {
         view.setNavigationOnClickListener(null);
       }
     });
+
+    view.setNavigationOnClickListener(listener);
   }
 }


### PR DESCRIPTION
This ensures that synchronous unsubscription (like take(1)) does not leak the listener onto the view.

Closes #291.