### PR TITLE
generic type nullable

### DIFF
--- a/rxbinding-design-kotlin/src/main/kotlin/com/jakewharton/rxbinding/support/design/widget/RxTextInputLayout.kt
+++ b/rxbinding-design-kotlin/src/main/kotlin/com/jakewharton/rxbinding/support/design/widget/RxTextInputLayout.kt
@@ -25,7 +25,7 @@ inline fun TextInputLayout.counterMaxLength(): Action1<in Int> = RxTextInputLayo
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
  */
-inline fun TextInputLayout.error(): Action1<in CharSequence> = RxTextInputLayout.error(this)
+inline fun TextInputLayout.error(): Action1<in CharSequence?> = RxTextInputLayout.error(this)
 
 /**
  * An action which sets the error text of `view` with a string resource.
@@ -33,7 +33,7 @@ inline fun TextInputLayout.error(): Action1<in CharSequence> = RxTextInputLayout
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
  */
-inline fun TextInputLayout.errorRes(): Action1<in Int> = RxTextInputLayout.errorRes(this)
+inline fun TextInputLayout.errorRes(): Action1<in Int?> = RxTextInputLayout.errorRes(this)
 
 /**
  * An action which sets the hint property of `view` with character sequences.

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/RxTextInputLayout.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding/support/design/widget/RxTextInputLayout.java
@@ -3,6 +3,9 @@ package com.jakewharton.rxbinding.support.design.widget;
 import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.support.design.widget.TextInputLayout;
+
+import com.jakewharton.rxbinding.internal.GenericTypeNullable;
+
 import rx.functions.Action1;
 
 import static com.jakewharton.rxbinding.internal.Preconditions.checkNotNull;
@@ -50,7 +53,7 @@ public final class RxTextInputLayout {
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
    * to free this reference.
    */
-  @CheckResult @NonNull
+  @CheckResult @NonNull @GenericTypeNullable
   public static Action1<? super CharSequence> error(@NonNull final TextInputLayout view) {
     checkNotNull(view, "view == null");
     return new Action1<CharSequence>() {
@@ -67,7 +70,7 @@ public final class RxTextInputLayout {
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
    * to free this reference.
    */
-  @CheckResult @NonNull
+  @CheckResult @NonNull @GenericTypeNullable
   public static Action1<? super Integer> errorRes(@NonNull final TextInputLayout view) {
     checkNotNull(view, "view == null");
     return new Action1<Integer>() {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/internal/GenericTypeNullable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/internal/GenericTypeNullable.java
@@ -6,7 +6,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This is used to mark a method as having nullable return type parameters for the kotlin generation task.
+ * This is used to mark a method as having nullable return type parameters
+ * for the kotlin generation task.
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.SOURCE)

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding/internal/GenericTypeNullable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding/internal/GenericTypeNullable.java
@@ -1,0 +1,14 @@
+package com.jakewharton.rxbinding.internal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This is used to mark a method as having nullable return type parameters for the kotlin generation task.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.SOURCE)
+public @interface GenericTypeNullable {
+}


### PR DESCRIPTION
Introduces the `@GenericTypeNullable` annotation to mark nullable return type parameters. 

If this needs to be torn up, let me know, this is my first whack at it.

Fixes #297 