### PR TITLE
FIx tests after converting Void to Object

### DIFF
--- a/rxbinding-appcompat-v7/src/androidTest/java/com/jakewharton/rxbinding2/support/v7/widget/RxPopupMenuTest.java
+++ b/rxbinding-appcompat-v7/src/androidTest/java/com/jakewharton/rxbinding2/support/v7/widget/RxPopupMenuTest.java
@@ -69,7 +69,7 @@ import static com.google.common.truth.Truth.assertThat;
         view.dismiss();
       }
     });
-    assertThat(o.takeNext()).isNull();
+    assertThat(o.takeNext()).isNotNull();
 
     o.dispose();
     instrumentation.runOnMainSync(new Runnable() {

--- a/rxbinding-appcompat-v7/src/androidTest/java/com/jakewharton/rxbinding2/support/v7/widget/RxToolbarTest.java
+++ b/rxbinding-appcompat-v7/src/androidTest/java/com/jakewharton/rxbinding2/support/v7/widget/RxToolbarTest.java
@@ -59,10 +59,10 @@ public final class RxToolbarTest {
     o.assertNoMoreEvents(); // No initial value.
 
     onView(withContentDescription(NAVIGATION_CONTENT_DESCRIPTION)).perform(click());
-    assertThat(o.takeNext()).isNull();
+    assertThat(o.takeNext()).isNotNull();
 
     onView(withContentDescription(NAVIGATION_CONTENT_DESCRIPTION)).perform(click());
-    assertThat(o.takeNext()).isNull();
+    assertThat(o.takeNext()).isNotNull();
 
     o.dispose();
 


### PR DESCRIPTION
This assertions verify only is something was emitted. It started to fail since we returns `notification` instead of null.