### PR TITLE
Fix package in AndroidManifest for RxJava2

### DIFF
--- a/rxbinding-appcompat-v7-kotlin/src/main/AndroidManifest.xml
+++ b/rxbinding-appcompat-v7-kotlin/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.jakewharton.rxbinding.support.v7.appcompat.kotlin"/>
+<manifest package="com.jakewharton.rxbinding2.support.v7.appcompat.kotlin"/>

--- a/rxbinding-design-kotlin/src/main/AndroidManifest.xml
+++ b/rxbinding-design-kotlin/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.jakewharton.rxbinding.support.design.kotlin"/>
+<manifest package="com.jakewharton.rxbinding2.support.design.kotlin"/>

--- a/rxbinding-kotlin/src/main/AndroidManifest.xml
+++ b/rxbinding-kotlin/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.jakewharton.rxbinding.kotlin"/>
+<manifest package="com.jakewharton.rxbinding2.kotlin"/>

--- a/rxbinding-leanback-v17-kotlin/src/main/AndroidManifest.xml
+++ b/rxbinding-leanback-v17-kotlin/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.jakewharton.rxbinding.support.v17.leanback.kotlin"/>
+<manifest package="com.jakewharton.rxbinding2.support.v17.leanback.kotlin"/>

--- a/rxbinding-recyclerview-v7-kotlin/src/main/AndroidManifest.xml
+++ b/rxbinding-recyclerview-v7-kotlin/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.jakewharton.rxbinding.support.v7.recyclerview.kotlin"/>
+<manifest package="com.jakewharton.rxbinding2.support.v7.recyclerview.kotlin"/>

--- a/rxbinding-support-v4-kotlin/src/main/AndroidManifest.xml
+++ b/rxbinding-support-v4-kotlin/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.jakewharton.rxbinding.support.v4.kotlin"/>
+<manifest package="com.jakewharton.rxbinding2.support.v4.kotlin"/>

--- a/rxbinding-support-v4/src/androidTest/java/com/jakewharton/rxbinding2/support/v4/widget/RxSwipeRefreshLayoutTest.java
+++ b/rxbinding-support-v4/src/androidTest/java/com/jakewharton/rxbinding2/support/v4/widget/RxSwipeRefreshLayoutTest.java
@@ -9,7 +9,7 @@ import android.support.test.espresso.action.Swipe;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.support.v4.widget.SwipeRefreshLayout;
-import com.jakewharton.rxbinding.support.v4.test.R;
+import com.jakewharton.rxbinding2.support.v4.test.R;
 import com.jakewharton.rxbinding2.RecordingObserver;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.functions.Consumer;

--- a/rxbinding-support-v4/src/androidTest/java/com/jakewharton/rxbinding2/support/v4/widget/RxSwipeRefreshLayoutTestActivity.java
+++ b/rxbinding-support-v4/src/androidTest/java/com/jakewharton/rxbinding2/support/v4/widget/RxSwipeRefreshLayoutTestActivity.java
@@ -11,7 +11,7 @@ import android.view.View;
 import android.view.ViewGroup.LayoutParams;
 import android.widget.FrameLayout;
 import android.widget.ScrollView;
-import com.jakewharton.rxbinding.support.v4.test.R;
+import com.jakewharton.rxbinding2.support.v4.test.R;
 
 import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
 

--- a/rxbinding-support-v4/src/main/AndroidManifest.xml
+++ b/rxbinding-support-v4/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.jakewharton.rxbinding.support.v4"/>
+<manifest package="com.jakewharton.rxbinding2.support.v4"/>

--- a/rxbinding/src/androidTest/AndroidManifest.xml
+++ b/rxbinding/src/androidTest/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.jakewharton.rxbinding">
+    package="com.jakewharton.rxbinding2">
 
   <application>
     <activity android:name="com.jakewharton.rxbinding2.view.RxViewAttachTestActivity"/>

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/view/RxMenuItemTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/view/RxMenuItemTest.java
@@ -14,7 +14,7 @@ import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.SubMenu;
 import android.view.View;
-import com.jakewharton.rxbinding.test.R;
+import com.jakewharton.rxbinding2.test.R;
 import com.jakewharton.rxbinding2.RecordingObserver;
 import com.jakewharton.rxbinding2.view.MenuItemActionViewEvent.Kind;
 import io.reactivex.functions.Predicate;

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/widget/RxAutoCompleteTextViewTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/widget/RxAutoCompleteTextViewTest.java
@@ -10,7 +10,7 @@ import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.widget.ArrayAdapter;
 import android.widget.AutoCompleteTextView;
-import com.jakewharton.rxbinding.test.R;
+import com.jakewharton.rxbinding2.test.R;
 import com.jakewharton.rxbinding2.RecordingObserver;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import java.util.Arrays;

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/widget/RxAutoCompleteTextViewTestActivity.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/widget/RxAutoCompleteTextViewTestActivity.java
@@ -5,7 +5,7 @@ import android.os.Bundle;
 import android.view.ViewGroup.LayoutParams;
 import android.widget.AutoCompleteTextView;
 import android.widget.LinearLayout;
-import com.jakewharton.rxbinding.test.R;
+import com.jakewharton.rxbinding2.test.R;
 
 import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
 import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/widget/RxTextViewTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/widget/RxTextViewTest.java
@@ -6,7 +6,7 @@ import android.support.test.annotation.UiThreadTest;
 import android.support.test.rule.UiThreadTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.widget.TextView;
-import com.jakewharton.rxbinding.test.R;
+import com.jakewharton.rxbinding2.test.R;
 import com.jakewharton.rxbinding2.RecordingObserver;
 import org.junit.Rule;
 import org.junit.Test;

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/widget/RxToolbarTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/widget/RxToolbarTest.java
@@ -7,7 +7,7 @@ import android.support.test.rule.ActivityTestRule;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.Toolbar;
-import com.jakewharton.rxbinding.test.R;
+import com.jakewharton.rxbinding2.test.R;
 import com.jakewharton.rxbinding2.RecordingObserver;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import org.junit.Before;

--- a/rxbinding/src/main/AndroidManifest.xml
+++ b/rxbinding/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.jakewharton.rxbinding"/>
+<manifest package="com.jakewharton.rxbinding2"/>


### PR DESCRIPTION
I tried to use the old version and the new version together but the BuildConfig file conflicted. So I changed the package name of AndroidManifest.

```
compile "com.github.JakeWharton.RxBinding:rxbinding-kotlin:0.4.0"
compile "com.jakewharton.rxbinding:rxbinding-support-v4-kotlin:31e02dcaca"
```
<img width="297" alt="2017-01-31 14 22 38" src="https://cloud.githubusercontent.com/assets/1279170/22453413/0b3ac710-e7c2-11e6-99e3-55dd9d4f3743.png">
