### PR TITLE
Avoid duplicating kotlin_module file

### DIFF
--- a/rxbinding-appcompat-v7-kotlin/build.gradle
+++ b/rxbinding-appcompat-v7-kotlin/build.gradle
@@ -24,6 +24,7 @@ android {
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_7
     targetCompatibility JavaVersion.VERSION_1_7
+    kotlinOptions.moduleName = "rxbinding2-appcompat-v7-kotlin"
   }
 
   dexOptions {

--- a/rxbinding-design-kotlin/build.gradle
+++ b/rxbinding-design-kotlin/build.gradle
@@ -24,6 +24,7 @@ android {
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_7
     targetCompatibility JavaVersion.VERSION_1_7
+    kotlinOptions.moduleName = "rxbinding2-design-kotlin"
   }
 
   dexOptions {

--- a/rxbinding-kotlin/build.gradle
+++ b/rxbinding-kotlin/build.gradle
@@ -24,6 +24,7 @@ android {
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_7
     targetCompatibility JavaVersion.VERSION_1_7
+    kotlinOptions.moduleName = "rxbinding2-kotlin"
   }
 
   dexOptions {

--- a/rxbinding-leanback-v17-kotlin/build.gradle
+++ b/rxbinding-leanback-v17-kotlin/build.gradle
@@ -24,6 +24,7 @@ android {
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_7
     targetCompatibility JavaVersion.VERSION_1_7
+    kotlinOptions.moduleName = "rxbinding2-leanback-v17-kotlin"
   }
 
   dexOptions {

--- a/rxbinding-recyclerview-v7-kotlin/build.gradle
+++ b/rxbinding-recyclerview-v7-kotlin/build.gradle
@@ -24,6 +24,7 @@ android {
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_7
     targetCompatibility JavaVersion.VERSION_1_7
+    kotlinOptions.moduleName = "rxbinding2-recyclerview-v7-kotlin"
   }
 
   dexOptions {

--- a/rxbinding-support-v4-kotlin/build.gradle
+++ b/rxbinding-support-v4-kotlin/build.gradle
@@ -24,6 +24,7 @@ android {
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_7
     targetCompatibility JavaVersion.VERSION_1_7
+    kotlinOptions.moduleName = "rxbinding2-support-v4-kotlin"
   }
 
   dexOptions {


### PR DESCRIPTION
The following problem occurred after #352. 😨 

Duplicating META-INF/rxbinding-kotlin-compileReleaseKotlin.kotlin_module files
```
Execution failed for task ':...transformResourcesWithMergeJavaResForProductRelease'.
> com.android.build.api.transform.TransformException: com.android.builder.packaging.DuplicateFileException: Duplicate files copied in APK META-INF/rxbinding-kotlin-compileReleaseKotlin.kotlin_module
        File1: .../build/intermediates/exploded-aar/com.jakewharton.rxbinding/rxbinding-kotlin/0.4.0/jars/classes.jar
        File2: .../build/intermediates/exploded-aar/com.github.JakeWharton.RxBinding/rxbinding-kotlin/93b010afdc/jars/classes.jar
```

It worked if I used bellow options.
https://blog.jetbrains.com/kotlin/2015/09/kotlin-m13-is-out/
`New layout of .class files for top-level declarations`
`in Gradle it’s project name + build task name, to customize`

Another way is changing module name such as `rxbinding2-kotlin`.