### PR TITLE
Send main thread checks to onError()

### DIFF
--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/ActionMenuViewItemClickObservable.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/ActionMenuViewItemClickObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class ActionMenuViewItemClickObservable extends Observable<MenuItem> {
   private final ActionMenuView view;
@@ -17,7 +17,7 @@ final class ActionMenuViewItemClickObservable extends Observable<MenuItem> {
   }
 
   @Override protected void subscribeActual(Observer<? super MenuItem> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/ActionMenuViewItemClickObservable.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/ActionMenuViewItemClickObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class ActionMenuViewItemClickObservable extends Observable<MenuItem> {
   private final ActionMenuView view;
@@ -17,7 +17,9 @@ final class ActionMenuViewItemClickObservable extends Observable<MenuItem> {
   }
 
   @Override protected void subscribeActual(Observer<? super MenuItem> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setOnMenuItemClickListener(listener);

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/PopupMenuDismissObservable.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/PopupMenuDismissObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class PopupMenuDismissObservable extends Observable<Object> {
   private final PopupMenu view;
@@ -16,7 +16,7 @@ final class PopupMenuDismissObservable extends Observable<Object> {
   }
 
   @Override protected void subscribeActual(Observer<? super Object> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/PopupMenuDismissObservable.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/PopupMenuDismissObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class PopupMenuDismissObservable extends Observable<Object> {
   private final PopupMenu view;
@@ -16,7 +16,9 @@ final class PopupMenuDismissObservable extends Observable<Object> {
   }
 
   @Override protected void subscribeActual(Observer<? super Object> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setOnDismissListener(listener);

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/PopupMenuItemClickObservable.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/PopupMenuItemClickObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class PopupMenuItemClickObservable extends Observable<MenuItem> {
   private final PopupMenu view;
@@ -17,7 +17,7 @@ final class PopupMenuItemClickObservable extends Observable<MenuItem> {
   }
 
   @Override protected void subscribeActual(Observer<? super MenuItem> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/PopupMenuItemClickObservable.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/PopupMenuItemClickObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class PopupMenuItemClickObservable extends Observable<MenuItem> {
   private final PopupMenu view;
@@ -17,7 +17,9 @@ final class PopupMenuItemClickObservable extends Observable<MenuItem> {
   }
 
   @Override protected void subscribeActual(Observer<? super MenuItem> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setOnMenuItemClickListener(listener);

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/SearchViewQueryTextChangeEventsObservable.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/SearchViewQueryTextChangeEventsObservable.java
@@ -5,7 +5,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class SearchViewQueryTextChangeEventsObservable extends Observable<SearchViewQueryTextEvent> {
   private final SearchView view;
@@ -15,7 +15,9 @@ final class SearchViewQueryTextChangeEventsObservable extends Observable<SearchV
   }
 
   @Override protected void subscribeActual(Observer<? super SearchViewQueryTextEvent> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setOnQueryTextListener(listener);

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/SearchViewQueryTextChangeEventsObservable.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/SearchViewQueryTextChangeEventsObservable.java
@@ -5,7 +5,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class SearchViewQueryTextChangeEventsObservable extends Observable<SearchViewQueryTextEvent> {
   private final SearchView view;
@@ -15,7 +15,7 @@ final class SearchViewQueryTextChangeEventsObservable extends Observable<SearchV
   }
 
   @Override protected void subscribeActual(Observer<? super SearchViewQueryTextEvent> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/SearchViewQueryTextChangesObservable.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/SearchViewQueryTextChangesObservable.java
@@ -5,7 +5,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class SearchViewQueryTextChangesObservable extends Observable<CharSequence> {
   private final SearchView view;
@@ -15,7 +15,9 @@ final class SearchViewQueryTextChangesObservable extends Observable<CharSequence
   }
 
   @Override protected void subscribeActual(Observer<? super CharSequence> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setOnQueryTextListener(listener);

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/SearchViewQueryTextChangesObservable.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/SearchViewQueryTextChangesObservable.java
@@ -5,7 +5,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class SearchViewQueryTextChangesObservable extends Observable<CharSequence> {
   private final SearchView view;
@@ -15,7 +15,7 @@ final class SearchViewQueryTextChangesObservable extends Observable<CharSequence
   }
 
   @Override protected void subscribeActual(Observer<? super CharSequence> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/ToolbarItemClickObservable.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/ToolbarItemClickObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class ToolbarItemClickObservable extends Observable<MenuItem> {
   private final Toolbar view;
@@ -17,7 +17,9 @@ final class ToolbarItemClickObservable extends Observable<MenuItem> {
   }
 
   @Override protected void subscribeActual(Observer<? super MenuItem> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setOnMenuItemClickListener(listener);

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/ToolbarItemClickObservable.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/ToolbarItemClickObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class ToolbarItemClickObservable extends Observable<MenuItem> {
   private final Toolbar view;
@@ -17,7 +17,7 @@ final class ToolbarItemClickObservable extends Observable<MenuItem> {
   }
 
   @Override protected void subscribeActual(Observer<? super MenuItem> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/ToolbarNavigationClickObservable.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/ToolbarNavigationClickObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class ToolbarNavigationClickObservable extends Observable<Object> {
   private final Toolbar view;
@@ -17,7 +17,9 @@ final class ToolbarNavigationClickObservable extends Observable<Object> {
   }
 
   @Override protected void subscribeActual(Observer<? super Object> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setNavigationOnClickListener(listener);

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/ToolbarNavigationClickObservable.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/ToolbarNavigationClickObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class ToolbarNavigationClickObservable extends Observable<Object> {
   private final Toolbar view;
@@ -17,7 +17,7 @@ final class ToolbarNavigationClickObservable extends Observable<Object> {
   }
 
   @Override protected void subscribeActual(Observer<? super Object> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/AppBarLayoutOffsetChangeObservable.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/AppBarLayoutOffsetChangeObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class AppBarLayoutOffsetChangeObservable extends Observable<Integer> {
   private final AppBarLayout view;
@@ -16,7 +16,7 @@ final class AppBarLayoutOffsetChangeObservable extends Observable<Integer> {
   }
 
   @Override protected void subscribeActual(Observer<? super Integer> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/AppBarLayoutOffsetChangeObservable.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/AppBarLayoutOffsetChangeObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class AppBarLayoutOffsetChangeObservable extends Observable<Integer> {
   private final AppBarLayout view;
@@ -16,7 +16,9 @@ final class AppBarLayoutOffsetChangeObservable extends Observable<Integer> {
   }
 
   @Override protected void subscribeActual(Observer<? super Integer> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.addOnOffsetChangedListener(listener);

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/BottomNavigationViewItemSelectionsObservable.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/BottomNavigationViewItemSelectionsObservable.java
@@ -9,7 +9,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class BottomNavigationViewItemSelectionsObservable extends Observable<MenuItem> {
   private final BottomNavigationView view;
@@ -19,7 +19,9 @@ final class BottomNavigationViewItemSelectionsObservable extends Observable<Menu
   }
 
   @Override protected void subscribeActual(Observer<? super MenuItem> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setOnNavigationItemSelectedListener(listener);

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/BottomNavigationViewItemSelectionsObservable.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/BottomNavigationViewItemSelectionsObservable.java
@@ -9,7 +9,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class BottomNavigationViewItemSelectionsObservable extends Observable<MenuItem> {
   private final BottomNavigationView view;
@@ -19,7 +19,7 @@ final class BottomNavigationViewItemSelectionsObservable extends Observable<Menu
   }
 
   @Override protected void subscribeActual(Observer<? super MenuItem> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/NavigationViewItemSelectionsObservable.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/NavigationViewItemSelectionsObservable.java
@@ -9,7 +9,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class NavigationViewItemSelectionsObservable extends Observable<MenuItem> {
   private final NavigationView view;
@@ -19,7 +19,7 @@ final class NavigationViewItemSelectionsObservable extends Observable<MenuItem> 
   }
 
   @Override protected void subscribeActual(Observer<? super MenuItem> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/NavigationViewItemSelectionsObservable.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/NavigationViewItemSelectionsObservable.java
@@ -9,7 +9,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class NavigationViewItemSelectionsObservable extends Observable<MenuItem> {
   private final NavigationView view;
@@ -19,7 +19,9 @@ final class NavigationViewItemSelectionsObservable extends Observable<MenuItem> 
   }
 
   @Override protected void subscribeActual(Observer<? super MenuItem> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setNavigationItemSelectedListener(listener);

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/SnackbarDismissesObservable.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/SnackbarDismissesObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class SnackbarDismissesObservable extends Observable<Integer> {
   private final Snackbar view;
@@ -16,7 +16,7 @@ final class SnackbarDismissesObservable extends Observable<Integer> {
   }
 
   @Override protected void subscribeActual(Observer<? super Integer> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/SnackbarDismissesObservable.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/SnackbarDismissesObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class SnackbarDismissesObservable extends Observable<Integer> {
   private final Snackbar view;
@@ -16,7 +16,9 @@ final class SnackbarDismissesObservable extends Observable<Integer> {
   }
 
   @Override protected void subscribeActual(Observer<? super Integer> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setCallback(listener.callback);

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/SwipeDismissBehaviorObservable.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/SwipeDismissBehaviorObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class SwipeDismissBehaviorObservable extends Observable<View> {
   private final View view;
@@ -18,7 +18,9 @@ final class SwipeDismissBehaviorObservable extends Observable<View> {
   }
 
   @Override protected void subscribeActual(Observer<? super View> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     if (!(view.getLayoutParams() instanceof LayoutParams)) {
       throw new IllegalArgumentException("The view is not in a Coordinator Layout.");
     }

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/SwipeDismissBehaviorObservable.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/SwipeDismissBehaviorObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class SwipeDismissBehaviorObservable extends Observable<View> {
   private final View view;
@@ -18,7 +18,7 @@ final class SwipeDismissBehaviorObservable extends Observable<View> {
   }
 
   @Override protected void subscribeActual(Observer<? super View> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     if (!(view.getLayoutParams() instanceof LayoutParams)) {

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/TabLayoutSelectionEventObservable.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/TabLayoutSelectionEventObservable.java
@@ -7,7 +7,8 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.support.design.widget.TabLayoutSelectionEvent.Kind.SELECTED;
 
 final class TabLayoutSelectionEventObservable extends Observable<TabLayoutSelectionEvent> {
   private final TabLayout view;
@@ -17,14 +18,16 @@ final class TabLayoutSelectionEventObservable extends Observable<TabLayoutSelect
   }
 
   @Override protected void subscribeActual(Observer<? super TabLayoutSelectionEvent> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.addOnTabSelectedListener(listener);
 
     int index = view.getSelectedTabPosition();
     if (index != -1) {
-      observer.onNext(TabLayoutSelectionEvent.create(view, Kind.SELECTED, view.getTabAt(index)));
+      observer.onNext(TabLayoutSelectionEvent.create(view, SELECTED, view.getTabAt(index)));
     }
   }
 

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/TabLayoutSelectionEventObservable.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/TabLayoutSelectionEventObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 import static com.jakewharton.rxbinding2.support.design.widget.TabLayoutSelectionEvent.Kind.SELECTED;
 
 final class TabLayoutSelectionEventObservable extends Observable<TabLayoutSelectionEvent> {
@@ -18,7 +18,7 @@ final class TabLayoutSelectionEventObservable extends Observable<TabLayoutSelect
   }
 
   @Override protected void subscribeActual(Observer<? super TabLayoutSelectionEvent> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/TabLayoutSelectionEventObservable.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/TabLayoutSelectionEventObservable.java
@@ -8,7 +8,6 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
 import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
-import static com.jakewharton.rxbinding2.support.design.widget.TabLayoutSelectionEvent.Kind.SELECTED;
 
 final class TabLayoutSelectionEventObservable extends Observable<TabLayoutSelectionEvent> {
   private final TabLayout view;
@@ -27,7 +26,7 @@ final class TabLayoutSelectionEventObservable extends Observable<TabLayoutSelect
 
     int index = view.getSelectedTabPosition();
     if (index != -1) {
-      observer.onNext(TabLayoutSelectionEvent.create(view, SELECTED, view.getTabAt(index)));
+      observer.onNext(TabLayoutSelectionEvent.create(view, Kind.SELECTED, view.getTabAt(index)));
     }
   }
 

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/TabLayoutSelectionsObservable.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/TabLayoutSelectionsObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class TabLayoutSelectionsObservable extends Observable<Tab> {
   private final TabLayout view;
@@ -17,7 +17,7 @@ final class TabLayoutSelectionsObservable extends Observable<Tab> {
   }
 
   @Override protected void subscribeActual(Observer<? super Tab> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/TabLayoutSelectionsObservable.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/TabLayoutSelectionsObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class TabLayoutSelectionsObservable extends Observable<Tab> {
   private final TabLayout view;
@@ -17,7 +17,9 @@ final class TabLayoutSelectionsObservable extends Observable<Tab> {
   }
 
   @Override protected void subscribeActual(Observer<? super Tab> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.addOnTabSelectedListener(listener);

--- a/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding2/support/v17/leanback/widget/SearchBarSearchQueryChangeEventsOnSubscribe.java
+++ b/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding2/support/v17/leanback/widget/SearchBarSearchQueryChangeEventsOnSubscribe.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class SearchBarSearchQueryChangeEventsOnSubscribe
     extends Observable<SearchBarSearchQueryEvent> {
@@ -18,7 +18,9 @@ final class SearchBarSearchQueryChangeEventsOnSubscribe
 
   @Override
   protected void subscribeActual(final Observer<? super SearchBarSearchQueryEvent> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setSearchBarListener(listener);

--- a/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding2/support/v17/leanback/widget/SearchBarSearchQueryChangeEventsOnSubscribe.java
+++ b/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding2/support/v17/leanback/widget/SearchBarSearchQueryChangeEventsOnSubscribe.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class SearchBarSearchQueryChangeEventsOnSubscribe
     extends Observable<SearchBarSearchQueryEvent> {
@@ -18,7 +18,7 @@ final class SearchBarSearchQueryChangeEventsOnSubscribe
 
   @Override
   protected void subscribeActual(final Observer<? super SearchBarSearchQueryEvent> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding2/support/v17/leanback/widget/SearchBarSearchQueryChangesOnSubscribe.java
+++ b/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding2/support/v17/leanback/widget/SearchBarSearchQueryChangesOnSubscribe.java
@@ -5,7 +5,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class SearchBarSearchQueryChangesOnSubscribe extends Observable<String> {
   final SearchBar view;
@@ -15,7 +15,7 @@ final class SearchBarSearchQueryChangesOnSubscribe extends Observable<String> {
   }
 
   @Override protected void subscribeActual(final Observer<? super String> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding2/support/v17/leanback/widget/SearchBarSearchQueryChangesOnSubscribe.java
+++ b/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding2/support/v17/leanback/widget/SearchBarSearchQueryChangesOnSubscribe.java
@@ -5,7 +5,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class SearchBarSearchQueryChangesOnSubscribe extends Observable<String> {
   final SearchBar view;
@@ -15,7 +15,9 @@ final class SearchBarSearchQueryChangesOnSubscribe extends Observable<String> {
   }
 
   @Override protected void subscribeActual(final Observer<? super String> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setSearchBarListener(listener);

--- a/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding2/support/v17/leanback/widget/SearchEditTextKeyboardDismissOnSubscribe.java
+++ b/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding2/support/v17/leanback/widget/SearchEditTextKeyboardDismissOnSubscribe.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class SearchEditTextKeyboardDismissOnSubscribe extends Observable<Object> {
   final SearchEditText view;
@@ -17,7 +17,7 @@ final class SearchEditTextKeyboardDismissOnSubscribe extends Observable<Object> 
   }
 
   @Override protected void subscribeActual(final Observer<? super Object> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding2/support/v17/leanback/widget/SearchEditTextKeyboardDismissOnSubscribe.java
+++ b/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding2/support/v17/leanback/widget/SearchEditTextKeyboardDismissOnSubscribe.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class SearchEditTextKeyboardDismissOnSubscribe extends Observable<Object> {
   final SearchEditText view;
@@ -17,7 +17,9 @@ final class SearchEditTextKeyboardDismissOnSubscribe extends Observable<Object> 
   }
 
   @Override protected void subscribeActual(final Observer<? super Object> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setOnKeyboardDismissListener(listener);

--- a/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RecyclerAdapterDataChangeObservable.java
+++ b/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RecyclerAdapterDataChangeObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class RecyclerAdapterDataChangeObservable<T extends Adapter<? extends ViewHolder>>
     extends Observable<T> {
@@ -18,7 +18,7 @@ final class RecyclerAdapterDataChangeObservable<T extends Adapter<? extends View
   }
 
   @Override protected void subscribeActual(Observer<? super T> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(adapter, observer);

--- a/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RecyclerAdapterDataChangeObservable.java
+++ b/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RecyclerAdapterDataChangeObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class RecyclerAdapterDataChangeObservable<T extends Adapter<? extends ViewHolder>>
     extends Observable<T> {
@@ -18,7 +18,9 @@ final class RecyclerAdapterDataChangeObservable<T extends Adapter<? extends View
   }
 
   @Override protected void subscribeActual(Observer<? super T> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(adapter, observer);
     observer.onSubscribe(listener);
     adapter.registerAdapterDataObserver(listener.dataObserver);

--- a/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RecyclerViewChildAttachStateChangeEventObservable.java
+++ b/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RecyclerViewChildAttachStateChangeEventObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class RecyclerViewChildAttachStateChangeEventObservable
     extends Observable<RecyclerViewChildAttachStateChangeEvent> {
@@ -19,7 +19,9 @@ final class RecyclerViewChildAttachStateChangeEventObservable
 
   @Override protected void subscribeActual(
       Observer<? super RecyclerViewChildAttachStateChangeEvent> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.addOnChildAttachStateChangeListener(listener);

--- a/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RecyclerViewChildAttachStateChangeEventObservable.java
+++ b/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RecyclerViewChildAttachStateChangeEventObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class RecyclerViewChildAttachStateChangeEventObservable
     extends Observable<RecyclerViewChildAttachStateChangeEvent> {
@@ -19,7 +19,7 @@ final class RecyclerViewChildAttachStateChangeEventObservable
 
   @Override protected void subscribeActual(
       Observer<? super RecyclerViewChildAttachStateChangeEvent> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RecyclerViewScrollEventObservable.java
+++ b/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RecyclerViewScrollEventObservable.java
@@ -5,7 +5,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class RecyclerViewScrollEventObservable extends Observable<RecyclerViewScrollEvent> {
   private final RecyclerView view;
@@ -15,7 +15,9 @@ final class RecyclerViewScrollEventObservable extends Observable<RecyclerViewScr
   }
 
   @Override protected void subscribeActual(Observer<? super RecyclerViewScrollEvent> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.addOnScrollListener(listener.scrollListener);

--- a/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RecyclerViewScrollEventObservable.java
+++ b/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RecyclerViewScrollEventObservable.java
@@ -5,7 +5,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class RecyclerViewScrollEventObservable extends Observable<RecyclerViewScrollEvent> {
   private final RecyclerView view;
@@ -15,7 +15,7 @@ final class RecyclerViewScrollEventObservable extends Observable<RecyclerViewScr
   }
 
   @Override protected void subscribeActual(Observer<? super RecyclerViewScrollEvent> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RecyclerViewScrollStateChangeObservable.java
+++ b/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RecyclerViewScrollStateChangeObservable.java
@@ -5,7 +5,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class RecyclerViewScrollStateChangeObservable extends Observable<Integer> {
   private final RecyclerView view;
@@ -15,7 +15,7 @@ final class RecyclerViewScrollStateChangeObservable extends Observable<Integer> 
   }
 
   @Override protected void subscribeActual(Observer<? super Integer> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RecyclerViewScrollStateChangeObservable.java
+++ b/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RecyclerViewScrollStateChangeObservable.java
@@ -5,7 +5,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class RecyclerViewScrollStateChangeObservable extends Observable<Integer> {
   private final RecyclerView view;
@@ -15,7 +15,9 @@ final class RecyclerViewScrollStateChangeObservable extends Observable<Integer> 
   }
 
   @Override protected void subscribeActual(Observer<? super Integer> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.addOnScrollListener(listener.scrollListener);

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/MenuItemActionViewEventObservable.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/MenuItemActionViewEventObservable.java
@@ -10,7 +10,7 @@ import io.reactivex.android.MainThreadDisposable;
 import io.reactivex.functions.Predicate;
 
 import static android.support.v4.view.MenuItemCompat.setOnActionExpandListener;
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class MenuItemActionViewEventObservable extends Observable<MenuItemActionViewEvent> {
   private final MenuItem menuItem;
@@ -23,7 +23,9 @@ final class MenuItemActionViewEventObservable extends Observable<MenuItemActionV
   }
 
   @Override protected void subscribeActual(Observer<? super MenuItemActionViewEvent> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(menuItem, handled, observer);
     observer.onSubscribe(listener);
     setOnActionExpandListener(menuItem, listener);

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/MenuItemActionViewEventObservable.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/MenuItemActionViewEventObservable.java
@@ -10,7 +10,7 @@ import io.reactivex.android.MainThreadDisposable;
 import io.reactivex.functions.Predicate;
 
 import static android.support.v4.view.MenuItemCompat.setOnActionExpandListener;
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class MenuItemActionViewEventObservable extends Observable<MenuItemActionViewEvent> {
   private final MenuItem menuItem;
@@ -23,7 +23,7 @@ final class MenuItemActionViewEventObservable extends Observable<MenuItemActionV
   }
 
   @Override protected void subscribeActual(Observer<? super MenuItemActionViewEvent> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(menuItem, handled, observer);

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/ViewPagerPageScrollStateChangedObservable.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/ViewPagerPageScrollStateChangedObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class ViewPagerPageScrollStateChangedObservable extends Observable<Integer> {
   private final ViewPager view;
@@ -16,7 +16,7 @@ final class ViewPagerPageScrollStateChangedObservable extends Observable<Integer
   }
 
   @Override protected void subscribeActual(Observer<? super Integer> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/ViewPagerPageScrollStateChangedObservable.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/ViewPagerPageScrollStateChangedObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class ViewPagerPageScrollStateChangedObservable extends Observable<Integer> {
   private final ViewPager view;
@@ -16,7 +16,9 @@ final class ViewPagerPageScrollStateChangedObservable extends Observable<Integer
   }
 
   @Override protected void subscribeActual(Observer<? super Integer> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.addOnPageChangeListener(listener);

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/ViewPagerPageSelectedObservable.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/ViewPagerPageSelectedObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class ViewPagerPageSelectedObservable extends Observable<Integer> {
   private final ViewPager view;
@@ -16,7 +16,9 @@ final class ViewPagerPageSelectedObservable extends Observable<Integer> {
   }
 
   @Override protected void subscribeActual(Observer<? super Integer> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.addOnPageChangeListener(listener);

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/ViewPagerPageSelectedObservable.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/ViewPagerPageSelectedObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class ViewPagerPageSelectedObservable extends Observable<Integer> {
   private final ViewPager view;
@@ -16,7 +16,7 @@ final class ViewPagerPageSelectedObservable extends Observable<Integer> {
   }
 
   @Override protected void subscribeActual(Observer<? super Integer> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/DrawerLayoutDrawerOpenedObservable.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/DrawerLayoutDrawerOpenedObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class DrawerLayoutDrawerOpenedObservable extends Observable<Boolean> {
   private final DrawerLayout view;
@@ -19,7 +19,7 @@ final class DrawerLayoutDrawerOpenedObservable extends Observable<Boolean> {
   }
 
   @Override protected void subscribeActual(Observer<? super Boolean> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, gravity, observer);

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/DrawerLayoutDrawerOpenedObservable.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/DrawerLayoutDrawerOpenedObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class DrawerLayoutDrawerOpenedObservable extends Observable<Boolean> {
   private final DrawerLayout view;
@@ -19,7 +19,9 @@ final class DrawerLayoutDrawerOpenedObservable extends Observable<Boolean> {
   }
 
   @Override protected void subscribeActual(Observer<? super Boolean> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, gravity, observer);
     observer.onSubscribe(listener);
     view.addDrawerListener(listener);

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/NestedScrollViewScrollChangeEventObservable.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/NestedScrollViewScrollChangeEventObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class NestedScrollViewScrollChangeEventObservable extends Observable<ViewScrollChangeEvent> {
   private final NestedScrollView view;
@@ -17,7 +17,9 @@ final class NestedScrollViewScrollChangeEventObservable extends Observable<ViewS
   }
 
   @Override protected void subscribeActual(Observer<? super ViewScrollChangeEvent> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setOnScrollChangeListener(listener);

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/NestedScrollViewScrollChangeEventObservable.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/NestedScrollViewScrollChangeEventObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class NestedScrollViewScrollChangeEventObservable extends Observable<ViewScrollChangeEvent> {
   private final NestedScrollView view;
@@ -17,7 +17,7 @@ final class NestedScrollViewScrollChangeEventObservable extends Observable<ViewS
   }
 
   @Override protected void subscribeActual(Observer<? super ViewScrollChangeEvent> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/SlidingPaneLayoutPaneOpenedObservable.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/SlidingPaneLayoutPaneOpenedObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class SlidingPaneLayoutPaneOpenedObservable extends Observable<Boolean> {
   private final SlidingPaneLayout view;
@@ -17,7 +17,7 @@ final class SlidingPaneLayoutPaneOpenedObservable extends Observable<Boolean> {
   }
 
   @Override protected void subscribeActual(Observer<? super Boolean> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/SlidingPaneLayoutPaneOpenedObservable.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/SlidingPaneLayoutPaneOpenedObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class SlidingPaneLayoutPaneOpenedObservable extends Observable<Boolean> {
   private final SlidingPaneLayout view;
@@ -17,7 +17,9 @@ final class SlidingPaneLayoutPaneOpenedObservable extends Observable<Boolean> {
   }
 
   @Override protected void subscribeActual(Observer<? super Boolean> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setPanelSlideListener(listener);

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/SlidingPaneLayoutSlideObservable.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/SlidingPaneLayoutSlideObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class SlidingPaneLayoutSlideObservable extends Observable<Float> {
   private final SlidingPaneLayout view;
@@ -16,7 +16,9 @@ final class SlidingPaneLayoutSlideObservable extends Observable<Float> {
   }
 
   @Override protected void subscribeActual(Observer<? super Float> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setPanelSlideListener(listener);

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/SlidingPaneLayoutSlideObservable.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/SlidingPaneLayoutSlideObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class SlidingPaneLayoutSlideObservable extends Observable<Float> {
   private final SlidingPaneLayout view;
@@ -16,7 +16,7 @@ final class SlidingPaneLayoutSlideObservable extends Observable<Float> {
   }
 
   @Override protected void subscribeActual(Observer<? super Float> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/SwipeRefreshLayoutRefreshObservable.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/SwipeRefreshLayoutRefreshObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class SwipeRefreshLayoutRefreshObservable extends Observable<Object> {
   private final SwipeRefreshLayout view;
@@ -17,7 +17,9 @@ final class SwipeRefreshLayoutRefreshObservable extends Observable<Object> {
   }
 
   @Override protected void subscribeActual(Observer<? super Object> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setOnRefreshListener(listener);

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/SwipeRefreshLayoutRefreshObservable.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/SwipeRefreshLayoutRefreshObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class SwipeRefreshLayoutRefreshObservable extends Observable<Object> {
   private final SwipeRefreshLayout view;
@@ -17,7 +17,7 @@ final class SwipeRefreshLayoutRefreshObservable extends Observable<Object> {
   }
 
   @Override protected void subscribeActual(Observer<? super Object> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/internal/Preconditions.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/internal/Preconditions.java
@@ -30,13 +30,13 @@ public final class Preconditions {
     return value;
   }
 
-  public static boolean isNotOnMainThread(Observer<?> observer) {
+  public static boolean checkMainThread(Observer<?> observer) {
     if (Looper.myLooper() != Looper.getMainLooper()) {
       observer.onError(new IllegalStateException(
           "Expected to be called on the main thread but was " + Thread.currentThread().getName()));
-      return true;
+      return false;
     }
-    return false;
+    return true;
   }
 
   private Preconditions() {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/internal/Preconditions.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/internal/Preconditions.java
@@ -13,6 +13,9 @@
  */
 package com.jakewharton.rxbinding2.internal;
 
+import android.os.Looper;
+import io.reactivex.Observer;
+
 public final class Preconditions {
   public static void checkArgument(boolean assertion, String message) {
     if (!assertion) {
@@ -25,6 +28,15 @@ public final class Preconditions {
       throw new NullPointerException(message);
     }
     return value;
+  }
+
+  public static boolean isNotOnMainThread(Observer<?> observer) {
+    if (Looper.myLooper() != Looper.getMainLooper()) {
+      observer.onError(new IllegalStateException(
+          "Expected to be called on the main thread but was " + Thread.currentThread().getName()));
+      return true;
+    }
+    return false;
   }
 
   private Preconditions() {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/MenuItemActionViewEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/MenuItemActionViewEventObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 import io.reactivex.functions.Predicate;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class MenuItemActionViewEventObservable extends Observable<MenuItemActionViewEvent> {
   private final MenuItem menuItem;
@@ -21,7 +21,9 @@ final class MenuItemActionViewEventObservable extends Observable<MenuItemActionV
   }
 
   @Override protected void subscribeActual(Observer<? super MenuItemActionViewEvent> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(menuItem, handled, observer);
     observer.onSubscribe(listener);
     menuItem.setOnActionExpandListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/MenuItemActionViewEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/MenuItemActionViewEventObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 import io.reactivex.functions.Predicate;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class MenuItemActionViewEventObservable extends Observable<MenuItemActionViewEvent> {
   private final MenuItem menuItem;
@@ -21,7 +21,7 @@ final class MenuItemActionViewEventObservable extends Observable<MenuItemActionV
   }
 
   @Override protected void subscribeActual(Observer<? super MenuItemActionViewEvent> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(menuItem, handled, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/MenuItemClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/MenuItemClickOnSubscribe.java
@@ -8,7 +8,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 import io.reactivex.functions.Predicate;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class MenuItemClickOnSubscribe extends Observable<Object> {
   private final MenuItem menuItem;
@@ -20,7 +20,7 @@ final class MenuItemClickOnSubscribe extends Observable<Object> {
   }
 
   @Override protected void subscribeActual(Observer<? super Object> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(menuItem, handled, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/MenuItemClickOnSubscribe.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/MenuItemClickOnSubscribe.java
@@ -8,7 +8,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 import io.reactivex.functions.Predicate;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class MenuItemClickOnSubscribe extends Observable<Object> {
   private final MenuItem menuItem;
@@ -20,7 +20,9 @@ final class MenuItemClickOnSubscribe extends Observable<Object> {
   }
 
   @Override protected void subscribeActual(Observer<? super Object> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(menuItem, handled, observer);
     observer.onSubscribe(listener);
     menuItem.setOnMenuItemClickListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewAttachEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewAttachEventObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 import static com.jakewharton.rxbinding2.view.ViewAttachEvent.Kind.ATTACH;
 import static com.jakewharton.rxbinding2.view.ViewAttachEvent.Kind.DETACH;
 
@@ -18,7 +18,7 @@ final class ViewAttachEventObservable extends Observable<ViewAttachEvent> {
   }
 
   @Override protected void subscribeActual(Observer<? super ViewAttachEvent> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewAttachEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewAttachEventObservable.java
@@ -6,9 +6,9 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 import static com.jakewharton.rxbinding2.view.ViewAttachEvent.Kind.ATTACH;
 import static com.jakewharton.rxbinding2.view.ViewAttachEvent.Kind.DETACH;
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
 
 final class ViewAttachEventObservable extends Observable<ViewAttachEvent> {
   private final View view;
@@ -18,7 +18,9 @@ final class ViewAttachEventObservable extends Observable<ViewAttachEvent> {
   }
 
   @Override protected void subscribeActual(Observer<? super ViewAttachEvent> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.addOnAttachStateChangeListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewAttachesObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewAttachesObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class ViewAttachesObservable extends Observable<Object> {
   private final boolean callOnAttach;
@@ -19,7 +19,7 @@ final class ViewAttachesObservable extends Observable<Object> {
   }
 
   @Override protected void subscribeActual(final Observer<? super Object> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, callOnAttach, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewAttachesObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewAttachesObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class ViewAttachesObservable extends Observable<Object> {
   private final boolean callOnAttach;
@@ -19,7 +19,9 @@ final class ViewAttachesObservable extends Observable<Object> {
   }
 
   @Override protected void subscribeActual(final Observer<? super Object> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, callOnAttach, observer);
     observer.onSubscribe(listener);
     view.addOnAttachStateChangeListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewClickObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewClickObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class ViewClickObservable extends Observable<Object> {
   private final View view;
@@ -17,7 +17,9 @@ final class ViewClickObservable extends Observable<Object> {
   }
 
   @Override protected void subscribeActual(Observer<? super Object> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setOnClickListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewClickObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewClickObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class ViewClickObservable extends Observable<Object> {
   private final View view;
@@ -17,7 +17,7 @@ final class ViewClickObservable extends Observable<Object> {
   }
 
   @Override protected void subscribeActual(Observer<? super Object> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewDragObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewDragObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 import io.reactivex.functions.Predicate;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class ViewDragObservable extends Observable<DragEvent> {
   private final View view;
@@ -20,7 +20,9 @@ final class ViewDragObservable extends Observable<DragEvent> {
   }
 
   @Override protected void subscribeActual(Observer<? super DragEvent> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, handled, observer);
     observer.onSubscribe(listener);
     view.setOnDragListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewDragObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewDragObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 import io.reactivex.functions.Predicate;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class ViewDragObservable extends Observable<DragEvent> {
   private final View view;
@@ -20,7 +20,7 @@ final class ViewDragObservable extends Observable<DragEvent> {
   }
 
   @Override protected void subscribeActual(Observer<? super DragEvent> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, handled, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewFocusChangeObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewFocusChangeObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class ViewFocusChangeObservable extends Observable<Boolean> {
   private final View view;
@@ -16,7 +16,7 @@ final class ViewFocusChangeObservable extends Observable<Boolean> {
   }
 
   @Override protected void subscribeActual(Observer<? super Boolean> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewFocusChangeObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewFocusChangeObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class ViewFocusChangeObservable extends Observable<Boolean> {
   private final View view;
@@ -16,7 +16,9 @@ final class ViewFocusChangeObservable extends Observable<Boolean> {
   }
 
   @Override protected void subscribeActual(Observer<? super Boolean> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setOnFocusChangeListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewGroupHierarchyChangeEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewGroupHierarchyChangeEventObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class ViewGroupHierarchyChangeEventObservable
     extends Observable<ViewGroupHierarchyChangeEvent> {
@@ -19,7 +19,9 @@ final class ViewGroupHierarchyChangeEventObservable
 
   @Override
   protected void subscribeActual(Observer<? super ViewGroupHierarchyChangeEvent> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(viewGroup, observer);
     observer.onSubscribe(listener);
     viewGroup.setOnHierarchyChangeListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewGroupHierarchyChangeEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewGroupHierarchyChangeEventObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class ViewGroupHierarchyChangeEventObservable
     extends Observable<ViewGroupHierarchyChangeEvent> {
@@ -19,7 +19,7 @@ final class ViewGroupHierarchyChangeEventObservable
 
   @Override
   protected void subscribeActual(Observer<? super ViewGroupHierarchyChangeEvent> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(viewGroup, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewHoverObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewHoverObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 import io.reactivex.functions.Predicate;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class ViewHoverObservable extends Observable<MotionEvent> {
   private final View view;
@@ -20,7 +20,7 @@ final class ViewHoverObservable extends Observable<MotionEvent> {
   }
 
   @Override protected void subscribeActual(Observer<? super MotionEvent> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, handled, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewHoverObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewHoverObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 import io.reactivex.functions.Predicate;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class ViewHoverObservable extends Observable<MotionEvent> {
   private final View view;
@@ -20,7 +20,9 @@ final class ViewHoverObservable extends Observable<MotionEvent> {
   }
 
   @Override protected void subscribeActual(Observer<? super MotionEvent> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, handled, observer);
     observer.onSubscribe(listener);
     view.setOnHoverListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewKeyObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewKeyObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 import io.reactivex.functions.Predicate;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class ViewKeyObservable extends Observable<KeyEvent> {
   private final View view;
@@ -20,7 +20,9 @@ final class ViewKeyObservable extends Observable<KeyEvent> {
   }
 
   @Override protected void subscribeActual(Observer<? super KeyEvent> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, handled, observer);
     observer.onSubscribe(listener);
     view.setOnKeyListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewKeyObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewKeyObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 import io.reactivex.functions.Predicate;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class ViewKeyObservable extends Observable<KeyEvent> {
   private final View view;
@@ -20,7 +20,7 @@ final class ViewKeyObservable extends Observable<KeyEvent> {
   }
 
   @Override protected void subscribeActual(Observer<? super KeyEvent> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, handled, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewLayoutChangeEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewLayoutChangeEventObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class ViewLayoutChangeEventObservable extends Observable<ViewLayoutChangeEvent> {
   private final View view;
@@ -16,7 +16,7 @@ final class ViewLayoutChangeEventObservable extends Observable<ViewLayoutChangeE
   }
 
   @Override protected void subscribeActual(Observer<? super ViewLayoutChangeEvent> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewLayoutChangeEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewLayoutChangeEventObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class ViewLayoutChangeEventObservable extends Observable<ViewLayoutChangeEvent> {
   private final View view;
@@ -16,7 +16,9 @@ final class ViewLayoutChangeEventObservable extends Observable<ViewLayoutChangeE
   }
 
   @Override protected void subscribeActual(Observer<? super ViewLayoutChangeEvent> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.addOnLayoutChangeListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewLayoutChangeObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewLayoutChangeObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class ViewLayoutChangeObservable extends Observable<Object> {
   private final View view;
@@ -17,7 +17,7 @@ final class ViewLayoutChangeObservable extends Observable<Object> {
   }
 
   @Override protected void subscribeActual(Observer<? super Object> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewLayoutChangeObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewLayoutChangeObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class ViewLayoutChangeObservable extends Observable<Object> {
   private final View view;
@@ -17,7 +17,9 @@ final class ViewLayoutChangeObservable extends Observable<Object> {
   }
 
   @Override protected void subscribeActual(Observer<? super Object> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.addOnLayoutChangeListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewLongClickObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewLongClickObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 import java.util.concurrent.Callable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class ViewLongClickObservable extends Observable<Object> {
   private final View view;
@@ -20,7 +20,7 @@ final class ViewLongClickObservable extends Observable<Object> {
   }
 
   @Override protected void subscribeActual(Observer<? super Object> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, handled, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewLongClickObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewLongClickObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 import java.util.concurrent.Callable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class ViewLongClickObservable extends Observable<Object> {
   private final View view;
@@ -20,7 +20,9 @@ final class ViewLongClickObservable extends Observable<Object> {
   }
 
   @Override protected void subscribeActual(Observer<? super Object> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, handled, observer);
     observer.onSubscribe(listener);
     view.setOnLongClickListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewScrollChangeEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewScrollChangeEventObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
 import static android.os.Build.VERSION_CODES.M;
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 @RequiresApi(M)
 final class ViewScrollChangeEventObservable extends Observable<ViewScrollChangeEvent> {
@@ -19,7 +19,7 @@ final class ViewScrollChangeEventObservable extends Observable<ViewScrollChangeE
   }
 
   @Override protected void subscribeActual(Observer<? super ViewScrollChangeEvent> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewScrollChangeEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewScrollChangeEventObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
 import static android.os.Build.VERSION_CODES.M;
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 @RequiresApi(M)
 final class ViewScrollChangeEventObservable extends Observable<ViewScrollChangeEvent> {
@@ -19,7 +19,9 @@ final class ViewScrollChangeEventObservable extends Observable<ViewScrollChangeE
   }
 
   @Override protected void subscribeActual(Observer<? super ViewScrollChangeEvent> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setOnScrollChangeListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewSystemUiVisibilityChangeObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewSystemUiVisibilityChangeObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class ViewSystemUiVisibilityChangeObservable extends Observable<Integer> {
   private final View view;
@@ -16,7 +16,9 @@ final class ViewSystemUiVisibilityChangeObservable extends Observable<Integer> {
   }
 
   @Override protected void subscribeActual(Observer<? super Integer> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setOnSystemUiVisibilityChangeListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewSystemUiVisibilityChangeObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewSystemUiVisibilityChangeObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class ViewSystemUiVisibilityChangeObservable extends Observable<Integer> {
   private final View view;
@@ -16,7 +16,7 @@ final class ViewSystemUiVisibilityChangeObservable extends Observable<Integer> {
   }
 
   @Override protected void subscribeActual(Observer<? super Integer> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewTouchObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewTouchObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 import io.reactivex.functions.Predicate;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class ViewTouchObservable extends Observable<MotionEvent> {
   private final View view;
@@ -20,7 +20,7 @@ final class ViewTouchObservable extends Observable<MotionEvent> {
   }
 
   @Override protected void subscribeActual(Observer<? super MotionEvent> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, handled, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewTouchObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewTouchObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 import io.reactivex.functions.Predicate;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class ViewTouchObservable extends Observable<MotionEvent> {
   private final View view;
@@ -20,7 +20,9 @@ final class ViewTouchObservable extends Observable<MotionEvent> {
   }
 
   @Override protected void subscribeActual(Observer<? super MotionEvent> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, handled, observer);
     observer.onSubscribe(listener);
     view.setOnTouchListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewTreeObserverDrawObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewTreeObserverDrawObservable.java
@@ -9,7 +9,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
 import static android.os.Build.VERSION_CODES.JELLY_BEAN;
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 @RequiresApi(JELLY_BEAN)
 final class ViewTreeObserverDrawObservable extends Observable<Object> {
@@ -20,10 +20,13 @@ final class ViewTreeObserverDrawObservable extends Observable<Object> {
   }
 
   @Override protected void subscribeActual(Observer<? super Object> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
-    view.getViewTreeObserver().addOnDrawListener(listener);
+    view.getViewTreeObserver()
+        .addOnDrawListener(listener);
   }
 
   static final class Listener extends MainThreadDisposable implements OnDrawListener {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewTreeObserverDrawObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewTreeObserverDrawObservable.java
@@ -9,7 +9,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
 import static android.os.Build.VERSION_CODES.JELLY_BEAN;
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 @RequiresApi(JELLY_BEAN)
 final class ViewTreeObserverDrawObservable extends Observable<Object> {
@@ -20,7 +20,7 @@ final class ViewTreeObserverDrawObservable extends Observable<Object> {
   }
 
   @Override protected void subscribeActual(Observer<? super Object> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewTreeObserverGlobalLayoutObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewTreeObserverGlobalLayoutObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class ViewTreeObserverGlobalLayoutObservable extends Observable<Object> {
   private final View view;
@@ -17,10 +17,13 @@ final class ViewTreeObserverGlobalLayoutObservable extends Observable<Object> {
   }
 
   @Override protected void subscribeActual(Observer<? super Object> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
-    view.getViewTreeObserver().addOnGlobalLayoutListener(listener);
+    view.getViewTreeObserver()
+        .addOnGlobalLayoutListener(listener);
   }
 
   static final class Listener extends MainThreadDisposable implements OnGlobalLayoutListener {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewTreeObserverGlobalLayoutObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewTreeObserverGlobalLayoutObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class ViewTreeObserverGlobalLayoutObservable extends Observable<Object> {
   private final View view;
@@ -17,7 +17,7 @@ final class ViewTreeObserverGlobalLayoutObservable extends Observable<Object> {
   }
 
   @Override protected void subscribeActual(Observer<? super Object> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewTreeObserverPreDrawObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewTreeObserverPreDrawObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 import java.util.concurrent.Callable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class ViewTreeObserverPreDrawObservable extends Observable<Object> {
   private final View view;
@@ -20,7 +20,7 @@ final class ViewTreeObserverPreDrawObservable extends Observable<Object> {
   }
 
   @Override protected void subscribeActual(Observer<? super Object> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, proceedDrawingPass, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewTreeObserverPreDrawObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewTreeObserverPreDrawObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 import java.util.concurrent.Callable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class ViewTreeObserverPreDrawObservable extends Observable<Object> {
   private final View view;
@@ -20,10 +20,13 @@ final class ViewTreeObserverPreDrawObservable extends Observable<Object> {
   }
 
   @Override protected void subscribeActual(Observer<? super Object> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, proceedDrawingPass, observer);
     observer.onSubscribe(listener);
-    view.getViewTreeObserver().addOnPreDrawListener(listener);
+    view.getViewTreeObserver()
+        .addOnPreDrawListener(listener);
   }
 
   static final class Listener extends MainThreadDisposable implements OnPreDrawListener {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AbsListViewScrollEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AbsListViewScrollEventObservable.java
@@ -5,7 +5,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class AbsListViewScrollEventObservable extends Observable<AbsListViewScrollEvent> {
   private final AbsListView view;
@@ -15,7 +15,7 @@ final class AbsListViewScrollEventObservable extends Observable<AbsListViewScrol
   }
 
   @Override protected void subscribeActual(Observer<? super AbsListViewScrollEvent> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AbsListViewScrollEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AbsListViewScrollEventObservable.java
@@ -5,7 +5,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class AbsListViewScrollEventObservable extends Observable<AbsListViewScrollEvent> {
   private final AbsListView view;
@@ -15,7 +15,9 @@ final class AbsListViewScrollEventObservable extends Observable<AbsListViewScrol
   }
 
   @Override protected void subscribeActual(Observer<? super AbsListViewScrollEvent> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setOnScrollListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterDataChangeObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterDataChangeObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class AdapterDataChangeObservable<T extends Adapter> extends Observable<T> {
   private final T adapter;
@@ -16,7 +16,7 @@ final class AdapterDataChangeObservable<T extends Adapter> extends Observable<T>
   }
 
   @Override protected void subscribeActual(Observer<? super T> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     ObserverDisposable<T> disposableDataSetObserver = new ObserverDisposable<>(adapter, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterDataChangeObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterDataChangeObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class AdapterDataChangeObservable<T extends Adapter> extends Observable<T> {
   private final T adapter;
@@ -16,7 +16,9 @@ final class AdapterDataChangeObservable<T extends Adapter> extends Observable<T>
   }
 
   @Override protected void subscribeActual(Observer<? super T> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     ObserverDisposable<T> disposableDataSetObserver = new ObserverDisposable<>(adapter, observer);
     adapter.registerDataSetObserver(disposableDataSetObserver.dataSetObserver);
     observer.onSubscribe(disposableDataSetObserver);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterViewItemClickEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterViewItemClickEventObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class AdapterViewItemClickEventObservable extends Observable<AdapterViewItemClickEvent> {
   private final AdapterView<?> view;
@@ -17,7 +17,9 @@ final class AdapterViewItemClickEventObservable extends Observable<AdapterViewIt
   }
 
   @Override protected void subscribeActual(Observer<? super AdapterViewItemClickEvent> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setOnItemClickListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterViewItemClickEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterViewItemClickEventObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class AdapterViewItemClickEventObservable extends Observable<AdapterViewItemClickEvent> {
   private final AdapterView<?> view;
@@ -17,7 +17,7 @@ final class AdapterViewItemClickEventObservable extends Observable<AdapterViewIt
   }
 
   @Override protected void subscribeActual(Observer<? super AdapterViewItemClickEvent> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterViewItemClickObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterViewItemClickObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class AdapterViewItemClickObservable extends Observable<Integer> {
   private final AdapterView<?> view;
@@ -17,7 +17,9 @@ final class AdapterViewItemClickObservable extends Observable<Integer> {
   }
 
   @Override protected void subscribeActual(Observer<? super Integer> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setOnItemClickListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterViewItemClickObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterViewItemClickObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class AdapterViewItemClickObservable extends Observable<Integer> {
   private final AdapterView<?> view;
@@ -17,7 +17,7 @@ final class AdapterViewItemClickObservable extends Observable<Integer> {
   }
 
   @Override protected void subscribeActual(Observer<? super Integer> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterViewItemLongClickEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterViewItemLongClickEventObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 import io.reactivex.functions.Predicate;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class AdapterViewItemLongClickEventObservable
     extends Observable<AdapterViewItemLongClickEvent> {
@@ -23,7 +23,7 @@ final class AdapterViewItemLongClickEventObservable
 
   @Override
   protected void subscribeActual(Observer<? super AdapterViewItemLongClickEvent> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer, handled);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterViewItemLongClickEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterViewItemLongClickEventObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 import io.reactivex.functions.Predicate;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class AdapterViewItemLongClickEventObservable
     extends Observable<AdapterViewItemLongClickEvent> {
@@ -23,7 +23,9 @@ final class AdapterViewItemLongClickEventObservable
 
   @Override
   protected void subscribeActual(Observer<? super AdapterViewItemLongClickEvent> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer, handled);
     observer.onSubscribe(listener);
     view.setOnItemLongClickListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterViewItemLongClickObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterViewItemLongClickObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 import java.util.concurrent.Callable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class AdapterViewItemLongClickObservable extends Observable<Integer> {
   private final AdapterView<?> view;
@@ -20,7 +20,7 @@ final class AdapterViewItemLongClickObservable extends Observable<Integer> {
   }
 
   @Override protected void subscribeActual(Observer<? super Integer> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer, handled);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterViewItemLongClickObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterViewItemLongClickObservable.java
@@ -3,12 +3,12 @@ package com.jakewharton.rxbinding2.widget;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemLongClickListener;
-import java.util.concurrent.Callable;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
+import java.util.concurrent.Callable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class AdapterViewItemLongClickObservable extends Observable<Integer> {
   private final AdapterView<?> view;
@@ -20,7 +20,9 @@ final class AdapterViewItemLongClickObservable extends Observable<Integer> {
   }
 
   @Override protected void subscribeActual(Observer<? super Integer> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer, handled);
     observer.onSubscribe(listener);
     view.setOnItemLongClickListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterViewItemSelectionObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterViewItemSelectionObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
 import static android.widget.AdapterView.INVALID_POSITION;
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class AdapterViewItemSelectionObservable extends Observable<Integer> {
   private final AdapterView<?> view;
@@ -18,7 +18,9 @@ final class AdapterViewItemSelectionObservable extends Observable<Integer> {
   }
 
   @Override protected void subscribeActual(Observer<? super Integer> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     view.setOnItemSelectedListener(listener);
     observer.onSubscribe(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterViewItemSelectionObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterViewItemSelectionObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
 import static android.widget.AdapterView.INVALID_POSITION;
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class AdapterViewItemSelectionObservable extends Observable<Integer> {
   private final AdapterView<?> view;
@@ -18,7 +18,7 @@ final class AdapterViewItemSelectionObservable extends Observable<Integer> {
   }
 
   @Override protected void subscribeActual(Observer<? super Integer> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterViewSelectionObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterViewSelectionObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
 import static android.widget.AdapterView.INVALID_POSITION;
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class AdapterViewSelectionObservable extends Observable<AdapterViewSelectionEvent> {
   private final AdapterView<?> view;
@@ -18,7 +18,9 @@ final class AdapterViewSelectionObservable extends Observable<AdapterViewSelecti
   }
 
   @Override protected void subscribeActual(Observer<? super AdapterViewSelectionEvent> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     view.setOnItemSelectedListener(listener);
     observer.onSubscribe(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterViewSelectionObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterViewSelectionObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
 import static android.widget.AdapterView.INVALID_POSITION;
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class AdapterViewSelectionObservable extends Observable<AdapterViewSelectionEvent> {
   private final AdapterView<?> view;
@@ -18,7 +18,7 @@ final class AdapterViewSelectionObservable extends Observable<AdapterViewSelecti
   }
 
   @Override protected void subscribeActual(Observer<? super AdapterViewSelectionEvent> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AutoCompleteTextViewItemClickEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AutoCompleteTextViewItemClickEventObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class AutoCompleteTextViewItemClickEventObservable
     extends Observable<AdapterViewItemClickEvent> {
@@ -19,7 +19,9 @@ final class AutoCompleteTextViewItemClickEventObservable
   }
 
   @Override protected void subscribeActual(Observer<? super AdapterViewItemClickEvent> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setOnItemClickListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AutoCompleteTextViewItemClickEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AutoCompleteTextViewItemClickEventObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class AutoCompleteTextViewItemClickEventObservable
     extends Observable<AdapterViewItemClickEvent> {
@@ -19,7 +19,7 @@ final class AutoCompleteTextViewItemClickEventObservable
   }
 
   @Override protected void subscribeActual(Observer<? super AdapterViewItemClickEvent> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/CompoundButtonCheckedChangeObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/CompoundButtonCheckedChangeObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class CompoundButtonCheckedChangeObservable extends Observable<Boolean> {
 
@@ -18,7 +18,7 @@ final class CompoundButtonCheckedChangeObservable extends Observable<Boolean> {
 
   @Override
   protected void subscribeActual(Observer<? super Boolean> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/CompoundButtonCheckedChangeObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/CompoundButtonCheckedChangeObservable.java
@@ -1,13 +1,12 @@
 package com.jakewharton.rxbinding2.widget;
 
 import android.widget.CompoundButton;
-
 import android.widget.CompoundButton.OnCheckedChangeListener;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class CompoundButtonCheckedChangeObservable extends Observable<Boolean> {
 
@@ -19,7 +18,9 @@ final class CompoundButtonCheckedChangeObservable extends Observable<Boolean> {
 
   @Override
   protected void subscribeActual(Observer<? super Boolean> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setOnCheckedChangeListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/PopupMenuDismissObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/PopupMenuDismissObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class PopupMenuDismissObservable extends Observable<Object> {
   private final PopupMenu view;
@@ -16,7 +16,7 @@ final class PopupMenuDismissObservable extends Observable<Object> {
   }
 
   @Override protected void subscribeActual(Observer<? super Object> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/PopupMenuDismissObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/PopupMenuDismissObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class PopupMenuDismissObservable extends Observable<Object> {
   private final PopupMenu view;
@@ -16,7 +16,9 @@ final class PopupMenuDismissObservable extends Observable<Object> {
   }
 
   @Override protected void subscribeActual(Observer<? super Object> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     view.setOnDismissListener(listener);
     observer.onSubscribe(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/PopupMenuItemClickObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/PopupMenuItemClickObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class PopupMenuItemClickObservable extends Observable<MenuItem> {
   private final PopupMenu view;
@@ -17,7 +17,7 @@ final class PopupMenuItemClickObservable extends Observable<MenuItem> {
   }
 
   @Override protected void subscribeActual(Observer<? super MenuItem> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/PopupMenuItemClickObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/PopupMenuItemClickObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class PopupMenuItemClickObservable extends Observable<MenuItem> {
   private final PopupMenu view;
@@ -17,7 +17,9 @@ final class PopupMenuItemClickObservable extends Observable<MenuItem> {
   }
 
   @Override protected void subscribeActual(Observer<? super MenuItem> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     view.setOnMenuItemClickListener(listener);
     observer.onSubscribe(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RadioGroupCheckedChangeObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RadioGroupCheckedChangeObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class RadioGroupCheckedChangeObservable extends Observable<Integer> {
   private final RadioGroup view;
@@ -16,7 +16,7 @@ final class RadioGroupCheckedChangeObservable extends Observable<Integer> {
   }
 
   @Override protected void subscribeActual(Observer<? super Integer> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RadioGroupCheckedChangeObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RadioGroupCheckedChangeObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class RadioGroupCheckedChangeObservable extends Observable<Integer> {
   private final RadioGroup view;
@@ -16,7 +16,9 @@ final class RadioGroupCheckedChangeObservable extends Observable<Integer> {
   }
 
   @Override protected void subscribeActual(Observer<? super Integer> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     view.setOnCheckedChangeListener(listener);
     observer.onSubscribe(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RatingBarRatingChangeEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RatingBarRatingChangeEventObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class RatingBarRatingChangeEventObservable extends Observable<RatingBarChangeEvent> {
   private final RatingBar view;
@@ -16,7 +16,9 @@ final class RatingBarRatingChangeEventObservable extends Observable<RatingBarCha
   }
 
   @Override protected void subscribeActual(Observer<? super RatingBarChangeEvent> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     view.setOnRatingBarChangeListener(listener);
     observer.onSubscribe(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RatingBarRatingChangeEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RatingBarRatingChangeEventObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class RatingBarRatingChangeEventObservable extends Observable<RatingBarChangeEvent> {
   private final RatingBar view;
@@ -16,7 +16,7 @@ final class RatingBarRatingChangeEventObservable extends Observable<RatingBarCha
   }
 
   @Override protected void subscribeActual(Observer<? super RatingBarChangeEvent> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RatingBarRatingChangeObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RatingBarRatingChangeObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class RatingBarRatingChangeObservable extends Observable<Float> {
   private final RatingBar view;
@@ -16,7 +16,7 @@ final class RatingBarRatingChangeObservable extends Observable<Float> {
   }
 
   @Override protected void subscribeActual(Observer<? super Float> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RatingBarRatingChangeObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RatingBarRatingChangeObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class RatingBarRatingChangeObservable extends Observable<Float> {
   private final RatingBar view;
@@ -16,7 +16,9 @@ final class RatingBarRatingChangeObservable extends Observable<Float> {
   }
 
   @Override protected void subscribeActual(Observer<? super Float> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     view.setOnRatingBarChangeListener(listener);
     observer.onSubscribe(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/SearchViewQueryTextChangeEventsObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/SearchViewQueryTextChangeEventsObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class SearchViewQueryTextChangeEventsObservable extends Observable<SearchViewQueryTextEvent> {
   private final SearchView view;
@@ -16,7 +16,9 @@ final class SearchViewQueryTextChangeEventsObservable extends Observable<SearchV
   }
 
   @Override protected void subscribeActual(Observer<? super SearchViewQueryTextEvent> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     view.setOnQueryTextListener(listener);
     observer.onSubscribe(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/SearchViewQueryTextChangeEventsObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/SearchViewQueryTextChangeEventsObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class SearchViewQueryTextChangeEventsObservable extends Observable<SearchViewQueryTextEvent> {
   private final SearchView view;
@@ -16,7 +16,7 @@ final class SearchViewQueryTextChangeEventsObservable extends Observable<SearchV
   }
 
   @Override protected void subscribeActual(Observer<? super SearchViewQueryTextEvent> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/SearchViewQueryTextChangesObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/SearchViewQueryTextChangesObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class SearchViewQueryTextChangesObservable extends Observable<CharSequence> {
   private final SearchView view;
@@ -16,7 +16,9 @@ final class SearchViewQueryTextChangesObservable extends Observable<CharSequence
   }
 
   @Override protected void subscribeActual(Observer<? super CharSequence> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     view.setOnQueryTextListener(listener);
     observer.onSubscribe(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/SearchViewQueryTextChangesObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/SearchViewQueryTextChangesObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class SearchViewQueryTextChangesObservable extends Observable<CharSequence> {
   private final SearchView view;
@@ -16,7 +16,7 @@ final class SearchViewQueryTextChangesObservable extends Observable<CharSequence
   }
 
   @Override protected void subscribeActual(Observer<? super CharSequence> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/SeekBarChangeEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/SeekBarChangeEventObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class SeekBarChangeEventObservable extends Observable<SeekBarChangeEvent> {
   private final SeekBar view;
@@ -16,7 +16,9 @@ final class SeekBarChangeEventObservable extends Observable<SeekBarChangeEvent> 
   }
 
   @Override protected void subscribeActual(Observer<? super SeekBarChangeEvent> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     view.setOnSeekBarChangeListener(listener);
     observer.onSubscribe(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/SeekBarChangeEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/SeekBarChangeEventObservable.java
@@ -6,7 +6,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class SeekBarChangeEventObservable extends Observable<SeekBarChangeEvent> {
   private final SeekBar view;
@@ -16,7 +16,7 @@ final class SeekBarChangeEventObservable extends Observable<SeekBarChangeEvent> 
   }
 
   @Override protected void subscribeActual(Observer<? super SeekBarChangeEvent> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/SeekBarChangeObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/SeekBarChangeObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class SeekBarChangeObservable extends Observable<Integer> {
   private final SeekBar view;
@@ -19,7 +19,9 @@ final class SeekBarChangeObservable extends Observable<Integer> {
   }
 
   @Override protected void subscribeActual(Observer<? super Integer> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, shouldBeFromUser, observer);
     view.setOnSeekBarChangeListener(listener);
     observer.onSubscribe(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/SeekBarChangeObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/SeekBarChangeObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class SeekBarChangeObservable extends Observable<Integer> {
   private final SeekBar view;
@@ -19,7 +19,7 @@ final class SeekBarChangeObservable extends Observable<Integer> {
   }
 
   @Override protected void subscribeActual(Observer<? super Integer> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, shouldBeFromUser, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewAfterTextChangeEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewAfterTextChangeEventObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class TextViewAfterTextChangeEventObservable
     extends Observable<TextViewAfterTextChangeEvent> {
@@ -19,7 +19,7 @@ final class TextViewAfterTextChangeEventObservable
 
   @Override
   protected void subscribeActual(Observer<? super TextViewAfterTextChangeEvent> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewAfterTextChangeEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewAfterTextChangeEventObservable.java
@@ -3,12 +3,11 @@ package com.jakewharton.rxbinding2.widget;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.widget.TextView;
-
 import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class TextViewAfterTextChangeEventObservable
     extends Observable<TextViewAfterTextChangeEvent> {
@@ -20,7 +19,9 @@ final class TextViewAfterTextChangeEventObservable
 
   @Override
   protected void subscribeActual(Observer<? super TextViewAfterTextChangeEvent> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.addTextChangedListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewBeforeTextChangeEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewBeforeTextChangeEventObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class TextViewBeforeTextChangeEventObservable
     extends Observable<TextViewBeforeTextChangeEvent> {
@@ -19,7 +19,7 @@ final class TextViewBeforeTextChangeEventObservable
 
   @Override
   protected void subscribeActual(Observer<? super TextViewBeforeTextChangeEvent> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewBeforeTextChangeEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewBeforeTextChangeEventObservable.java
@@ -3,12 +3,11 @@ package com.jakewharton.rxbinding2.widget;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.widget.TextView;
-
 import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class TextViewBeforeTextChangeEventObservable
     extends Observable<TextViewBeforeTextChangeEvent> {
@@ -20,7 +19,9 @@ final class TextViewBeforeTextChangeEventObservable
 
   @Override
   protected void subscribeActual(Observer<? super TextViewBeforeTextChangeEvent> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.addTextChangedListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewEditorActionEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewEditorActionEventObservable.java
@@ -2,14 +2,13 @@ package com.jakewharton.rxbinding2.widget;
 
 import android.view.KeyEvent;
 import android.widget.TextView;
-
 import android.widget.TextView.OnEditorActionListener;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 import io.reactivex.functions.Predicate;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class TextViewEditorActionEventObservable extends Observable<TextViewEditorActionEvent> {
   private final TextView view;
@@ -23,7 +22,9 @@ final class TextViewEditorActionEventObservable extends Observable<TextViewEdito
 
   @Override
   protected void subscribeActual(Observer<? super TextViewEditorActionEvent> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer, handled);
     observer.onSubscribe(listener);
     view.setOnEditorActionListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewEditorActionEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewEditorActionEventObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 import io.reactivex.functions.Predicate;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class TextViewEditorActionEventObservable extends Observable<TextViewEditorActionEvent> {
   private final TextView view;
@@ -22,7 +22,7 @@ final class TextViewEditorActionEventObservable extends Observable<TextViewEdito
 
   @Override
   protected void subscribeActual(Observer<? super TextViewEditorActionEvent> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer, handled);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewEditorActionObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewEditorActionObservable.java
@@ -2,14 +2,13 @@ package com.jakewharton.rxbinding2.widget;
 
 import android.view.KeyEvent;
 import android.widget.TextView;
-
 import android.widget.TextView.OnEditorActionListener;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 import io.reactivex.functions.Predicate;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class TextViewEditorActionObservable extends Observable<Integer> {
   private final TextView view;
@@ -22,7 +21,9 @@ final class TextViewEditorActionObservable extends Observable<Integer> {
 
   @Override
   protected void subscribeActual(Observer<? super Integer> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer, handled);
     observer.onSubscribe(listener);
     view.setOnEditorActionListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewEditorActionObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewEditorActionObservable.java
@@ -8,7 +8,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 import io.reactivex.functions.Predicate;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class TextViewEditorActionObservable extends Observable<Integer> {
   private final TextView view;
@@ -21,7 +21,7 @@ final class TextViewEditorActionObservable extends Observable<Integer> {
 
   @Override
   protected void subscribeActual(Observer<? super Integer> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer, handled);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewTextChangeEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewTextChangeEventObservable.java
@@ -3,12 +3,11 @@ package com.jakewharton.rxbinding2.widget;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.widget.TextView;
-
 import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class TextViewTextChangeEventObservable extends Observable<TextViewTextChangeEvent> {
   private final TextView view;
@@ -19,7 +18,9 @@ final class TextViewTextChangeEventObservable extends Observable<TextViewTextCha
 
   @Override
   protected void subscribeActual(Observer<? super TextViewTextChangeEvent> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.addTextChangedListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewTextChangeEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewTextChangeEventObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class TextViewTextChangeEventObservable extends Observable<TextViewTextChangeEvent> {
   private final TextView view;
@@ -18,7 +18,7 @@ final class TextViewTextChangeEventObservable extends Observable<TextViewTextCha
 
   @Override
   protected void subscribeActual(Observer<? super TextViewTextChangeEvent> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewTextObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewTextObservable.java
@@ -3,12 +3,11 @@ package com.jakewharton.rxbinding2.widget;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.widget.TextView;
-
 import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 final class TextViewTextObservable extends Observable<CharSequence> {
   private final TextView view;
@@ -19,7 +18,9 @@ final class TextViewTextObservable extends Observable<CharSequence> {
 
   @Override
   protected void subscribeActual(Observer<? super CharSequence> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.addTextChangedListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewTextObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewTextObservable.java
@@ -7,7 +7,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class TextViewTextObservable extends Observable<CharSequence> {
   private final TextView view;
@@ -18,7 +18,7 @@ final class TextViewTextObservable extends Observable<CharSequence> {
 
   @Override
   protected void subscribeActual(Observer<? super CharSequence> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/ToolbarItemClickObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/ToolbarItemClickObservable.java
@@ -9,7 +9,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 @RequiresApi(LOLLIPOP)
 final class ToolbarItemClickObservable extends Observable<MenuItem> {
@@ -20,7 +20,9 @@ final class ToolbarItemClickObservable extends Observable<MenuItem> {
   }
 
   @Override protected void subscribeActual(Observer<? super MenuItem> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setOnMenuItemClickListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/ToolbarItemClickObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/ToolbarItemClickObservable.java
@@ -9,7 +9,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 @RequiresApi(LOLLIPOP)
 final class ToolbarItemClickObservable extends Observable<MenuItem> {
@@ -20,7 +20,7 @@ final class ToolbarItemClickObservable extends Observable<MenuItem> {
   }
 
   @Override protected void subscribeActual(Observer<? super MenuItem> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/ToolbarNavigationClickObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/ToolbarNavigationClickObservable.java
@@ -10,7 +10,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
-import static io.reactivex.android.MainThreadDisposable.verifyMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
 
 @RequiresApi(LOLLIPOP)
 final class ToolbarNavigationClickObservable extends Observable<Object> {
@@ -21,7 +21,9 @@ final class ToolbarNavigationClickObservable extends Observable<Object> {
   }
 
   @Override protected void subscribeActual(Observer<? super Object> observer) {
-    verifyMainThread();
+    if (isNotOnMainThread(observer)) {
+      return;
+    }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setNavigationOnClickListener(listener);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/ToolbarNavigationClickObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/ToolbarNavigationClickObservable.java
@@ -10,7 +10,7 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
-import static com.jakewharton.rxbinding2.internal.Preconditions.isNotOnMainThread;
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 @RequiresApi(LOLLIPOP)
 final class ToolbarNavigationClickObservable extends Observable<Object> {
@@ -21,7 +21,7 @@ final class ToolbarNavigationClickObservable extends Observable<Object> {
   }
 
   @Override protected void subscribeActual(Observer<? super Object> observer) {
-    if (isNotOnMainThread(observer)) {
+    if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);


### PR DESCRIPTION
This ensures they go through onError implementations rather than failing hard. Resolves #353