### PR TITLE
Add a type-safe observable subclass for initial-value skipping.

### DIFF
--- a/rxbinding-appcompat-v7-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/support/v7/widget/RxSearchView.kt
+++ b/rxbinding-appcompat-v7-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/support/v7/widget/RxSearchView.kt
@@ -1,6 +1,7 @@
 package com.jakewharton.rxbinding2.support.v7.widget
 
 import android.support.v7.widget.SearchView
+import com.jakewharton.rxbinding2.InitialValueObservable
 import io.reactivex.Observable
 import io.reactivex.functions.Consumer
 
@@ -13,7 +14,7 @@ import io.reactivex.functions.Consumer
  *
  * *Note:* A value will be emitted immediately on subscribe.
  */
-inline fun SearchView.queryTextChangeEvents(): Observable<SearchViewQueryTextEvent> = RxSearchView.queryTextChangeEvents(this)
+inline fun SearchView.queryTextChangeEvents(): InitialValueObservable<SearchViewQueryTextEvent> = RxSearchView.queryTextChangeEvents(this)
 
 /**
  * Create an observable of character sequences for query text changes on `view`.
@@ -23,7 +24,7 @@ inline fun SearchView.queryTextChangeEvents(): Observable<SearchViewQueryTextEve
  *
  * *Note:* A value will be emitted immediately on subscribe.
  */
-inline fun SearchView.queryTextChanges(): Observable<CharSequence> = RxSearchView.queryTextChanges(this)
+inline fun SearchView.queryTextChanges(): InitialValueObservable<CharSequence> = RxSearchView.queryTextChanges(this)
 
 /**
  * An action which sets the query property of `view` with character sequences.

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RxSearchView.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RxSearchView.java
@@ -3,6 +3,7 @@ package com.jakewharton.rxbinding2.support.v7.widget;
 import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.SearchView;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observable;
 import io.reactivex.functions.Consumer;
 
@@ -23,7 +24,7 @@ public final class RxSearchView {
    * <em>Note:</em> A value will be emitted immediately on subscribe.
    */
   @CheckResult @NonNull
-  public static Observable<SearchViewQueryTextEvent> queryTextChangeEvents(
+  public static InitialValueObservable<SearchViewQueryTextEvent> queryTextChangeEvents(
       @NonNull SearchView view) {
     checkNotNull(view, "view == null");
     return new SearchViewQueryTextChangeEventsObservable(view);
@@ -38,7 +39,7 @@ public final class RxSearchView {
    * <em>Note:</em> A value will be emitted immediately on subscribe.
    */
   @CheckResult @NonNull
-  public static Observable<CharSequence> queryTextChanges(@NonNull SearchView view) {
+  public static InitialValueObservable<CharSequence> queryTextChanges(@NonNull SearchView view) {
     checkNotNull(view, "view == null");
     return new SearchViewQueryTextChangesObservable(view);
   }

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/SearchViewQueryTextChangeEventsObservable.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/SearchViewQueryTextChangeEventsObservable.java
@@ -1,29 +1,31 @@
 package com.jakewharton.rxbinding2.support.v7.widget;
 
 import android.support.v7.widget.SearchView;
-import io.reactivex.Observable;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
 import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
-final class SearchViewQueryTextChangeEventsObservable extends Observable<SearchViewQueryTextEvent> {
+final class SearchViewQueryTextChangeEventsObservable
+    extends InitialValueObservable<SearchViewQueryTextEvent> {
   private final SearchView view;
 
   SearchViewQueryTextChangeEventsObservable(SearchView view) {
     this.view = view;
   }
 
-  @Override protected void subscribeActual(Observer<? super SearchViewQueryTextEvent> observer) {
+  @Override protected void subscribeListener(Observer<? super SearchViewQueryTextEvent> observer) {
     if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setOnQueryTextListener(listener);
+  }
 
-    // Emit initial value.
-    observer.onNext(SearchViewQueryTextEvent.create(view, view.getQuery(), false));
+  @Override protected SearchViewQueryTextEvent getInitialValue() {
+    return SearchViewQueryTextEvent.create(view, view.getQuery(), false);
   }
 
   final class Listener extends MainThreadDisposable implements SearchView.OnQueryTextListener {

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/SearchViewQueryTextChangesObservable.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/SearchViewQueryTextChangesObservable.java
@@ -1,29 +1,30 @@
 package com.jakewharton.rxbinding2.support.v7.widget;
 
 import android.support.v7.widget.SearchView;
-import io.reactivex.Observable;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
 import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
-final class SearchViewQueryTextChangesObservable extends Observable<CharSequence> {
+final class SearchViewQueryTextChangesObservable extends InitialValueObservable<CharSequence> {
   private final SearchView view;
 
   SearchViewQueryTextChangesObservable(SearchView view) {
     this.view = view;
   }
 
-  @Override protected void subscribeActual(Observer<? super CharSequence> observer) {
+  @Override protected void subscribeListener(Observer<? super CharSequence> observer) {
     if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setOnQueryTextListener(listener);
+  }
 
-    // Emit initial value.
-    observer.onNext(view.getQuery());
+  @Override protected CharSequence getInitialValue() {
+    return view.getQuery();
   }
 
   final class Listener extends MainThreadDisposable implements SearchView.OnQueryTextListener {

--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/view/RxView.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/view/RxView.kt
@@ -5,6 +5,7 @@ import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewTreeObserver
+import com.jakewharton.rxbinding2.InitialValueObservable
 import io.reactivex.Observable
 import io.reactivex.functions.Consumer
 import io.reactivex.functions.Predicate
@@ -95,7 +96,7 @@ inline fun View.draws(): Observable<Any> = RxView.draws(this)
  *
  * *Note:* A value will be emitted immediately on subscribe.
  */
-inline fun View.focusChanges(): Observable<Boolean> = RxView.focusChanges(this)
+inline fun View.focusChanges(): InitialValueObservable<Boolean> = RxView.focusChanges(this)
 
 /**
  * Create an observable which emits on `view` globalLayout events. The emitted value is

--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/widget/RxAdapter.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/widget/RxAdapter.kt
@@ -1,6 +1,7 @@
 package com.jakewharton.rxbinding2.widget
 
 import android.widget.Adapter
+import com.jakewharton.rxbinding2.InitialValueObservable
 import io.reactivex.Observable
 
 /**
@@ -8,4 +9,4 @@ import io.reactivex.Observable
  *
  * *Note:* A value will be emitted immediately on subscribe.
  */
-inline fun <T : Adapter> T.dataChanges(): Observable<T> = RxAdapter.dataChanges(this)
+inline fun <T : Adapter> T.dataChanges(): InitialValueObservable<T> = RxAdapter.dataChanges(this)

--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/widget/RxAdapterView.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/widget/RxAdapterView.kt
@@ -2,6 +2,7 @@ package com.jakewharton.rxbinding2.widget
 
 import android.widget.Adapter
 import android.widget.AdapterView
+import com.jakewharton.rxbinding2.InitialValueObservable
 import com.jakewharton.rxbinding2.internal.Functions
 import java.util.concurrent.Callable
 import io.reactivex.Observable
@@ -17,7 +18,7 @@ import io.reactivex.functions.Predicate
  *
  * *Note:* A value will be emitted immediately on subscribe.
  */
-inline fun <T : Adapter> AdapterView<T>.itemSelections(): Observable<Int> = RxAdapterView.itemSelections(this)
+inline fun <T : Adapter> AdapterView<T>.itemSelections(): InitialValueObservable<Int> = RxAdapterView.itemSelections(this)
 
 /**
  * Create an observable of selection events for `view`.
@@ -27,7 +28,7 @@ inline fun <T : Adapter> AdapterView<T>.itemSelections(): Observable<Int> = RxAd
  *
  * *Note:* A value will be emitted immediately on subscribe.
  */
-inline fun <T : Adapter> AdapterView<T>.selectionEvents(): Observable<AdapterViewSelectionEvent> = RxAdapterView.selectionEvents(this)
+inline fun <T : Adapter> AdapterView<T>.selectionEvents(): InitialValueObservable<AdapterViewSelectionEvent> = RxAdapterView.selectionEvents(this)
 
 /**
  * Create an observable of the position of item clicks for `view`.

--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/widget/RxCompoundButton.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/widget/RxCompoundButton.kt
@@ -1,6 +1,7 @@
 package com.jakewharton.rxbinding2.widget
 
 import android.widget.CompoundButton
+import com.jakewharton.rxbinding2.InitialValueObservable
 import io.reactivex.Observable
 import io.reactivex.functions.Consumer
 
@@ -15,7 +16,7 @@ import io.reactivex.functions.Consumer
  *
  * *Note:* A value will be emitted immediately on subscribe.
  */
-inline fun CompoundButton.checkedChanges(): Observable<Boolean> = RxCompoundButton.checkedChanges(this)
+inline fun CompoundButton.checkedChanges(): InitialValueObservable<Boolean> = RxCompoundButton.checkedChanges(this)
 
 /**
  * An action which sets the checked property of `view`.

--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/widget/RxRadioGroup.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/widget/RxRadioGroup.kt
@@ -1,7 +1,7 @@
 package com.jakewharton.rxbinding2.widget
 
 import android.widget.RadioGroup
-import io.reactivex.Observable
+import com.jakewharton.rxbinding2.InitialValueObservable
 import io.reactivex.functions.Consumer
 
 /**
@@ -12,7 +12,7 @@ import io.reactivex.functions.Consumer
  *
  * *Note:* A value will be emitted immediately on subscribe.
  */
-inline fun RadioGroup.checkedChanges(): Observable<Int> = RxRadioGroup.checkedChanges(this)
+inline fun RadioGroup.checkedChanges(): InitialValueObservable<Int> = RxRadioGroup.checkedChanges(this)
 
 /**
  * An action which sets the checked child of `view` with ID. Passing {@code -1} will clear

--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/widget/RxRatingBar.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/widget/RxRatingBar.kt
@@ -1,7 +1,7 @@
 package com.jakewharton.rxbinding2.widget
 
 import android.widget.RatingBar
-import io.reactivex.Observable
+import com.jakewharton.rxbinding2.InitialValueObservable
 import io.reactivex.functions.Consumer
 
 /**
@@ -12,7 +12,7 @@ import io.reactivex.functions.Consumer
  *
  * *Note:* A value will be emitted immediately on subscribe.
  */
-inline fun RatingBar.ratingChanges(): Observable<Float> = RxRatingBar.ratingChanges(this)
+inline fun RatingBar.ratingChanges(): InitialValueObservable<Float> = RxRatingBar.ratingChanges(this)
 
 /**
  * Create an observable of the rating change events on `view`.
@@ -22,7 +22,7 @@ inline fun RatingBar.ratingChanges(): Observable<Float> = RxRatingBar.ratingChan
  *
  * *Note:* A value will be emitted immediately on subscribe.
  */
-inline fun RatingBar.ratingChangeEvents(): Observable<RatingBarChangeEvent> = RxRatingBar.ratingChangeEvents(this)
+inline fun RatingBar.ratingChangeEvents(): InitialValueObservable<RatingBarChangeEvent> = RxRatingBar.ratingChangeEvents(this)
 
 /**
  * An action which sets the rating of `view`.

--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/widget/RxSearchView.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/widget/RxSearchView.kt
@@ -1,6 +1,7 @@
 package com.jakewharton.rxbinding2.widget
 
 import android.widget.SearchView
+import com.jakewharton.rxbinding2.InitialValueObservable
 import io.reactivex.Observable
 import io.reactivex.functions.Consumer
 
@@ -13,7 +14,7 @@ import io.reactivex.functions.Consumer
  *
  * *Note:* A value will be emitted immediately on subscribe.
  */
-inline fun SearchView.queryTextChangeEvents(): Observable<SearchViewQueryTextEvent> = RxSearchView.queryTextChangeEvents(this)
+inline fun SearchView.queryTextChangeEvents(): InitialValueObservable<SearchViewQueryTextEvent> = RxSearchView.queryTextChangeEvents(this)
 
 /**
  * Create an observable of character sequences for query text changes on `view`.
@@ -23,7 +24,7 @@ inline fun SearchView.queryTextChangeEvents(): Observable<SearchViewQueryTextEve
  *
  * *Note:* A value will be emitted immediately on subscribe.
  */
-inline fun SearchView.queryTextChanges(): Observable<CharSequence> = RxSearchView.queryTextChanges(this)
+inline fun SearchView.queryTextChanges(): InitialValueObservable<CharSequence> = RxSearchView.queryTextChanges(this)
 
 /**
  * An action which sets the query property of `view` with character sequences.

--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/widget/RxSeekBar.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/widget/RxSeekBar.kt
@@ -1,7 +1,7 @@
 package com.jakewharton.rxbinding2.widget
 
 import android.widget.SeekBar
-import io.reactivex.Observable
+import com.jakewharton.rxbinding2.InitialValueObservable
 
 /**
  * Create an observable of progress value changes on `view`.
@@ -11,7 +11,7 @@ import io.reactivex.Observable
  *
  * *Note:* A value will be emitted immediately on subscribe.
  */
-inline fun SeekBar.changes(): Observable<Int> = RxSeekBar.changes(this)
+inline fun SeekBar.changes(): InitialValueObservable<Int> = RxSeekBar.changes(this)
 
 /**
  * Create an observable of progress value changes on `view` that were made only from the
@@ -22,7 +22,7 @@ inline fun SeekBar.changes(): Observable<Int> = RxSeekBar.changes(this)
  *
  * *Note:* A value will be emitted immediately on subscribe.
  */
-inline fun SeekBar.userChanges(): Observable<Int> = RxSeekBar.userChanges(this)
+inline fun SeekBar.userChanges(): InitialValueObservable<Int> = RxSeekBar.userChanges(this)
 
 /**
  * Create an observable of progress value changes on `view` that were made only from the
@@ -33,7 +33,7 @@ inline fun SeekBar.userChanges(): Observable<Int> = RxSeekBar.userChanges(this)
  *
  * *Note:* A value will be emitted immediately on subscribe.
  */
-inline fun SeekBar.systemChanges(): Observable<Int> = RxSeekBar.systemChanges(this)
+inline fun SeekBar.systemChanges(): InitialValueObservable<Int> = RxSeekBar.systemChanges(this)
 
 /**
  * Create an observable of progress change events for `view`.
@@ -43,4 +43,4 @@ inline fun SeekBar.systemChanges(): Observable<Int> = RxSeekBar.systemChanges(th
  *
  * *Note:* A value will be emitted immediately on subscribe.
  */
-inline fun SeekBar.changeEvents(): Observable<SeekBarChangeEvent> = RxSeekBar.changeEvents(this)
+inline fun SeekBar.changeEvents(): InitialValueObservable<SeekBarChangeEvent> = RxSeekBar.changeEvents(this)

--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/widget/RxTextView.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/widget/RxTextView.kt
@@ -1,6 +1,7 @@
 package com.jakewharton.rxbinding2.widget
 
 import android.widget.TextView
+import com.jakewharton.rxbinding2.InitialValueObservable
 import com.jakewharton.rxbinding2.internal.Functions
 import io.reactivex.Observable
 import io.reactivex.functions.Consumer
@@ -70,7 +71,7 @@ inline fun TextView.editorActionEvents(handled: Predicate<in TextViewEditorActio
  *
  * *Note:* A value will be emitted immediately on subscribe.
  */
-inline fun TextView.textChanges(): Observable<CharSequence> = RxTextView.textChanges(this)
+inline fun TextView.textChanges(): InitialValueObservable<CharSequence> = RxTextView.textChanges(this)
 
 /**
  * Create an observable of text change events for `view`.
@@ -86,7 +87,7 @@ inline fun TextView.textChanges(): Observable<CharSequence> = RxTextView.textCha
  *
  * *Note:* A value will be emitted immediately on subscribe.
  */
-inline fun TextView.textChangeEvents(): Observable<TextViewTextChangeEvent> = RxTextView.textChangeEvents(this)
+inline fun TextView.textChangeEvents(): InitialValueObservable<TextViewTextChangeEvent> = RxTextView.textChangeEvents(this)
 
 /**
  * Create an observable of before text change events for `view`.
@@ -96,7 +97,7 @@ inline fun TextView.textChangeEvents(): Observable<TextViewTextChangeEvent> = Rx
  *
  * *Note:* A value will be emitted immediately on subscribe.
  */
-inline fun TextView.beforeTextChangeEvents(): Observable<TextViewBeforeTextChangeEvent> = RxTextView.beforeTextChangeEvents(this)
+inline fun TextView.beforeTextChangeEvents(): InitialValueObservable<TextViewBeforeTextChangeEvent> = RxTextView.beforeTextChangeEvents(this)
 
 /**
  * Create an observable of after text change events for `view`.
@@ -106,7 +107,7 @@ inline fun TextView.beforeTextChangeEvents(): Observable<TextViewBeforeTextChang
  *
  * *Note:* A value will be emitted immediately on subscribe.
  */
-inline fun TextView.afterTextChangeEvents(): Observable<TextViewAfterTextChangeEvent> = RxTextView.afterTextChangeEvents(this)
+inline fun TextView.afterTextChangeEvents(): InitialValueObservable<TextViewAfterTextChangeEvent> = RxTextView.afterTextChangeEvents(this)
 
 /**
  * An action which sets the text property of `view` with character sequences.

--- a/rxbinding-recyclerview-v7-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/support/v7/widget/RxRecyclerViewAdapter.kt
+++ b/rxbinding-recyclerview-v7-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/support/v7/widget/RxRecyclerViewAdapter.kt
@@ -2,6 +2,7 @@ package com.jakewharton.rxbinding2.support.v7.widget
 
 import android.support.v7.widget.RecyclerView.Adapter
 import android.support.v7.widget.RecyclerView.ViewHolder
+import com.jakewharton.rxbinding2.InitialValueObservable
 import io.reactivex.Observable
 
 /**
@@ -9,4 +10,4 @@ import io.reactivex.Observable
  *
  * *Note:* A value will be emitted immediately on subscribe.
  */
-inline fun <T : Adapter<out ViewHolder>> T.dataChanges(): Observable<T> = RxRecyclerViewAdapter.dataChanges(this)
+inline fun <T : Adapter<out ViewHolder>> T.dataChanges(): InitialValueObservable<T> = RxRecyclerViewAdapter.dataChanges(this)

--- a/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RecyclerAdapterDataChangeObservable.java
+++ b/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RecyclerAdapterDataChangeObservable.java
@@ -3,29 +3,31 @@ package com.jakewharton.rxbinding2.support.v7.widget;
 import android.support.v7.widget.RecyclerView.Adapter;
 import android.support.v7.widget.RecyclerView.AdapterDataObserver;
 import android.support.v7.widget.RecyclerView.ViewHolder;
-import io.reactivex.Observable;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
 import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class RecyclerAdapterDataChangeObservable<T extends Adapter<? extends ViewHolder>>
-    extends Observable<T> {
+    extends InitialValueObservable<T> {
   private final T adapter;
 
   RecyclerAdapterDataChangeObservable(T adapter) {
     this.adapter = adapter;
   }
 
-  @Override protected void subscribeActual(Observer<? super T> observer) {
+  @Override protected void subscribeListener(Observer<? super T> observer) {
     if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(adapter, observer);
     observer.onSubscribe(listener);
     adapter.registerAdapterDataObserver(listener.dataObserver);
-    // Emit initial value.
-    observer.onNext(adapter);
+  }
+
+  @Override protected T getInitialValue() {
+    return adapter;
   }
 
   final class Listener extends MainThreadDisposable {

--- a/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RxRecyclerViewAdapter.java
+++ b/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RxRecyclerViewAdapter.java
@@ -4,6 +4,7 @@ import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView.Adapter;
 import android.support.v7.widget.RecyclerView.ViewHolder;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observable;
 
 import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
@@ -16,7 +17,7 @@ public final class RxRecyclerViewAdapter {
    * <em>Note:</em> A value will be emitted immediately on subscribe.
    */
   @CheckResult @NonNull
-  public static <T extends Adapter<? extends ViewHolder>> Observable<T> dataChanges(
+  public static <T extends Adapter<? extends ViewHolder>> InitialValueObservable<T> dataChanges(
       @NonNull T adapter) {
     checkNotNull(adapter, "adapter == null");
     return new RecyclerAdapterDataChangeObservable<>(adapter);

--- a/rxbinding-support-v4-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/support/v4/view/RxViewPager.kt
+++ b/rxbinding-support-v4-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/support/v4/view/RxViewPager.kt
@@ -1,6 +1,7 @@
 package com.jakewharton.rxbinding2.support.v4.view
 
 import android.support.v4.view.ViewPager
+import com.jakewharton.rxbinding2.InitialValueObservable
 import io.reactivex.Observable
 import io.reactivex.functions.Consumer
 
@@ -21,7 +22,7 @@ inline fun ViewPager.pageScrollStateChanges(): Observable<Int> = RxViewPager.pag
  *
  * *Note:* A value will be emitted immediately on subscribe.
  */
-inline fun ViewPager.pageSelections(): Observable<Int> = RxViewPager.pageSelections(this)
+inline fun ViewPager.pageSelections(): InitialValueObservable<Int> = RxViewPager.pageSelections(this)
 
 /**
  * An action which sets the current item of `view`.

--- a/rxbinding-support-v4-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/support/v4/widget/RxDrawerLayout.kt
+++ b/rxbinding-support-v4-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/support/v4/widget/RxDrawerLayout.kt
@@ -1,7 +1,7 @@
 package com.jakewharton.rxbinding2.support.v4.widget
 
 import android.support.v4.widget.DrawerLayout
-import io.reactivex.Observable
+import com.jakewharton.rxbinding2.InitialValueObservable
 import io.reactivex.functions.Consumer
 
 /**
@@ -12,7 +12,7 @@ import io.reactivex.functions.Consumer
  *
  * *Note:* A value will be emitted immediately on subscribe.
  */
-inline fun DrawerLayout.drawerOpen(gravity: Int): Observable<Boolean> = RxDrawerLayout.drawerOpen(this, gravity)
+inline fun DrawerLayout.drawerOpen(gravity: Int): InitialValueObservable<Boolean> = RxDrawerLayout.drawerOpen(this, gravity)
 
 /**
  * An action which sets whether the drawer with `gravity` of `view` is open.

--- a/rxbinding-support-v4-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/support/v4/widget/RxSlidingPaneLayout.kt
+++ b/rxbinding-support-v4-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/support/v4/widget/RxSlidingPaneLayout.kt
@@ -1,6 +1,7 @@
 package com.jakewharton.rxbinding2.support.v4.widget
 
 import android.support.v4.widget.SlidingPaneLayout
+import com.jakewharton.rxbinding2.InitialValueObservable
 import io.reactivex.Observable
 import io.reactivex.functions.Consumer
 
@@ -15,7 +16,7 @@ import io.reactivex.functions.Consumer
  *
  * *Note:* A value will be emitted immediately on subscribe.
  */
-inline fun SlidingPaneLayout.panelOpens(): Observable<Boolean> = RxSlidingPaneLayout.panelOpens(this)
+inline fun SlidingPaneLayout.panelOpens(): InitialValueObservable<Boolean> = RxSlidingPaneLayout.panelOpens(this)
 
 /**
  * Create an observable of the slide offset of the pane of `view`

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/RxViewPager.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/RxViewPager.java
@@ -3,6 +3,7 @@ package com.jakewharton.rxbinding2.support.v4.view;
 import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.support.v4.view.ViewPager;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observable;
 import io.reactivex.functions.Consumer;
 
@@ -30,7 +31,8 @@ public final class RxViewPager {
    * <p>
    * <em>Note:</em> A value will be emitted immediately on subscribe.
    */
-  @CheckResult @NonNull public static Observable<Integer> pageSelections(@NonNull ViewPager view) {
+  @CheckResult @NonNull
+  public static InitialValueObservable<Integer> pageSelections(@NonNull ViewPager view) {
     checkNotNull(view, "view == null");
     return new ViewPagerPageSelectedObservable(view);
   }

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/ViewPagerPageSelectedObservable.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/ViewPagerPageSelectedObservable.java
@@ -2,27 +2,25 @@ package com.jakewharton.rxbinding2.support.v4.view;
 
 import android.support.v4.view.ViewPager;
 import android.support.v4.view.ViewPager.OnPageChangeListener;
-import io.reactivex.Observable;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
-
-final class ViewPagerPageSelectedObservable extends Observable<Integer> {
+final class ViewPagerPageSelectedObservable extends InitialValueObservable<Integer> {
   private final ViewPager view;
 
   ViewPagerPageSelectedObservable(ViewPager view) {
     this.view = view;
   }
 
-  @Override protected void subscribeActual(Observer<? super Integer> observer) {
-    if (!checkMainThread(observer)) {
-      return;
-    }
+  @Override protected void subscribeListener(Observer<? super Integer> observer) {
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.addOnPageChangeListener(listener);
-    observer.onNext(view.getCurrentItem());
+  }
+
+  @Override protected Integer getInitialValue() {
+    return view.getCurrentItem();
   }
 
   static final class Listener extends MainThreadDisposable implements OnPageChangeListener {

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/DrawerLayoutDrawerOpenedObservable.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/DrawerLayoutDrawerOpenedObservable.java
@@ -3,13 +3,13 @@ package com.jakewharton.rxbinding2.support.v4.widget;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v4.widget.DrawerLayout.DrawerListener;
 import android.view.View;
-import io.reactivex.Observable;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
 import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
-final class DrawerLayoutDrawerOpenedObservable extends Observable<Boolean> {
+final class DrawerLayoutDrawerOpenedObservable extends InitialValueObservable<Boolean> {
   private final DrawerLayout view;
   private final int gravity;
 
@@ -18,14 +18,17 @@ final class DrawerLayoutDrawerOpenedObservable extends Observable<Boolean> {
     this.gravity = gravity;
   }
 
-  @Override protected void subscribeActual(Observer<? super Boolean> observer) {
+  @Override protected void subscribeListener(Observer<? super Boolean> observer) {
     if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, gravity, observer);
     observer.onSubscribe(listener);
     view.addDrawerListener(listener);
-    observer.onNext(view.isDrawerOpen(gravity));
+  }
+
+  @Override protected Boolean getInitialValue() {
+    return view.isDrawerOpen(gravity);
   }
 
   static final class Listener extends MainThreadDisposable implements DrawerListener {

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/RxDrawerLayout.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/RxDrawerLayout.java
@@ -3,7 +3,7 @@ package com.jakewharton.rxbinding2.support.v4.widget;
 import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.support.v4.widget.DrawerLayout;
-import io.reactivex.Observable;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.functions.Consumer;
 
 import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
@@ -17,8 +17,8 @@ public final class RxDrawerLayout {
    * <p>
    * <em>Note:</em> A value will be emitted immediately on subscribe.
    */
-  @CheckResult @NonNull public static Observable<Boolean> drawerOpen(@NonNull DrawerLayout view,
-      int gravity) {
+  @CheckResult @NonNull public static InitialValueObservable<Boolean> drawerOpen(
+      @NonNull DrawerLayout view, int gravity) {
     checkNotNull(view, "view == null");
     return new DrawerLayoutDrawerOpenedObservable(view, gravity);
   }

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/RxSlidingPaneLayout.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/RxSlidingPaneLayout.java
@@ -3,6 +3,7 @@ package com.jakewharton.rxbinding2.support.v4.widget;
 import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.support.v4.widget.SlidingPaneLayout;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observable;
 import io.reactivex.functions.Consumer;
 
@@ -24,7 +25,7 @@ public final class RxSlidingPaneLayout {
    * <p>
    * <em>Note:</em> A value will be emitted immediately on subscribe.
    */
-  @CheckResult @NonNull public static Observable<Boolean> panelOpens(
+  @CheckResult @NonNull public static InitialValueObservable<Boolean> panelOpens(
       @NonNull SlidingPaneLayout view) {
     checkNotNull(view, "view == null");
     return new SlidingPaneLayoutPaneOpenedObservable(view);

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/SlidingPaneLayoutPaneOpenedObservable.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/SlidingPaneLayoutPaneOpenedObservable.java
@@ -3,27 +3,25 @@ package com.jakewharton.rxbinding2.support.v4.widget;
 import android.support.v4.widget.SlidingPaneLayout;
 import android.support.v4.widget.SlidingPaneLayout.PanelSlideListener;
 import android.view.View;
-import io.reactivex.Observable;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
-
-final class SlidingPaneLayoutPaneOpenedObservable extends Observable<Boolean> {
+final class SlidingPaneLayoutPaneOpenedObservable extends InitialValueObservable<Boolean> {
   private final SlidingPaneLayout view;
 
   SlidingPaneLayoutPaneOpenedObservable(SlidingPaneLayout view) {
     this.view = view;
   }
 
-  @Override protected void subscribeActual(Observer<? super Boolean> observer) {
-    if (!checkMainThread(observer)) {
-      return;
-    }
+  @Override protected void subscribeListener(Observer<? super Boolean> observer) {
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setPanelSlideListener(listener);
-    observer.onNext(view.isOpen());
+  }
+
+  @Override protected Boolean getInitialValue() {
+    return view.isOpen();
   }
 
   static final class Listener extends MainThreadDisposable implements PanelSlideListener {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/InitialValueObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/InitialValueObservable.java
@@ -1,0 +1,27 @@
+package com.jakewharton.rxbinding2;
+
+import io.reactivex.Observable;
+import io.reactivex.Observer;
+
+public abstract class InitialValueObservable<T> extends Observable<T> {
+  @Override protected final void subscribeActual(Observer<? super T> observer) {
+    subscribeListener(observer);
+    observer.onNext(getInitialValue());
+  }
+
+  protected abstract void subscribeListener(Observer<? super T> observer);
+  protected abstract T getInitialValue();
+
+  public final Observable<T> skipInitialValue() {
+    return new Skipped();
+  }
+
+  private final class Skipped extends Observable<T> {
+    Skipped() {
+    }
+
+    @Override protected void subscribeActual(Observer<? super T> observer) {
+      subscribeListener(observer);
+    }
+  }
+}

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/RxView.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/RxView.java
@@ -8,6 +8,7 @@ import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewTreeObserver;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observable;
 import io.reactivex.functions.Consumer;
 import io.reactivex.functions.Predicate;
@@ -143,7 +144,7 @@ public final class RxView {
    * <em>Note:</em> A value will be emitted immediately on subscribe.
    */
   @CheckResult @NonNull
-  public static Observable<Boolean> focusChanges(@NonNull View view) {
+  public static InitialValueObservable<Boolean> focusChanges(@NonNull View view) {
     checkNotNull(view, "view == null");
     return new ViewFocusChangeObservable(view);
   }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewFocusChangeObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewFocusChangeObservable.java
@@ -2,27 +2,25 @@ package com.jakewharton.rxbinding2.view;
 
 import android.view.View;
 import android.view.View.OnFocusChangeListener;
-import io.reactivex.Observable;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
-
-final class ViewFocusChangeObservable extends Observable<Boolean> {
+final class ViewFocusChangeObservable extends InitialValueObservable<Boolean> {
   private final View view;
 
   ViewFocusChangeObservable(View view) {
     this.view = view;
   }
 
-  @Override protected void subscribeActual(Observer<? super Boolean> observer) {
-    if (!checkMainThread(observer)) {
-      return;
-    }
+  @Override protected void subscribeListener(Observer<? super Boolean> observer) {
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setOnFocusChangeListener(listener);
-    observer.onNext(view.hasFocus());
+  }
+
+  @Override protected Boolean getInitialValue() {
+    return view.hasFocus();
   }
 
   static final class Listener extends MainThreadDisposable implements OnFocusChangeListener {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterDataChangeObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterDataChangeObservable.java
@@ -2,27 +2,30 @@ package com.jakewharton.rxbinding2.widget;
 
 import android.database.DataSetObserver;
 import android.widget.Adapter;
-import io.reactivex.Observable;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
 import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
-final class AdapterDataChangeObservable<T extends Adapter> extends Observable<T> {
+final class AdapterDataChangeObservable<T extends Adapter> extends InitialValueObservable<T> {
   private final T adapter;
 
   AdapterDataChangeObservable(T adapter) {
     this.adapter = adapter;
   }
 
-  @Override protected void subscribeActual(Observer<? super T> observer) {
+  @Override protected void subscribeListener(Observer<? super T> observer) {
     if (!checkMainThread(observer)) {
       return;
     }
     ObserverDisposable<T> disposableDataSetObserver = new ObserverDisposable<>(adapter, observer);
     adapter.registerDataSetObserver(disposableDataSetObserver.dataSetObserver);
     observer.onSubscribe(disposableDataSetObserver);
-    observer.onNext(adapter);
+  }
+
+  @Override protected T getInitialValue() {
+    return adapter;
   }
 
   static final class ObserverDisposable<T extends Adapter> extends MainThreadDisposable {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterViewItemSelectionObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterViewItemSelectionObservable.java
@@ -3,28 +3,31 @@ package com.jakewharton.rxbinding2.widget;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
-import io.reactivex.Observable;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
 import static android.widget.AdapterView.INVALID_POSITION;
 import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
-final class AdapterViewItemSelectionObservable extends Observable<Integer> {
+final class AdapterViewItemSelectionObservable extends InitialValueObservable<Integer> {
   private final AdapterView<?> view;
 
   AdapterViewItemSelectionObservable(AdapterView<?> view) {
     this.view = view;
   }
 
-  @Override protected void subscribeActual(Observer<? super Integer> observer) {
+  @Override protected void subscribeListener(Observer<? super Integer> observer) {
     if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);
     view.setOnItemSelectedListener(listener);
     observer.onSubscribe(listener);
-    observer.onNext(view.getSelectedItemPosition());
+  }
+
+  @Override protected Integer getInitialValue() {
+    return view.getSelectedItemPosition();
   }
 
   static final class Listener extends MainThreadDisposable implements OnItemSelectedListener {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterViewSelectionObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterViewSelectionObservable.java
@@ -3,31 +3,31 @@ package com.jakewharton.rxbinding2.widget;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
-import io.reactivex.Observable;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
 import static android.widget.AdapterView.INVALID_POSITION;
 import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
-final class AdapterViewSelectionObservable extends Observable<AdapterViewSelectionEvent> {
+final class AdapterViewSelectionObservable
+    extends InitialValueObservable<AdapterViewSelectionEvent> {
   private final AdapterView<?> view;
 
   AdapterViewSelectionObservable(AdapterView<?> view) {
     this.view = view;
   }
 
-  @Override protected void subscribeActual(Observer<? super AdapterViewSelectionEvent> observer) {
+  @Override protected void subscribeListener(Observer<? super AdapterViewSelectionEvent> observer) {
     if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);
     view.setOnItemSelectedListener(listener);
     observer.onSubscribe(listener);
-    observer.onNext(createInitialEvent());
   }
 
-  private AdapterViewSelectionEvent createInitialEvent() {
+  @Override protected AdapterViewSelectionEvent getInitialValue() {
     int selectedPosition = view.getSelectedItemPosition();
     if (selectedPosition == INVALID_POSITION) {
       return AdapterViewNothingSelectionEvent.create(view);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/CompoundButtonCheckedChangeObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/CompoundButtonCheckedChangeObservable.java
@@ -2,29 +2,30 @@ package com.jakewharton.rxbinding2.widget;
 
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
-import io.reactivex.Observable;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
 import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
-final class CompoundButtonCheckedChangeObservable extends Observable<Boolean> {
-
+final class CompoundButtonCheckedChangeObservable extends InitialValueObservable<Boolean> {
   private final CompoundButton view;
 
   CompoundButtonCheckedChangeObservable(CompoundButton view) {
     this.view = view;
   }
 
-  @Override
-  protected void subscribeActual(Observer<? super Boolean> observer) {
+  @Override protected void subscribeListener(Observer<? super Boolean> observer) {
     if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.setOnCheckedChangeListener(listener);
-    observer.onNext(view.isChecked());
+  }
+
+  @Override protected Boolean getInitialValue() {
+    return view.isChecked();
   }
 
   static final class Listener extends MainThreadDisposable implements OnCheckedChangeListener {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RadioGroupCheckedChangeObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RadioGroupCheckedChangeObservable.java
@@ -2,32 +2,36 @@ package com.jakewharton.rxbinding2.widget;
 
 import android.widget.RadioGroup;
 import android.widget.RadioGroup.OnCheckedChangeListener;
-import io.reactivex.Observable;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
 import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
-final class RadioGroupCheckedChangeObservable extends Observable<Integer> {
+final class RadioGroupCheckedChangeObservable extends InitialValueObservable<Integer> {
   private final RadioGroup view;
 
   RadioGroupCheckedChangeObservable(RadioGroup view) {
     this.view = view;
   }
 
-  @Override protected void subscribeActual(Observer<? super Integer> observer) {
+  @Override protected void subscribeListener(Observer<? super Integer> observer) {
     if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);
     view.setOnCheckedChangeListener(listener);
     observer.onSubscribe(listener);
-    observer.onNext(view.getCheckedRadioButtonId());
+  }
+
+  @Override protected Integer getInitialValue() {
+    return view.getCheckedRadioButtonId();
   }
 
   static final class Listener extends MainThreadDisposable implements OnCheckedChangeListener {
     private final RadioGroup view;
     private final Observer<? super Integer> observer;
+    private int lastChecked = -1;
 
     Listener(RadioGroup view, Observer<? super Integer> observer) {
       this.view = view;
@@ -35,7 +39,8 @@ final class RadioGroupCheckedChangeObservable extends Observable<Integer> {
     }
 
     @Override public void onCheckedChanged(RadioGroup radioGroup, int checkedId) {
-      if (!isDisposed()) {
+      if (!isDisposed() && checkedId != lastChecked) {
+        lastChecked = checkedId;
         observer.onNext(checkedId);
       }
     }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RatingBarRatingChangeEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RatingBarRatingChangeEventObservable.java
@@ -2,27 +2,31 @@ package com.jakewharton.rxbinding2.widget;
 
 import android.widget.RatingBar;
 import android.widget.RatingBar.OnRatingBarChangeListener;
-import io.reactivex.Observable;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
 import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
-final class RatingBarRatingChangeEventObservable extends Observable<RatingBarChangeEvent> {
+final class RatingBarRatingChangeEventObservable
+    extends InitialValueObservable<RatingBarChangeEvent> {
   private final RatingBar view;
 
   RatingBarRatingChangeEventObservable(RatingBar view) {
     this.view = view;
   }
 
-  @Override protected void subscribeActual(Observer<? super RatingBarChangeEvent> observer) {
+  @Override protected void subscribeListener(Observer<? super RatingBarChangeEvent> observer) {
     if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);
     view.setOnRatingBarChangeListener(listener);
     observer.onSubscribe(listener);
-    observer.onNext(RatingBarChangeEvent.create(view, view.getRating(), false));
+  }
+
+  @Override protected RatingBarChangeEvent getInitialValue() {
+    return RatingBarChangeEvent.create(view, view.getRating(), false);
   }
 
   static final class Listener extends MainThreadDisposable implements OnRatingBarChangeListener {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RatingBarRatingChangeObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RatingBarRatingChangeObservable.java
@@ -2,27 +2,30 @@ package com.jakewharton.rxbinding2.widget;
 
 import android.widget.RatingBar;
 import android.widget.RatingBar.OnRatingBarChangeListener;
-import io.reactivex.Observable;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
 import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
-final class RatingBarRatingChangeObservable extends Observable<Float> {
+final class RatingBarRatingChangeObservable extends InitialValueObservable<Float> {
   private final RatingBar view;
 
   RatingBarRatingChangeObservable(RatingBar view) {
     this.view = view;
   }
 
-  @Override protected void subscribeActual(Observer<? super Float> observer) {
+  @Override protected void subscribeListener(Observer<? super Float> observer) {
     if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);
     view.setOnRatingBarChangeListener(listener);
     observer.onSubscribe(listener);
-    observer.onNext(view.getRating());
+  }
+
+  @Override protected Float getInitialValue() {
+    return view.getRating();
   }
 
   static final class Listener extends MainThreadDisposable implements OnRatingBarChangeListener {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxAdapter.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxAdapter.java
@@ -3,6 +3,7 @@ package com.jakewharton.rxbinding2.widget;
 import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.widget.Adapter;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observable;
 
 import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
@@ -17,7 +18,7 @@ public final class RxAdapter {
    * <em>Note:</em> A value will be emitted immediately on subscribe.
    */
   @CheckResult @NonNull
-  public static <T extends Adapter> Observable<T> dataChanges(@NonNull T adapter) {
+  public static <T extends Adapter> InitialValueObservable<T> dataChanges(@NonNull T adapter) {
     checkNotNull(adapter, "adapter == null");
     return new AdapterDataChangeObservable<>(adapter);
   }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxAdapterView.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxAdapterView.java
@@ -4,6 +4,7 @@ import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.widget.Adapter;
 import android.widget.AdapterView;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import com.jakewharton.rxbinding2.internal.Functions;
 import java.util.concurrent.Callable;
 import io.reactivex.Observable;
@@ -27,7 +28,7 @@ public final class RxAdapterView {
    * <em>Note:</em> A value will be emitted immediately on subscribe.
    */
   @CheckResult @NonNull
-  public static <T extends Adapter> Observable<Integer> itemSelections(
+  public static <T extends Adapter> InitialValueObservable<Integer> itemSelections(
       @NonNull AdapterView<T> view) {
     checkNotNull(view, "view == null");
     return new AdapterViewItemSelectionObservable(view);
@@ -42,8 +43,8 @@ public final class RxAdapterView {
    * <em>Note:</em> A value will be emitted immediately on subscribe.
    */
   @CheckResult @NonNull
-  public static <T extends Adapter> Observable<AdapterViewSelectionEvent> selectionEvents(
-      @NonNull AdapterView<T> view) {
+  public static <T extends Adapter> InitialValueObservable<AdapterViewSelectionEvent>
+  selectionEvents(@NonNull AdapterView<T> view) {
     checkNotNull(view, "view == null");
     return new AdapterViewSelectionObservable(view);
   }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxCompoundButton.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxCompoundButton.java
@@ -4,6 +4,7 @@ import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.widget.CompoundButton;
 
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observable;
 import io.reactivex.functions.Consumer;
 
@@ -26,7 +27,7 @@ public final class RxCompoundButton {
    * <em>Note:</em> A value will be emitted immediately on subscribe.
    */
   @CheckResult @NonNull
-  public static Observable<Boolean> checkedChanges(@NonNull CompoundButton view) {
+  public static InitialValueObservable<Boolean> checkedChanges(@NonNull CompoundButton view) {
     checkNotNull(view, "view == null");
     return new CompoundButtonCheckedChangeObservable(view);
   }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxRadioGroup.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxRadioGroup.java
@@ -3,7 +3,7 @@ package com.jakewharton.rxbinding2.widget;
 import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.widget.RadioGroup;
-import io.reactivex.Observable;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.functions.Consumer;
 
 import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
@@ -18,10 +18,9 @@ public final class RxRadioGroup {
    * <em>Note:</em> A value will be emitted immediately on subscribe.
    */
   @CheckResult @NonNull
-  public static Observable<Integer> checkedChanges(@NonNull RadioGroup view) {
+  public static InitialValueObservable<Integer> checkedChanges(@NonNull RadioGroup view) {
     checkNotNull(view, "view == null");
-    return new RadioGroupCheckedChangeObservable(view)
-        .distinctUntilChanged(); // Radio group can fire non-changes.
+    return new RadioGroupCheckedChangeObservable(view);
   }
 
   /**

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxRatingBar.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxRatingBar.java
@@ -3,7 +3,7 @@ package com.jakewharton.rxbinding2.widget;
 import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.widget.RatingBar;
-import io.reactivex.Observable;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.functions.Consumer;
 
 import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
@@ -18,7 +18,7 @@ public final class RxRatingBar {
    * <em>Note:</em> A value will be emitted immediately on subscribe.
    */
   @CheckResult @NonNull
-  public static Observable<Float> ratingChanges(@NonNull RatingBar view) {
+  public static InitialValueObservable<Float> ratingChanges(@NonNull RatingBar view) {
     checkNotNull(view, "view == null");
     return new RatingBarRatingChangeObservable(view);
   }
@@ -32,7 +32,8 @@ public final class RxRatingBar {
    * <em>Note:</em> A value will be emitted immediately on subscribe.
    */
   @CheckResult @NonNull
-  public static Observable<RatingBarChangeEvent> ratingChangeEvents(@NonNull RatingBar view) {
+  public static InitialValueObservable<RatingBarChangeEvent> ratingChangeEvents(
+      @NonNull RatingBar view) {
     checkNotNull(view, "view == null");
     return new RatingBarRatingChangeEventObservable(view);
   }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxSearchView.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxSearchView.java
@@ -3,6 +3,7 @@ package com.jakewharton.rxbinding2.widget;
 import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.widget.SearchView;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observable;
 import io.reactivex.functions.Consumer;
 
@@ -23,7 +24,7 @@ public final class RxSearchView {
    * <em>Note:</em> A value will be emitted immediately on subscribe.
    */
   @CheckResult @NonNull
-  public static Observable<SearchViewQueryTextEvent> queryTextChangeEvents(
+  public static InitialValueObservable<SearchViewQueryTextEvent> queryTextChangeEvents(
       @NonNull SearchView view) {
     checkNotNull(view, "view == null");
     return new SearchViewQueryTextChangeEventsObservable(view);
@@ -38,7 +39,7 @@ public final class RxSearchView {
    * <em>Note:</em> A value will be emitted immediately on subscribe.
    */
   @CheckResult @NonNull
-  public static Observable<CharSequence> queryTextChanges(@NonNull SearchView view) {
+  public static InitialValueObservable<CharSequence> queryTextChanges(@NonNull SearchView view) {
     checkNotNull(view, "view == null");
     return new SearchViewQueryTextChangesObservable(view);
   }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxSeekBar.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxSeekBar.java
@@ -3,7 +3,7 @@ package com.jakewharton.rxbinding2.widget;
 import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.widget.SeekBar;
-import io.reactivex.Observable;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 
 import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
 
@@ -17,7 +17,7 @@ public final class RxSeekBar {
    * <em>Note:</em> A value will be emitted immediately on subscribe.
    */
   @CheckResult @NonNull
-  public static Observable<Integer> changes(@NonNull SeekBar view) {
+  public static InitialValueObservable<Integer> changes(@NonNull SeekBar view) {
     checkNotNull(view, "view == null");
     return new SeekBarChangeObservable(view, null);
   }
@@ -32,7 +32,7 @@ public final class RxSeekBar {
    * <em>Note:</em> A value will be emitted immediately on subscribe.
    */
   @CheckResult @NonNull
-  public static Observable<Integer> userChanges(@NonNull SeekBar view) {
+  public static InitialValueObservable<Integer> userChanges(@NonNull SeekBar view) {
     checkNotNull(view, "view == null");
     return new SeekBarChangeObservable(view, true);
   }
@@ -47,7 +47,7 @@ public final class RxSeekBar {
    * <em>Note:</em> A value will be emitted immediately on subscribe.
    */
   @CheckResult @NonNull
-  public static Observable<Integer> systemChanges(@NonNull SeekBar view) {
+  public static InitialValueObservable<Integer> systemChanges(@NonNull SeekBar view) {
     checkNotNull(view, "view == null");
     return new SeekBarChangeObservable(view, false);
   }
@@ -61,7 +61,7 @@ public final class RxSeekBar {
    * <em>Note:</em> A value will be emitted immediately on subscribe.
    */
   @CheckResult @NonNull
-  public static Observable<SeekBarChangeEvent> changeEvents(@NonNull SeekBar view) {
+  public static InitialValueObservable<SeekBarChangeEvent> changeEvents(@NonNull SeekBar view) {
     checkNotNull(view, "view == null");
     return new SeekBarChangeEventObservable(view);
   }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxTextView.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxTextView.java
@@ -4,6 +4,7 @@ import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.widget.TextView;
 
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import com.jakewharton.rxbinding2.internal.Functions;
 
 import io.reactivex.Observable;
@@ -102,7 +103,7 @@ public final class RxTextView {
    * <em>Note:</em> A value will be emitted immediately on subscribe.
    */
   @CheckResult @NonNull
-  public static Observable<CharSequence> textChanges(@NonNull TextView view) {
+  public static InitialValueObservable<CharSequence> textChanges(@NonNull TextView view) {
     checkNotNull(view, "view == null");
     return new TextViewTextObservable(view);
   }
@@ -122,7 +123,8 @@ public final class RxTextView {
    * <em>Note:</em> A value will be emitted immediately on subscribe.
    */
   @CheckResult @NonNull
-  public static Observable<TextViewTextChangeEvent> textChangeEvents(@NonNull TextView view) {
+  public static InitialValueObservable<TextViewTextChangeEvent> textChangeEvents(
+      @NonNull TextView view) {
     checkNotNull(view, "view == null");
     return new TextViewTextChangeEventObservable(view);
   }
@@ -136,7 +138,7 @@ public final class RxTextView {
    * <em>Note:</em> A value will be emitted immediately on subscribe.
    */
   @CheckResult @NonNull
-  public static Observable<TextViewBeforeTextChangeEvent> beforeTextChangeEvents(
+  public static InitialValueObservable<TextViewBeforeTextChangeEvent> beforeTextChangeEvents(
       @NonNull TextView view) {
     checkNotNull(view, "view == null");
     return new TextViewBeforeTextChangeEventObservable(view);
@@ -151,7 +153,7 @@ public final class RxTextView {
    * <em>Note:</em> A value will be emitted immediately on subscribe.
    */
   @CheckResult @NonNull
-  public static Observable<TextViewAfterTextChangeEvent> afterTextChangeEvents(
+  public static InitialValueObservable<TextViewAfterTextChangeEvent> afterTextChangeEvents(
       @NonNull TextView view) {
     checkNotNull(view, "view == null");
     return new TextViewAfterTextChangeEventObservable(view);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/SearchViewQueryTextChangeEventsObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/SearchViewQueryTextChangeEventsObservable.java
@@ -2,27 +2,31 @@ package com.jakewharton.rxbinding2.widget;
 
 import android.widget.SearchView;
 import android.widget.SearchView.OnQueryTextListener;
-import io.reactivex.Observable;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
 import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
-final class SearchViewQueryTextChangeEventsObservable extends Observable<SearchViewQueryTextEvent> {
+final class SearchViewQueryTextChangeEventsObservable
+    extends InitialValueObservable<SearchViewQueryTextEvent> {
   private final SearchView view;
 
   SearchViewQueryTextChangeEventsObservable(SearchView view) {
     this.view = view;
   }
 
-  @Override protected void subscribeActual(Observer<? super SearchViewQueryTextEvent> observer) {
+  @Override protected void subscribeListener(Observer<? super SearchViewQueryTextEvent> observer) {
     if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);
     view.setOnQueryTextListener(listener);
     observer.onSubscribe(listener);
-    observer.onNext(SearchViewQueryTextEvent.create(view, view.getQuery(), false));
+  }
+
+  @Override protected SearchViewQueryTextEvent getInitialValue() {
+    return SearchViewQueryTextEvent.create(view, view.getQuery(), false);
   }
 
   static final class Listener extends MainThreadDisposable implements OnQueryTextListener {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/SearchViewQueryTextChangesObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/SearchViewQueryTextChangesObservable.java
@@ -2,27 +2,30 @@ package com.jakewharton.rxbinding2.widget;
 
 import android.widget.SearchView;
 import android.widget.SearchView.OnQueryTextListener;
-import io.reactivex.Observable;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
 import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
-final class SearchViewQueryTextChangesObservable extends Observable<CharSequence> {
+final class SearchViewQueryTextChangesObservable extends InitialValueObservable<CharSequence> {
   private final SearchView view;
 
   SearchViewQueryTextChangesObservable(SearchView view) {
     this.view = view;
   }
 
-  @Override protected void subscribeActual(Observer<? super CharSequence> observer) {
+  @Override protected void subscribeListener(Observer<? super CharSequence> observer) {
     if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);
     view.setOnQueryTextListener(listener);
     observer.onSubscribe(listener);
-    observer.onNext(view.getQuery());
+  }
+
+  @Override protected CharSequence getInitialValue() {
+    return view.getQuery();
   }
 
   static final class Listener extends MainThreadDisposable implements OnQueryTextListener {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/SeekBarChangeEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/SeekBarChangeEventObservable.java
@@ -2,27 +2,30 @@ package com.jakewharton.rxbinding2.widget;
 
 import android.widget.SeekBar;
 import android.widget.SeekBar.OnSeekBarChangeListener;
-import io.reactivex.Observable;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
 import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
-final class SeekBarChangeEventObservable extends Observable<SeekBarChangeEvent> {
+final class SeekBarChangeEventObservable extends InitialValueObservable<SeekBarChangeEvent> {
   private final SeekBar view;
 
   SeekBarChangeEventObservable(SeekBar view) {
     this.view = view;
   }
 
-  @Override protected void subscribeActual(Observer<? super SeekBarChangeEvent> observer) {
+  @Override protected void subscribeListener(Observer<? super SeekBarChangeEvent> observer) {
     if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, observer);
     view.setOnSeekBarChangeListener(listener);
     observer.onSubscribe(listener);
-    observer.onNext(SeekBarProgressChangeEvent.create(view, view.getProgress(), false));
+  }
+
+  @Override protected SeekBarChangeEvent getInitialValue() {
+    return SeekBarProgressChangeEvent.create(view, view.getProgress(), false);
   }
 
   static final class Listener extends MainThreadDisposable implements OnSeekBarChangeListener {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/SeekBarChangeObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/SeekBarChangeObservable.java
@@ -3,13 +3,13 @@ package com.jakewharton.rxbinding2.widget;
 import android.support.annotation.Nullable;
 import android.widget.SeekBar;
 import android.widget.SeekBar.OnSeekBarChangeListener;
-import io.reactivex.Observable;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
 import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
-final class SeekBarChangeObservable extends Observable<Integer> {
+final class SeekBarChangeObservable extends InitialValueObservable<Integer> {
   private final SeekBar view;
   @Nullable private final Boolean shouldBeFromUser;
 
@@ -18,14 +18,17 @@ final class SeekBarChangeObservable extends Observable<Integer> {
     this.shouldBeFromUser = shouldBeFromUser;
   }
 
-  @Override protected void subscribeActual(Observer<? super Integer> observer) {
+  @Override protected void subscribeListener(Observer<? super Integer> observer) {
     if (!checkMainThread(observer)) {
       return;
     }
     Listener listener = new Listener(view, shouldBeFromUser, observer);
     view.setOnSeekBarChangeListener(listener);
     observer.onSubscribe(listener);
-    observer.onNext(view.getProgress());
+  }
+
+  @Override protected Integer getInitialValue() {
+    return view.getProgress();
   }
 
   static final class Listener extends MainThreadDisposable implements OnSeekBarChangeListener {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewAfterTextChangeEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewAfterTextChangeEventObservable.java
@@ -3,14 +3,12 @@ package com.jakewharton.rxbinding2.widget;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.widget.TextView;
-import io.reactivex.Observable;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
-
 final class TextViewAfterTextChangeEventObservable
-    extends Observable<TextViewAfterTextChangeEvent> {
+    extends InitialValueObservable<TextViewAfterTextChangeEvent> {
   private final TextView view;
 
   TextViewAfterTextChangeEventObservable(TextView view) {
@@ -18,14 +16,14 @@ final class TextViewAfterTextChangeEventObservable
   }
 
   @Override
-  protected void subscribeActual(Observer<? super TextViewAfterTextChangeEvent> observer) {
-    if (!checkMainThread(observer)) {
-      return;
-    }
+  protected void subscribeListener(Observer<? super TextViewAfterTextChangeEvent> observer) {
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.addTextChangedListener(listener);
-    observer.onNext(TextViewAfterTextChangeEvent.create(view, view.getEditableText()));
+  }
+
+  @Override protected TextViewAfterTextChangeEvent getInitialValue() {
+    return TextViewAfterTextChangeEvent.create(view, view.getEditableText());
   }
 
   static final class Listener extends MainThreadDisposable implements TextWatcher {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewBeforeTextChangeEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewBeforeTextChangeEventObservable.java
@@ -3,14 +3,12 @@ package com.jakewharton.rxbinding2.widget;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.widget.TextView;
-import io.reactivex.Observable;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
-
 final class TextViewBeforeTextChangeEventObservable
-    extends Observable<TextViewBeforeTextChangeEvent> {
+    extends InitialValueObservable<TextViewBeforeTextChangeEvent> {
   private final TextView view;
 
   TextViewBeforeTextChangeEventObservable(TextView view) {
@@ -18,14 +16,14 @@ final class TextViewBeforeTextChangeEventObservable
   }
 
   @Override
-  protected void subscribeActual(Observer<? super TextViewBeforeTextChangeEvent> observer) {
-    if (!checkMainThread(observer)) {
-      return;
-    }
+  protected void subscribeListener(Observer<? super TextViewBeforeTextChangeEvent> observer) {
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.addTextChangedListener(listener);
-    observer.onNext(TextViewBeforeTextChangeEvent.create(view, view.getText(), 0, 0, 0));
+  }
+
+  @Override protected TextViewBeforeTextChangeEvent getInitialValue() {
+    return TextViewBeforeTextChangeEvent.create(view, view.getText(), 0, 0, 0);
   }
 
   static final class Listener extends MainThreadDisposable implements TextWatcher {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewTextChangeEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewTextChangeEventObservable.java
@@ -3,13 +3,12 @@ package com.jakewharton.rxbinding2.widget;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.widget.TextView;
-import io.reactivex.Observable;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
-
-final class TextViewTextChangeEventObservable extends Observable<TextViewTextChangeEvent> {
+final class TextViewTextChangeEventObservable
+    extends InitialValueObservable<TextViewTextChangeEvent> {
   private final TextView view;
 
   TextViewTextChangeEventObservable(TextView view) {
@@ -17,14 +16,14 @@ final class TextViewTextChangeEventObservable extends Observable<TextViewTextCha
   }
 
   @Override
-  protected void subscribeActual(Observer<? super TextViewTextChangeEvent> observer) {
-    if (!checkMainThread(observer)) {
-      return;
-    }
+  protected void subscribeListener(Observer<? super TextViewTextChangeEvent> observer) {
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.addTextChangedListener(listener);
-    observer.onNext(TextViewTextChangeEvent.create(view, view.getText(), 0, 0, 0));
+  }
+
+  @Override protected TextViewTextChangeEvent getInitialValue() {
+    return TextViewTextChangeEvent.create(view, view.getText(), 0, 0, 0);
   }
 
   final static class Listener extends MainThreadDisposable implements TextWatcher {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewTextObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewTextObservable.java
@@ -3,13 +3,11 @@ package com.jakewharton.rxbinding2.widget;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.widget.TextView;
-import io.reactivex.Observable;
+import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
-
-final class TextViewTextObservable extends Observable<CharSequence> {
+final class TextViewTextObservable extends InitialValueObservable<CharSequence> {
   private final TextView view;
 
   TextViewTextObservable(TextView view) {
@@ -17,14 +15,14 @@ final class TextViewTextObservable extends Observable<CharSequence> {
   }
 
   @Override
-  protected void subscribeActual(Observer<? super CharSequence> observer) {
-    if (!checkMainThread(observer)) {
-      return;
-    }
+  protected void subscribeListener(Observer<? super CharSequence> observer) {
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
     view.addTextChangedListener(listener);
-    observer.onNext(view.getText());
+  }
+
+  @Override protected CharSequence getInitialValue() {
+    return view.getText();
   }
 
   final static class Listener extends MainThreadDisposable implements TextWatcher {


### PR DESCRIPTION
Closes #153.