### PR TITLE
Restrict internal APIs to library group.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
   kotlinPlugin = 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.0.4'
   kotlinStdlib = 'org.jetbrains.kotlin:kotlin-stdlib:1.0.4'
 
-  supportVersion = '25.0.1'
+  supportVersion = '25.1.1'
   supportAnnotations = "com.android.support:support-annotations:$supportVersion"
   supportV4CoreUi = "com.android.support:support-core-ui:$supportVersion"
   supportRecyclerView = "com.android.support:recyclerview-v7:$supportVersion"

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/internal/Functions.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/internal/Functions.java
@@ -1,8 +1,12 @@
 package com.jakewharton.rxbinding2.internal;
 
-import java.util.concurrent.Callable;
+import android.support.annotation.RestrictTo;
 import io.reactivex.functions.Predicate;
+import java.util.concurrent.Callable;
 
+import static android.support.annotation.RestrictTo.Scope.LIBRARY_GROUP;
+
+@RestrictTo(LIBRARY_GROUP)
 public final class Functions {
   private static final Always ALWAYS_TRUE = new Always(true);
   public static final Callable<Boolean> CALLABLE_ALWAYS_TRUE = ALWAYS_TRUE;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/internal/GenericTypeNullable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/internal/GenericTypeNullable.java
@@ -1,9 +1,12 @@
 package com.jakewharton.rxbinding2.internal;
 
+import android.support.annotation.RestrictTo;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
+import static android.support.annotation.RestrictTo.Scope.LIBRARY_GROUP;
 
 /**
  * This is used to mark a method as having nullable return type parameters
@@ -11,5 +14,6 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.SOURCE)
+@RestrictTo(LIBRARY_GROUP)
 public @interface GenericTypeNullable {
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/internal/Notification.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/internal/Notification.java
@@ -1,5 +1,10 @@
 package com.jakewharton.rxbinding2.internal;
 
+import android.support.annotation.RestrictTo;
+
+import static android.support.annotation.RestrictTo.Scope.LIBRARY_GROUP;
+
+@RestrictTo(LIBRARY_GROUP)
 public enum Notification {
   INSTANCE
 }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/internal/Preconditions.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/internal/Preconditions.java
@@ -14,20 +14,17 @@
 package com.jakewharton.rxbinding2.internal;
 
 import android.os.Looper;
+import android.support.annotation.RestrictTo;
 import io.reactivex.Observer;
 
-public final class Preconditions {
-  public static void checkArgument(boolean assertion, String message) {
-    if (!assertion) {
-      throw new IllegalArgumentException(message);
-    }
-  }
+import static android.support.annotation.RestrictTo.Scope.LIBRARY_GROUP;
 
-  public static <T> T checkNotNull(T value, String message) {
+@RestrictTo(LIBRARY_GROUP)
+public final class Preconditions {
+  public static void checkNotNull(Object value, String message) {
     if (value == null) {
       throw new NullPointerException(message);
     }
-    return value;
   }
 
   public static boolean checkMainThread(Observer<?> observer) {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/RxView.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/RxView.java
@@ -17,7 +17,6 @@ import java.util.concurrent.Callable;
 
 import static android.os.Build.VERSION_CODES.JELLY_BEAN;
 import static android.os.Build.VERSION_CODES.M;
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkArgument;
 import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
 import static com.jakewharton.rxbinding2.internal.Functions.CALLABLE_ALWAYS_TRUE;
 import static com.jakewharton.rxbinding2.internal.Functions.PREDICATE_ALWAYS_TRUE;
@@ -507,10 +506,13 @@ public final class RxView {
   public static Consumer<? super Boolean> visibility(@NonNull final View view,
       final int visibilityWhenFalse) {
     checkNotNull(view, "view == null");
-    checkArgument(visibilityWhenFalse != View.VISIBLE,
-        "Setting visibility to VISIBLE when false would have no effect.");
-    checkArgument(visibilityWhenFalse == View.INVISIBLE || visibilityWhenFalse == View.GONE,
-        "Must set visibility to INVISIBLE or GONE when false.");
+    if (visibilityWhenFalse == View.VISIBLE) {
+      throw new IllegalArgumentException(
+          "Setting visibility to VISIBLE when false would have no effect.");
+    }
+    if (visibilityWhenFalse != View.INVISIBLE && visibilityWhenFalse != View.GONE) {
+      throw new IllegalArgumentException("Must set visibility to INVISIBLE or GONE when false.");
+    }
     return new Consumer<Boolean>() {
       @Override public void accept(Boolean value) {
         view.setVisibility(value ? View.VISIBLE : visibilityWhenFalse);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewEvent.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewEvent.java
@@ -15,7 +15,8 @@ public abstract class ViewEvent<T extends View> {
   private final T view;
 
   protected ViewEvent(@NonNull T view) {
-    this.view = checkNotNull(view, "view == null");
+    checkNotNull(view, "view == null");
+    this.view = view;
   }
 
   /** The view from which this event occurred. */


### PR DESCRIPTION
Inline checkArgument method which was only used twice (and both inside a single method).