### PR TITLE
Call onNext and return handled response

### DIFF
--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewTouchObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/ViewTouchObservable.java
@@ -43,10 +43,8 @@ final class ViewTouchObservable extends Observable<MotionEvent> {
     @Override public boolean onTouch(View v, MotionEvent event) {
       if (!isDisposed()) {
         try {
-          if (handled.test(event)) {
-            observer.onNext(event);
-            return true;
-          }
+          observer.onNext(event);
+          return handled.test(event);
         } catch (Exception e) {
           observer.onError(e);
           dispose();


### PR DESCRIPTION
With the current implementation, the observable won't be triggered if you want to return false to the `View.OnTouchListener` `onTouch` method.  This change means the `onNext` method gets called on the observer and the `onTouch` method has it's return value set as sepcified in the passed in Predicate