### PR TITLE
FIX: Private member access between outer and inner classes

### DIFF
--- a/rxbinding-appcompat-v7/src/androidTest/java/com/jakewharton/rxbinding2/support/v7/widget/RxPopupMenuTest.java
+++ b/rxbinding-appcompat-v7/src/androidTest/java/com/jakewharton/rxbinding2/support/v7/widget/RxPopupMenuTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertSame;
 
   private final Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
 
-  private PopupMenu view;
+  PopupMenu view;
 
   @Before public void setUp() {
     view = activityRule.getActivity().popupMenu;

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/SearchViewQueryTextChangeEventsObservable.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/SearchViewQueryTextChangeEventsObservable.java
@@ -9,7 +9,7 @@ import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class SearchViewQueryTextChangeEventsObservable
     extends InitialValueObservable<SearchViewQueryTextEvent> {
-  private final SearchView view;
+  final SearchView view;
 
   SearchViewQueryTextChangeEventsObservable(SearchView view) {
     this.view = view;

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/SnackbarDismissesObservable.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/SnackbarDismissesObservable.java
@@ -26,7 +26,7 @@ final class SnackbarDismissesObservable extends Observable<Integer> {
 
   final class Listener extends MainThreadDisposable {
     private final Snackbar snackbar;
-    private final Callback callback;
+    final Callback callback;
 
     Listener(Snackbar snackbar, final Observer<? super Integer> observer) {
       this.snackbar = snackbar;

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/TabLayoutSelectionEventObservable.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/TabLayoutSelectionEventObservable.java
@@ -9,7 +9,7 @@ import io.reactivex.android.MainThreadDisposable;
 import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
 
 final class TabLayoutSelectionEventObservable extends Observable<TabLayoutSelectionEvent> {
-  private final TabLayout view;
+  final TabLayout view;
 
   TabLayoutSelectionEventObservable(TabLayout view) {
     this.view = view;

--- a/rxbinding-recyclerview-v7/src/androidTest/java/com/jakewharton/rxbinding2/support/v7/widget/RxRecyclerViewAdapterTest.java
+++ b/rxbinding-recyclerview-v7/src/androidTest/java/com/jakewharton/rxbinding2/support/v7/widget/RxRecyclerViewAdapterTest.java
@@ -36,6 +36,9 @@ public final class RxRecyclerViewAdapterTest {
   }
 
   private static final class TestRecyclerAdapter extends RecyclerView.Adapter<ViewHolder> {
+    TestRecyclerAdapter() {
+    }
+
     @Override public ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
       return null;
     }

--- a/rxbinding-recyclerview-v7/src/androidTest/java/com/jakewharton/rxbinding2/support/v7/widget/RxRecyclerViewTest.java
+++ b/rxbinding-recyclerview-v7/src/androidTest/java/com/jakewharton/rxbinding2/support/v7/widget/RxRecyclerViewTest.java
@@ -3,8 +3,6 @@ package com.jakewharton.rxbinding2.support.v7.widget;
 import android.app.Instrumentation;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.espresso.Espresso;
-import android.support.test.espresso.ViewInteraction;
-import android.support.test.espresso.matcher.ViewMatchers;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.support.v7.widget.LinearLayoutManager;
@@ -13,8 +11,8 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
-import com.jakewharton.rxbinding2.RecordingObserver;
 import com.jakewharton.rxbinding.ViewDirtyIdlingResource;
+import com.jakewharton.rxbinding2.RecordingObserver;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import org.junit.After;
 import org.junit.Before;
@@ -32,8 +30,7 @@ public final class RxRecyclerViewTest {
 
   private final Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
 
-  private RecyclerView view;
-  private ViewInteraction interaction;
+  RecyclerView view;
   private ViewDirtyIdlingResource viewDirtyIdler;
   private View child;
 
@@ -41,7 +38,6 @@ public final class RxRecyclerViewTest {
     RxRecyclerViewTestActivity activity = activityRule.getActivity();
     view = activity.recyclerView;
     child = new View(activityRule.getActivity());
-    interaction = Espresso.onView(ViewMatchers.withId(android.R.id.primary));
     viewDirtyIdler = new ViewDirtyIdlingResource(activity);
     Espresso.registerIdlingResources(viewDirtyIdler);
   }
@@ -227,7 +223,7 @@ public final class RxRecyclerViewTest {
   private class SimpleAdapter extends RecyclerView.Adapter {
     private final View child;
 
-    public SimpleAdapter(View child) {
+    SimpleAdapter(View child) {
       this.child = child;
     }
 
@@ -271,7 +267,7 @@ public final class RxRecyclerViewTest {
 
     TextView textView;
 
-    public ViewHolder(TextView itemView) {
+    ViewHolder(TextView itemView) {
       super(itemView);
       this.textView = itemView;
     }

--- a/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RecyclerAdapterDataChangeObservable.java
+++ b/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RecyclerAdapterDataChangeObservable.java
@@ -32,7 +32,7 @@ final class RecyclerAdapterDataChangeObservable<T extends Adapter<? extends View
 
   final class Listener extends MainThreadDisposable {
     private final T recyclerAdapter;
-    private final AdapterDataObserver dataObserver;
+    final AdapterDataObserver dataObserver;
 
     Listener(final T recyclerAdapter, final Observer<? super T> observer) {
       this.recyclerAdapter = recyclerAdapter;

--- a/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RecyclerViewScrollEventObservable.java
+++ b/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RecyclerViewScrollEventObservable.java
@@ -25,7 +25,7 @@ final class RecyclerViewScrollEventObservable extends Observable<RecyclerViewScr
 
   final class Listener extends MainThreadDisposable {
     private final RecyclerView recyclerView;
-    private final RecyclerView.OnScrollListener scrollListener;
+    final RecyclerView.OnScrollListener scrollListener;
 
     Listener(RecyclerView recyclerView, final Observer<? super RecyclerViewScrollEvent> observer) {
       this.recyclerView = recyclerView;

--- a/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RecyclerViewScrollStateChangeObservable.java
+++ b/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RecyclerViewScrollStateChangeObservable.java
@@ -25,7 +25,7 @@ final class RecyclerViewScrollStateChangeObservable extends Observable<Integer> 
 
   final class Listener extends MainThreadDisposable {
     private final RecyclerView recyclerView;
-    private final RecyclerView.OnScrollListener scrollListener;
+    final RecyclerView.OnScrollListener scrollListener;
 
     Listener(RecyclerView recyclerView, final Observer<? super Integer> observer) {
       this.recyclerView = recyclerView;

--- a/rxbinding-support-v4/src/androidTest/java/com/jakewharton/rxbinding2/support/v4/view/RxViewPagerTestActivity.java
+++ b/rxbinding-support-v4/src/androidTest/java/com/jakewharton/rxbinding2/support/v4/view/RxViewPagerTestActivity.java
@@ -23,6 +23,8 @@ public final class RxViewPagerTestActivity extends Activity {
   }
 
   private static class Adapter extends PagerAdapter {
+    Adapter() {
+    }
 
     @Override public int getCount() {
       return 20;

--- a/rxbinding-support-v4/src/androidTest/java/com/jakewharton/rxbinding2/support/v4/widget/RxDrawerLayoutTest.java
+++ b/rxbinding-support-v4/src/androidTest/java/com/jakewharton/rxbinding2/support/v4/widget/RxDrawerLayoutTest.java
@@ -33,7 +33,7 @@ public final class RxDrawerLayoutTest {
 
   private final Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
 
-  private DrawerLayout view;
+  DrawerLayout view;
   private ViewDirtyIdlingResource viewDirtyIdler;
 
   @Before public void setUp() {

--- a/rxbinding-support-v4/src/androidTest/java/com/jakewharton/rxbinding2/support/v4/widget/RxSlidingPaneLayoutTest.java
+++ b/rxbinding-support-v4/src/androidTest/java/com/jakewharton/rxbinding2/support/v4/widget/RxSlidingPaneLayoutTest.java
@@ -33,9 +33,9 @@ import static org.junit.Assert.assertTrue;
 
   private final Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
 
-  private SlidingPaneLayout view;
+  SlidingPaneLayout view;
 
-  private CountingIdlingResource idler;
+  CountingIdlingResource idler;
 
   @Before public void setUp() {
     RxSlidingPaneLayoutTestActivity activity = activityRule.getActivity();

--- a/rxbinding-support-v4/src/androidTest/java/com/jakewharton/rxbinding2/support/v4/widget/RxSwipeRefreshLayoutTestActivity.java
+++ b/rxbinding-support-v4/src/androidTest/java/com/jakewharton/rxbinding2/support/v4/widget/RxSwipeRefreshLayoutTestActivity.java
@@ -18,8 +18,8 @@ import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
 public final class RxSwipeRefreshLayoutTestActivity extends Activity {
   SwipeRefreshLayout swipeRefreshLayout;
 
-  private final Handler handler = new Handler(Looper.getMainLooper());
-  private final Runnable stopRefreshing = new Runnable() {
+  final Handler handler = new Handler(Looper.getMainLooper());
+  final Runnable stopRefreshing = new Runnable() {
     @Override public void run() {
       swipeRefreshLayout.setRefreshing(false);
     }

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/view/RxViewAttachTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/view/RxViewAttachTest.java
@@ -22,8 +22,8 @@ public final class RxViewAttachTest {
       new ActivityTestRule<>(RxViewAttachTestActivity.class);
 
   private final Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
-  private FrameLayout parent;
-  private View child;
+  FrameLayout parent;
+  View child;
 
   @Before public void setUp() {
     RxViewAttachTestActivity activity = activityRule.getActivity();

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/view/RxViewSystemUiVisibilityTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/view/RxViewSystemUiVisibilityTest.java
@@ -21,7 +21,7 @@ public final class RxViewSystemUiVisibilityTest {
       new ActivityTestRule<>(RxViewSystemUiVisibilityTestActivity.class);
 
   private final Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
-  private FrameLayout root;
+  FrameLayout root;
 
   @Before public void setUp() {
     RxViewSystemUiVisibilityTestActivity activity = activityRule.getActivity();

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/widget/RxAbsListViewTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/widget/RxAbsListViewTest.java
@@ -22,7 +22,7 @@ public final class RxAbsListViewTest {
   private Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
 
   private RxAbsListViewTestActivity activity;
-  private ListView listView;
+  ListView listView;
 
   @Before public void setUp() {
     activity = activityRule.getActivity();

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/widget/RxAbsListViewTestActivity.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/widget/RxAbsListViewTestActivity.java
@@ -29,7 +29,7 @@ public final class RxAbsListViewTestActivity extends Activity {
   }
 
   private static List<String> createValues(int count) {
-    final List<String> values = new ArrayList<String>(count);
+    final List<String> values = new ArrayList<>(count);
     for (int i = 0; i < count; i++) {
       values.add(String.valueOf(i));
     }

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/widget/RxAdapterTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/widget/RxAdapterTest.java
@@ -36,6 +36,9 @@ public final class RxAdapterTest {
   }
 
   private static final class TestAdapter extends BaseAdapter {
+    TestAdapter() {
+    }
+
     @Override public int getCount() {
       return 0;
     }

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/widget/RxAdapterViewTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/widget/RxAdapterViewTest.java
@@ -26,9 +26,9 @@ public final class RxAdapterViewTest {
 
   private Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
 
-  private RxAdapterViewTestActivity activity;
-  private Spinner spinner;
-  private ListView listView;
+  RxAdapterViewTestActivity activity;
+  Spinner spinner;
+  ListView listView;
 
   @Before public void setUp() {
     activity = activityRule.getActivity();

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/widget/RxAutoCompleteTextViewTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/widget/RxAutoCompleteTextViewTest.java
@@ -41,7 +41,7 @@ public final class RxAutoCompleteTextViewTest {
   private final Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
 
   private RxAutoCompleteTextViewTestActivity activity;
-  private AutoCompleteTextView autoCompleteTextView;
+  AutoCompleteTextView autoCompleteTextView;
 
   @Before public void setUp() {
     activity = activityRule.getActivity();

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/widget/RxPopupMenuTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/widget/RxPopupMenuTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertSame;
 
   private final Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
 
-  private PopupMenu view;
+  PopupMenu view;
 
   @Before public void setUp() {
     view = activityRule.getActivity().popupMenu;

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/widget/RxRatingBarTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/widget/RxRatingBarTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertTrue;
 
   private final Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
 
-  private RatingBar view;
+  RatingBar view;
 
   @Before public void setUp() {
     view = activityRule.getActivity().ratingBar;

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/widget/RxSeekBarTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/widget/RxSeekBarTest.java
@@ -25,7 +25,7 @@ public final class RxSeekBarTest {
 
   private final Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
 
-  private SeekBar seekBar;
+  SeekBar seekBar;
 
   @Before public void setUp() {
     seekBar = activityRule.getActivity().seekBar;

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterDataChangeObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/AdapterDataChangeObservable.java
@@ -30,7 +30,7 @@ final class AdapterDataChangeObservable<T extends Adapter> extends InitialValueO
 
   static final class ObserverDisposable<T extends Adapter> extends MainThreadDisposable {
     private final T adapter;
-    private final DataSetObserver dataSetObserver;
+    final DataSetObserver dataSetObserver;
 
     ObserverDisposable(final T adapter, final Observer<? super T> observer) {
       this.adapter = adapter;


### PR DESCRIPTION
Made package-private all private members accessed from inner classes, including tests.

fix #379 

the tests ran fine here: https://travis-ci.org/oldergod/RxBinding/builds/230737839