### PR TITLE
FIX: Use of Snackbar.add/removeCallback instead of setCallback.

### DIFF
--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/SnackbarDismissesObservable.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/SnackbarDismissesObservable.java
@@ -21,7 +21,7 @@ final class SnackbarDismissesObservable extends Observable<Integer> {
     }
     Listener listener = new Listener(view, observer);
     observer.onSubscribe(listener);
-    view.setCallback(listener.callback);
+    view.addCallback(listener.callback);
   }
 
   final class Listener extends MainThreadDisposable {
@@ -40,7 +40,7 @@ final class SnackbarDismissesObservable extends Observable<Integer> {
     }
 
     @Override protected void onDispose() {
-      snackbar.setCallback(null);
+      snackbar.removeCallback(callback);
     }
   }
 }


### PR DESCRIPTION
setCallback is deprecated and should be replaced with the usage of addCallback and removeCallback. The PR applies the change.

the tests ran fine locally.