### PR TITLE
Call onSubscribe before onError when main thread check fails.

### DIFF
--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/internal/PreconditionsTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding2/internal/PreconditionsTest.java
@@ -1,0 +1,30 @@
+package com.jakewharton.rxbinding2.internal;
+
+import android.support.test.annotation.UiThreadTest;
+import android.support.test.rule.UiThreadTestRule;
+import com.jakewharton.rxbinding2.RecordingObserver;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public final class PreconditionsTest {
+  @Rule public final TestRule uiThread = new UiThreadTestRule();
+
+  @UiThreadTest
+  @Test public void checkMainOnMainDoesNotNotify() {
+    RecordingObserver<Object> o = new RecordingObserver<>();
+    assertTrue(Preconditions.checkMainThread(o));
+    o.assertNoMoreEvents();
+  }
+
+  @Test public void checkMainOnNotMainNotifies() {
+    RecordingObserver<Object> o = new RecordingObserver<>();
+    assertFalse(Preconditions.checkMainThread(o));
+    Throwable e = o.takeError();
+    assertTrue(e instanceof IllegalStateException);
+    assertTrue(e.getMessage().startsWith("Expected to be called on the main thread but was "));
+  }
+}

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/internal/Preconditions.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/internal/Preconditions.java
@@ -16,6 +16,7 @@ package com.jakewharton.rxbinding2.internal;
 import android.os.Looper;
 import android.support.annotation.RestrictTo;
 import io.reactivex.Observer;
+import io.reactivex.disposables.Disposables;
 
 import static android.support.annotation.RestrictTo.Scope.LIBRARY_GROUP;
 
@@ -29,6 +30,7 @@ public final class Preconditions {
 
   public static boolean checkMainThread(Observer<?> observer) {
     if (Looper.myLooper() != Looper.getMainLooper()) {
+      observer.onSubscribe(Disposables.empty());
       observer.onError(new IllegalStateException(
           "Expected to be called on the main thread but was " + Thread.currentThread().getName()));
       return false;


### PR DESCRIPTION
Closes #391.