### PR TITLE
Fix ViewPagerPageScrollStateChangedObservable

### DIFF
--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/ViewPagerPageScrollStateChangedObservable.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/ViewPagerPageScrollStateChangedObservable.java
@@ -49,9 +49,7 @@ final class ViewPagerPageScrollStateChangedObservable extends Observable<Integer
     }
 
     @Override protected void onDispose() {
-      if (!isDisposed()) {
-        view.removeOnPageChangeListener(this);
-      }
+      view.removeOnPageChangeListener(this);
     }
   }
 }


### PR DESCRIPTION
Since onDispose is called exactly once there is no need to check is it was already disposed.
It fixes #406