### PR TITLE
Preserving nullability contracts in runtime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+  id 'tech.harmonysoft.oss.traute' version '1.1.8'
+}
+
 subprojects {
   buildscript {
     repositories {
@@ -11,6 +15,11 @@ subprojects {
   }
 
   plugins.apply('checkstyle')
+  apply plugin: 'tech.harmonysoft.oss.traute'
+
+  traute {
+    exceptionTexts = [ 'parameter': '${PARAMETER_NAME} == null' ]
+  }
 
   task('checkstyle', type: Checkstyle) {
     configFile rootProject.file('checkstyle.xml')

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RxActionMenuView.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RxActionMenuView.java
@@ -6,8 +6,6 @@ import android.support.v7.widget.ActionMenuView;
 import android.view.MenuItem;
 import io.reactivex.Observable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 /**
  * Static factory methods for creating {@linkplain Observable observables} for
  * {@link android.widget.ActionMenuView}.
@@ -22,7 +20,6 @@ public final class RxActionMenuView {
    */
   @CheckResult @NonNull
   public static Observable<MenuItem> itemClicks(@NonNull ActionMenuView view) {
-    checkNotNull(view, "view == null");
     return new ActionMenuViewItemClickObservable(view);
   }
 

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RxPopupMenu.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RxPopupMenu.java
@@ -6,8 +6,6 @@ import android.support.v7.widget.PopupMenu;
 import android.view.MenuItem;
 import io.reactivex.Observable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 /**
  * Static factory methods for creating {@linkplain Observable observables} for {@link PopupMenu}.
  */
@@ -23,7 +21,6 @@ public final class RxPopupMenu {
    */
   @CheckResult @NonNull
   public static Observable<MenuItem> itemClicks(@NonNull PopupMenu view) {
-    checkNotNull(view, "view == null");
     return new PopupMenuItemClickObservable(view);
   }
 
@@ -39,7 +36,6 @@ public final class RxPopupMenu {
    */
   @CheckResult @NonNull
   public static Observable<Object> dismisses(@NonNull PopupMenu view) {
-    checkNotNull(view, "view == null");
     return new PopupMenuDismissObservable(view);
   }
 

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RxSearchView.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RxSearchView.java
@@ -7,8 +7,6 @@ import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observable;
 import io.reactivex.functions.Consumer;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 /**
  * Static factory methods for creating {@linkplain Observable observables} and {@linkplain Action1
  * actions} for {@link SearchView}.
@@ -26,7 +24,6 @@ public final class RxSearchView {
   @CheckResult @NonNull
   public static InitialValueObservable<SearchViewQueryTextEvent> queryTextChangeEvents(
       @NonNull SearchView view) {
-    checkNotNull(view, "view == null");
     return new SearchViewQueryTextChangeEventsObservable(view);
   }
 
@@ -40,7 +37,6 @@ public final class RxSearchView {
    */
   @CheckResult @NonNull
   public static InitialValueObservable<CharSequence> queryTextChanges(@NonNull SearchView view) {
-    checkNotNull(view, "view == null");
     return new SearchViewQueryTextChangesObservable(view);
   }
 
@@ -55,7 +51,6 @@ public final class RxSearchView {
   @CheckResult @NonNull
   public static Consumer<? super CharSequence> query(@NonNull final SearchView view,
       final boolean submit) {
-    checkNotNull(view, "view == null");
     return new Consumer<CharSequence>() {
       @Override public void accept(CharSequence text) {
         view.setQuery(text, submit);

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RxToolbar.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RxToolbar.java
@@ -8,8 +8,6 @@ import com.jakewharton.rxbinding2.internal.GenericTypeNullable;
 import io.reactivex.Observable;
 import io.reactivex.functions.Consumer;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 /**
  * Static factory methods for creating {@linkplain Observable observables} for {@link Toolbar}.
  */
@@ -22,7 +20,6 @@ public final class RxToolbar {
    */
   @CheckResult @NonNull
   public static Observable<MenuItem> itemClicks(@NonNull Toolbar view) {
-    checkNotNull(view, "view == null");
     return new ToolbarItemClickObservable(view);
   }
 
@@ -38,7 +35,6 @@ public final class RxToolbar {
    */
   @CheckResult @NonNull
   public static Observable<Object> navigationClicks(@NonNull Toolbar view) {
-    checkNotNull(view, "view == null");
     return new ToolbarNavigationClickObservable(view);
   }
 
@@ -50,7 +46,6 @@ public final class RxToolbar {
    */
   @CheckResult @NonNull @GenericTypeNullable
   public static Consumer<? super CharSequence> title(@NonNull final Toolbar view) {
-    checkNotNull(view, "view == null");
     return new Consumer<CharSequence>() {
       @Override public void accept(CharSequence title) {
         view.setTitle(title);
@@ -66,7 +61,6 @@ public final class RxToolbar {
    */
   @CheckResult @NonNull
   public static Consumer<? super Integer> titleRes(@NonNull final Toolbar view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Integer>() {
       @Override public void accept(Integer titleRes) {
         view.setTitle(titleRes);
@@ -82,7 +76,6 @@ public final class RxToolbar {
    */
   @CheckResult @NonNull @GenericTypeNullable
   public static Consumer<? super CharSequence> subtitle(@NonNull final Toolbar view) {
-    checkNotNull(view, "view == null");
     return new Consumer<CharSequence>() {
       @Override public void accept(CharSequence subtitle) {
         view.setSubtitle(subtitle);
@@ -98,7 +91,6 @@ public final class RxToolbar {
    */
   @CheckResult @NonNull
   public static Consumer<? super Integer> subtitleRes(@NonNull final Toolbar view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Integer>() {
       @Override public void accept(Integer subtitleRes) {
         view.setSubtitle(subtitleRes);

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/RxAppBarLayout.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/RxAppBarLayout.java
@@ -5,8 +5,6 @@ import android.support.annotation.NonNull;
 import android.support.design.widget.AppBarLayout;
 import io.reactivex.Observable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 /**
  * Static factory methods for creating {@linkplain Observable observables} for {@link AppBarLayout}.
  */
@@ -20,7 +18,6 @@ public final class RxAppBarLayout {
    */
   @CheckResult @NonNull
   public static Observable<Integer> offsetChanges(@NonNull AppBarLayout view) {
-    checkNotNull(view, "view == null");
     return new AppBarLayoutOffsetChangeObservable(view);
   }
 

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/RxBottomNavigationView.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/RxBottomNavigationView.java
@@ -6,8 +6,6 @@ import android.support.design.widget.BottomNavigationView;
 import android.view.MenuItem;
 import io.reactivex.Observable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 /**
  * Static factory methods for creating {@linkplain Observable observables} for
  * {@link BottomNavigationView}.
@@ -24,7 +22,6 @@ public final class RxBottomNavigationView {
    */
   @CheckResult @NonNull public static Observable<MenuItem> itemSelections(
       @NonNull BottomNavigationView view) {
-    checkNotNull(view, "view == null");
     return new BottomNavigationViewItemSelectionsObservable(view);
   }
 

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/RxNavigationView.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/RxNavigationView.java
@@ -6,8 +6,6 @@ import android.support.design.widget.NavigationView;
 import android.view.MenuItem;
 import io.reactivex.Observable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 /**
  * Static factory methods for creating {@linkplain Observable observables} for
  * {@link NavigationView}.
@@ -24,7 +22,6 @@ public final class RxNavigationView {
    */
   @CheckResult @NonNull
   public static Observable<MenuItem> itemSelections(@NonNull NavigationView view) {
-    checkNotNull(view, "view == null");
     return new NavigationViewItemSelectionsObservable(view);
   }
 

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/RxSnackbar.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/RxSnackbar.java
@@ -5,8 +5,6 @@ import android.support.annotation.NonNull;
 import android.support.design.widget.Snackbar;
 import io.reactivex.Observable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 /**
  * Static factory methods for creating {@linkplain Observable observables} for {@link Snackbar}.
  */
@@ -19,7 +17,6 @@ public final class RxSnackbar {
    */
   @CheckResult @NonNull
   public static Observable<Integer> dismisses(@NonNull Snackbar view) {
-    checkNotNull(view, "view == null");
     return new SnackbarDismissesObservable(view);
   }
 

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/RxSwipeDismissBehavior.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/RxSwipeDismissBehavior.java
@@ -6,8 +6,6 @@ import android.support.design.widget.SwipeDismissBehavior;
 import android.view.View;
 import io.reactivex.Observable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 /**
  * Static factory methods for creating {@linkplain Observable observables}
  * for {@link SwipeDismissBehavior} on (@link View).
@@ -22,7 +20,6 @@ public final class RxSwipeDismissBehavior {
    */
   @CheckResult @NonNull
   public static Observable<View> dismisses(@NonNull View view) {
-    checkNotNull(view, "view == null");
     return new SwipeDismissBehaviorObservable(view);
   }
 

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/RxTabLayout.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/RxTabLayout.java
@@ -7,8 +7,6 @@ import android.support.design.widget.TabLayout.Tab;
 import io.reactivex.Observable;
 import io.reactivex.functions.Consumer;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 /**
  * Static factory methods for creating {@linkplain Observable observables} and {@linkplain Consumer
  * actions} for {@link TabLayout}.
@@ -24,7 +22,6 @@ public final class RxTabLayout {
    */
   @CheckResult @NonNull
   public static Observable<Tab> selections(@NonNull TabLayout view) {
-    checkNotNull(view, "view == null");
     return new TabLayoutSelectionsObservable(view);
   }
 
@@ -39,7 +36,6 @@ public final class RxTabLayout {
    */
   @CheckResult @NonNull
   public static Observable<TabLayoutSelectionEvent> selectionEvents(@NonNull TabLayout view) {
-    checkNotNull(view, "view == null");
     return new TabLayoutSelectionEventObservable(view);
   }
 
@@ -51,7 +47,6 @@ public final class RxTabLayout {
    */
   @CheckResult @NonNull
   public static Consumer<? super Integer> select(@NonNull final TabLayout view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Integer>() {
       @Override public void accept(Integer index) {
         if (index < 0 || index >= view.getTabCount()) {

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/RxTextInputLayout.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/RxTextInputLayout.java
@@ -6,8 +6,6 @@ import android.support.design.widget.TextInputLayout;
 import com.jakewharton.rxbinding2.internal.GenericTypeNullable;
 import io.reactivex.functions.Consumer;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 /**
  * Static factory methods for creating {@linkplain Consumer actions} for {@link TextInputLayout}.
  */
@@ -21,7 +19,6 @@ public final class RxTextInputLayout {
    */
   @CheckResult @NonNull
   public static Consumer<? super Boolean> counterEnabled(@NonNull final TextInputLayout view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Boolean>() {
       @Override public void accept(Boolean enable) {
         view.setCounterEnabled(enable);
@@ -37,7 +34,6 @@ public final class RxTextInputLayout {
    */
   @CheckResult @NonNull
   public static Consumer<? super Integer> counterMaxLength(@NonNull final TextInputLayout view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Integer>() {
       @Override public void accept(Integer maxLength) {
         view.setCounterMaxLength(maxLength);
@@ -53,7 +49,6 @@ public final class RxTextInputLayout {
    */
   @CheckResult @NonNull @GenericTypeNullable
   public static Consumer<? super CharSequence> error(@NonNull final TextInputLayout view) {
-    checkNotNull(view, "view == null");
     return new Consumer<CharSequence>() {
       @Override
       public void accept(CharSequence error) {
@@ -70,7 +65,6 @@ public final class RxTextInputLayout {
    */
   @CheckResult @NonNull @GenericTypeNullable
   public static Consumer<? super Integer> errorRes(@NonNull final TextInputLayout view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Integer>() {
       @Override
       public void accept(Integer errorRes) {
@@ -87,7 +81,6 @@ public final class RxTextInputLayout {
    */
   @CheckResult @NonNull
   public static Consumer<? super CharSequence> hint(@NonNull final TextInputLayout view) {
-    checkNotNull(view, "view == null");
     return new Consumer<CharSequence>() {
       @Override public void accept(CharSequence hint) {
         view.setHint(hint);
@@ -103,7 +96,6 @@ public final class RxTextInputLayout {
    */
   @CheckResult @NonNull
   public static Consumer<? super Integer> hintRes(@NonNull final TextInputLayout view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Integer>() {
       @Override public void accept(Integer hintRes) {
         view.setHint(view.getContext().getResources().getText(hintRes));

--- a/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding2/support/v17/leanback/widget/RxSearchBar.java
+++ b/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding2/support/v17/leanback/widget/RxSearchBar.java
@@ -6,8 +6,6 @@ import android.support.v17.leanback.widget.SearchBar;
 import io.reactivex.Observable;
 import io.reactivex.functions.Consumer;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 /**
  * Static factory methods for creating {@linkplain Observable observables} and {@linkplain Consumer
  * actions} for {@link SearchBar}.
@@ -25,7 +23,6 @@ public final class RxSearchBar {
   @NonNull
   public static Observable<SearchBarSearchQueryEvent> searchQueryChangeEvents(
           @NonNull SearchBar view) {
-    checkNotNull(view, "view == null");
     return new SearchBarSearchQueryChangeEventsOnSubscribe(view);
   }
 
@@ -38,7 +35,6 @@ public final class RxSearchBar {
    */
   @CheckResult @NonNull
   public static Observable<String> searchQueryChanges(@NonNull SearchBar view) {
-    checkNotNull(view, "view == null");
     return new SearchBarSearchQueryChangesOnSubscribe(view);
   }
 
@@ -50,7 +46,6 @@ public final class RxSearchBar {
    */
   @CheckResult @NonNull
   public static Consumer<? super String> searchQuery(@NonNull final SearchBar view) {
-    checkNotNull(view, "view == null");
     return new Consumer<String>() {
       @Override public void accept(String text) throws Exception {
         view.setSearchQuery(text);

--- a/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding2/support/v17/leanback/widget/RxSearchEditText.java
+++ b/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding2/support/v17/leanback/widget/RxSearchEditText.java
@@ -5,8 +5,6 @@ import android.support.annotation.NonNull;
 import android.support.v17.leanback.widget.SearchEditText;
 import io.reactivex.Observable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 /**
  * Static factory methods for creating {@linkplain Observable observables} for
  * {@link SearchEditText}.
@@ -20,7 +18,6 @@ public final class RxSearchEditText {
    */
   @CheckResult @NonNull
   public static Observable<Object> keyboardDismisses(@NonNull SearchEditText view) {
-    checkNotNull(view, "view == null");
     return new SearchEditTextKeyboardDismissOnSubscribe(view);
   }
 

--- a/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RxRecyclerView.java
+++ b/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RxRecyclerView.java
@@ -5,8 +5,6 @@ import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import io.reactivex.Observable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 /**
  * Static factory methods for creating {@linkplain Observable observables} for {@link RecyclerView}.
  */
@@ -21,7 +19,6 @@ public final class RxRecyclerView {
   @CheckResult @NonNull
   public static Observable<RecyclerViewChildAttachStateChangeEvent> childAttachStateChangeEvents(
       @NonNull RecyclerView view) {
-    checkNotNull(view, "view == null");
     return new RecyclerViewChildAttachStateChangeEventObservable(view);
   }
 
@@ -34,7 +31,6 @@ public final class RxRecyclerView {
   @CheckResult @NonNull
   public static Observable<RecyclerViewScrollEvent> scrollEvents(
       @NonNull RecyclerView view) {
-    checkNotNull(view, "view == null");
     return new RecyclerViewScrollEventObservable(view);
   }
 
@@ -46,7 +42,6 @@ public final class RxRecyclerView {
    */
   @CheckResult @NonNull
   public static Observable<Integer> scrollStateChanges(@NonNull RecyclerView view) {
-    checkNotNull(view, "view == null");
     return new RecyclerViewScrollStateChangeObservable(view);
   }
 

--- a/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RxRecyclerViewAdapter.java
+++ b/rxbinding-recyclerview-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RxRecyclerViewAdapter.java
@@ -7,8 +7,6 @@ import android.support.v7.widget.RecyclerView.ViewHolder;
 import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 /** Static factory methods for creating {@linkplain Observable observables} for {@link Adapter}. */
 public final class RxRecyclerViewAdapter {
   /**
@@ -19,7 +17,6 @@ public final class RxRecyclerViewAdapter {
   @CheckResult @NonNull
   public static <T extends Adapter<? extends ViewHolder>> InitialValueObservable<T> dataChanges(
       @NonNull T adapter) {
-    checkNotNull(adapter, "adapter == null");
     return new RecyclerAdapterDataChangeObservable<>(adapter);
   }
 

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/RxMenuItemCompat.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/RxMenuItemCompat.java
@@ -8,8 +8,6 @@ import com.jakewharton.rxbinding2.view.MenuItemActionViewEvent;
 import io.reactivex.Observable;
 import io.reactivex.functions.Predicate;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 /**
  * Static factory methods for creating {@linkplain Observable observables}
  * for {@link android.support.v4.view.MenuItemCompat}.
@@ -27,7 +25,6 @@ public final class RxMenuItemCompat {
    */
   @CheckResult @NonNull public static Observable<MenuItemActionViewEvent> actionViewEvents(
       @NonNull MenuItem menuItem) {
-    checkNotNull(menuItem, "menuItem == null");
     return new MenuItemActionViewEventObservable(menuItem, Functions.PREDICATE_ALWAYS_TRUE);
   }
 
@@ -45,8 +42,6 @@ public final class RxMenuItemCompat {
    */
   @CheckResult @NonNull public static Observable<MenuItemActionViewEvent> actionViewEvents(
       @NonNull MenuItem menuItem, @NonNull Predicate<? super MenuItemActionViewEvent> handled) {
-    checkNotNull(menuItem, "menuItem == null");
-    checkNotNull(handled, "handled == null");
     return new MenuItemActionViewEventObservable(menuItem, handled);
   }
 

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/RxViewPager.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/RxViewPager.java
@@ -7,8 +7,6 @@ import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observable;
 import io.reactivex.functions.Consumer;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 public final class RxViewPager {
   /**
    * Create an observable of scroll state change events on {@code view}.
@@ -19,7 +17,6 @@ public final class RxViewPager {
    */
   @CheckResult @NonNull public static Observable<Integer> pageScrollStateChanges(
       @NonNull ViewPager view) {
-    checkNotNull(view, "view == null");
     return new ViewPagerPageScrollStateChangedObservable(view);
   }
 
@@ -33,7 +30,6 @@ public final class RxViewPager {
    */
   @CheckResult @NonNull
   public static InitialValueObservable<Integer> pageSelections(@NonNull ViewPager view) {
-    checkNotNull(view, "view == null");
     return new ViewPagerPageSelectedObservable(view);
   }
 
@@ -45,7 +41,6 @@ public final class RxViewPager {
    */
   @CheckResult @NonNull public static Consumer<? super Integer> currentItem(
       @NonNull final ViewPager view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Integer>() {
       @Override public void accept(Integer value) {
         view.setCurrentItem(value);

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/RxDrawerLayout.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/RxDrawerLayout.java
@@ -6,8 +6,6 @@ import android.support.v4.widget.DrawerLayout;
 import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.functions.Consumer;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 public final class RxDrawerLayout {
   /**
    * Create an observable of the open state of the drawer of {@code view}.
@@ -19,7 +17,6 @@ public final class RxDrawerLayout {
    */
   @CheckResult @NonNull public static InitialValueObservable<Boolean> drawerOpen(
       @NonNull DrawerLayout view, int gravity) {
-    checkNotNull(view, "view == null");
     return new DrawerLayoutDrawerOpenedObservable(view, gravity);
   }
 
@@ -31,7 +28,6 @@ public final class RxDrawerLayout {
    */
   @CheckResult @NonNull public static Consumer<? super Boolean> open(
       @NonNull final DrawerLayout view, final int gravity) {
-    checkNotNull(view, "view == null");
     return new Consumer<Boolean>() {
       @Override public void accept(Boolean aBoolean) {
         if (aBoolean) {

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/RxNestedScrollView.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/RxNestedScrollView.java
@@ -6,8 +6,6 @@ import android.support.v4.widget.NestedScrollView;
 import com.jakewharton.rxbinding2.view.ViewScrollChangeEvent;
 import io.reactivex.Observable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 public final class RxNestedScrollView {
   /**
    * Create an observable of scroll-change events for {@code view}.
@@ -17,7 +15,6 @@ public final class RxNestedScrollView {
    */
   @CheckResult @NonNull public static Observable<ViewScrollChangeEvent> scrollChangeEvents(
       @NonNull NestedScrollView view) {
-    checkNotNull(view, "view == null");
     return new NestedScrollViewScrollChangeEventObservable(view);
   }
 

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/RxSlidingPaneLayout.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/RxSlidingPaneLayout.java
@@ -7,8 +7,6 @@ import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observable;
 import io.reactivex.functions.Consumer;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 /**
  * Static factory methods for creating {@linkplain Observable observables}
  * for {@link SlidingPaneLayout}
@@ -27,7 +25,6 @@ public final class RxSlidingPaneLayout {
    */
   @CheckResult @NonNull public static InitialValueObservable<Boolean> panelOpens(
       @NonNull SlidingPaneLayout view) {
-    checkNotNull(view, "view == null");
     return new SlidingPaneLayoutPaneOpenedObservable(view);
   }
 
@@ -42,7 +39,6 @@ public final class RxSlidingPaneLayout {
    */
   @CheckResult @NonNull public static Observable<Float> panelSlides(
       @NonNull SlidingPaneLayout view) {
-    checkNotNull(view, "view == null");
     return new SlidingPaneLayoutSlideObservable(view);
   }
 
@@ -54,7 +50,6 @@ public final class RxSlidingPaneLayout {
    */
   @CheckResult @NonNull public static Consumer<? super Boolean> open(
       @NonNull final SlidingPaneLayout view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Boolean>() {
       @Override public void accept(Boolean value) {
         if (value) {

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/RxSwipeRefreshLayout.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/RxSwipeRefreshLayout.java
@@ -6,8 +6,6 @@ import android.support.v4.widget.SwipeRefreshLayout;
 import io.reactivex.Observable;
 import io.reactivex.functions.Consumer;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 public final class RxSwipeRefreshLayout {
   /**
    * Create an observable of refresh events on {@code view}.
@@ -17,7 +15,6 @@ public final class RxSwipeRefreshLayout {
    */
   @CheckResult @NonNull public static Observable<Object> refreshes(
       @NonNull SwipeRefreshLayout view) {
-    checkNotNull(view, "view == null");
     return new SwipeRefreshLayoutRefreshObservable(view);
   }
 
@@ -29,7 +26,6 @@ public final class RxSwipeRefreshLayout {
    */
   @CheckResult @NonNull public static Consumer<? super Boolean> refreshing(
       @NonNull final SwipeRefreshLayout view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Boolean>() {
       @Override public void accept(Boolean value) {
         view.setRefreshing(value);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/internal/Preconditions.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/internal/Preconditions.java
@@ -22,11 +22,6 @@ import static android.support.annotation.RestrictTo.Scope.LIBRARY_GROUP;
 
 @RestrictTo(LIBRARY_GROUP)
 public final class Preconditions {
-  public static void checkNotNull(Object value, String message) {
-    if (value == null) {
-      throw new NullPointerException(message);
-    }
-  }
 
   public static boolean checkMainThread(Observer<?> observer) {
     if (Looper.myLooper() != Looper.getMainLooper()) {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/RxMenuItem.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/RxMenuItem.java
@@ -9,8 +9,6 @@ import io.reactivex.Observable;
 import io.reactivex.functions.Consumer;
 import io.reactivex.functions.Predicate;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 /**
  * Static factory methods for creating {@linkplain Observable observables} and {@linkplain Consumer
  * actions} for {@link MenuItem}.
@@ -29,7 +27,6 @@ public final class RxMenuItem {
    */
   @CheckResult @NonNull
   public static Observable<Object> clicks(@NonNull MenuItem menuItem) {
-    checkNotNull(menuItem, "menuItem == null");
     return new MenuItemClickOnSubscribe(menuItem, Functions.PREDICATE_ALWAYS_TRUE);
   }
 
@@ -49,8 +46,6 @@ public final class RxMenuItem {
   @CheckResult @NonNull
   public static Observable<Object> clicks(@NonNull MenuItem menuItem,
       @NonNull Predicate<? super MenuItem> handled) {
-    checkNotNull(menuItem, "menuItem == null");
-    checkNotNull(handled, "handled == null");
     return new MenuItemClickOnSubscribe(menuItem, handled);
   }
 
@@ -65,7 +60,6 @@ public final class RxMenuItem {
    */
   @CheckResult @NonNull
   public static Observable<MenuItemActionViewEvent> actionViewEvents(@NonNull MenuItem menuItem) {
-    checkNotNull(menuItem, "menuItem == null");
     return new MenuItemActionViewEventObservable(menuItem, Functions.PREDICATE_ALWAYS_TRUE);
   }
 
@@ -84,8 +78,6 @@ public final class RxMenuItem {
   @CheckResult @NonNull
   public static Observable<MenuItemActionViewEvent> actionViewEvents(@NonNull MenuItem menuItem,
       @NonNull Predicate<? super MenuItemActionViewEvent> handled) {
-    checkNotNull(menuItem, "menuItem == null");
-    checkNotNull(handled, "handled == null");
     return new MenuItemActionViewEventObservable(menuItem, handled);
   }
 
@@ -97,7 +89,6 @@ public final class RxMenuItem {
    */
   @CheckResult @NonNull
   public static Consumer<? super Boolean> checked(@NonNull final MenuItem menuItem) {
-    checkNotNull(menuItem, "menuItem == null");
     return new Consumer<Boolean>() {
       @Override public void accept(Boolean value) {
         menuItem.setChecked(value);
@@ -113,7 +104,6 @@ public final class RxMenuItem {
    */
   @CheckResult @NonNull
   public static Consumer<? super Boolean> enabled(@NonNull final MenuItem menuItem) {
-    checkNotNull(menuItem, "menuItem == null");
     return new Consumer<Boolean>() {
       @Override public void accept(Boolean value) {
         menuItem.setEnabled(value);
@@ -129,7 +119,6 @@ public final class RxMenuItem {
    */
   @CheckResult @NonNull
   public static Consumer<? super Drawable> icon(@NonNull final MenuItem menuItem) {
-    checkNotNull(menuItem, "menuItem == null");
     return new Consumer<Drawable>() {
       @Override public void accept(Drawable value) {
         menuItem.setIcon(value);
@@ -145,7 +134,6 @@ public final class RxMenuItem {
    */
   @CheckResult @NonNull
   public static Consumer<? super Integer> iconRes(@NonNull final MenuItem menuItem) {
-    checkNotNull(menuItem, "menuItem == null");
     return new Consumer<Integer>() {
       @Override public void accept(Integer value) {
         menuItem.setIcon(value);
@@ -161,7 +149,6 @@ public final class RxMenuItem {
    */
   @CheckResult @NonNull
   public static Consumer<? super CharSequence> title(@NonNull final MenuItem menuItem) {
-    checkNotNull(menuItem, "menuItem == null");
     return new Consumer<CharSequence>() {
       @Override public void accept(CharSequence value) {
         menuItem.setTitle(value);
@@ -177,7 +164,6 @@ public final class RxMenuItem {
    */
   @CheckResult @NonNull
   public static Consumer<? super Integer> titleRes(@NonNull final MenuItem menuItem) {
-    checkNotNull(menuItem, "menuItem == null");
     return new Consumer<Integer>() {
       @Override public void accept(Integer value) {
         menuItem.setTitle(value);
@@ -193,7 +179,6 @@ public final class RxMenuItem {
    */
   @CheckResult @NonNull
   public static Consumer<? super Boolean> visible(@NonNull final MenuItem menuItem) {
-    checkNotNull(menuItem, "menuItem == null");
     return new Consumer<Boolean>() {
       @Override public void accept(Boolean value) {
         menuItem.setVisible(value);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/RxView.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/RxView.java
@@ -17,7 +17,6 @@ import java.util.concurrent.Callable;
 
 import static android.os.Build.VERSION_CODES.JELLY_BEAN;
 import static android.os.Build.VERSION_CODES.M;
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
 import static com.jakewharton.rxbinding2.internal.Functions.CALLABLE_ALWAYS_TRUE;
 import static com.jakewharton.rxbinding2.internal.Functions.PREDICATE_ALWAYS_TRUE;
 
@@ -35,7 +34,6 @@ public final class RxView {
    */
   @CheckResult @NonNull
   public static Observable<Object> attaches(@NonNull View view) {
-    checkNotNull(view, "view == null");
     return new ViewAttachesObservable(view, true);
   }
 
@@ -47,7 +45,6 @@ public final class RxView {
    */
   @CheckResult @NonNull
   public static Observable<ViewAttachEvent> attachEvents(@NonNull View view) {
-    checkNotNull(view, "view == null");
     return new ViewAttachEventObservable(view);
   }
 
@@ -60,7 +57,6 @@ public final class RxView {
    */
   @CheckResult @NonNull
   public static Observable<Object> detaches(@NonNull View view) {
-    checkNotNull(view, "view == null");
     return new ViewAttachesObservable(view, false);
   }
 
@@ -76,7 +72,6 @@ public final class RxView {
    */
   @CheckResult @NonNull
   public static Observable<Object> clicks(@NonNull View view) {
-    checkNotNull(view, "view == null");
     return new ViewClickObservable(view);
   }
 
@@ -91,7 +86,6 @@ public final class RxView {
    */
   @CheckResult @NonNull
   public static Observable<DragEvent> drags(@NonNull View view) {
-    checkNotNull(view, "view == null");
     return new ViewDragObservable(view, PREDICATE_ALWAYS_TRUE);
   }
 
@@ -110,8 +104,6 @@ public final class RxView {
   @CheckResult @NonNull
   public static Observable<DragEvent> drags(@NonNull View view,
       @NonNull Predicate<? super DragEvent> handled) {
-    checkNotNull(view, "view == null");
-    checkNotNull(handled, "handled == null");
     return new ViewDragObservable(view, handled);
   }
 
@@ -127,7 +119,6 @@ public final class RxView {
   @RequiresApi(JELLY_BEAN)
   @CheckResult @NonNull
   public static Observable<Object> draws(@NonNull View view) {
-    checkNotNull(view, "view == null");
     return new ViewTreeObserverDrawObservable(view);
   }
 
@@ -144,7 +135,6 @@ public final class RxView {
    */
   @CheckResult @NonNull
   public static InitialValueObservable<Boolean> focusChanges(@NonNull View view) {
-    checkNotNull(view, "view == null");
     return new ViewFocusChangeObservable(view);
   }
 
@@ -161,7 +151,6 @@ public final class RxView {
    */
   @CheckResult @NonNull
   public static Observable<Object> globalLayouts(@NonNull View view) {
-    checkNotNull(view, "view == null");
     return new ViewTreeObserverGlobalLayoutObservable(view);
   }
 
@@ -182,7 +171,6 @@ public final class RxView {
    */
   @CheckResult @NonNull
   public static Observable<MotionEvent> hovers(@NonNull View view) {
-    checkNotNull(view, "view == null");
     return new ViewHoverObservable(view, PREDICATE_ALWAYS_TRUE);
   }
 
@@ -207,8 +195,6 @@ public final class RxView {
   @CheckResult @NonNull
   public static Observable<MotionEvent> hovers(@NonNull View view,
       @NonNull Predicate<? super MotionEvent> handled) {
-    checkNotNull(view, "view == null");
-    checkNotNull(handled, "handled == null");
     return new ViewHoverObservable(view, handled);
   }
 
@@ -221,7 +207,6 @@ public final class RxView {
    */
   @CheckResult @NonNull
   public static Observable<Object> layoutChanges(@NonNull View view) {
-    checkNotNull(view, "view == null");
     return new ViewLayoutChangeObservable(view);
   }
 
@@ -233,7 +218,6 @@ public final class RxView {
    */
   @CheckResult @NonNull
   public static Observable<ViewLayoutChangeEvent> layoutChangeEvents(@NonNull View view) {
-    checkNotNull(view, "view == null");
     return new ViewLayoutChangeEventObservable(view);
   }
 
@@ -249,7 +233,6 @@ public final class RxView {
    */
   @CheckResult @NonNull
   public static Observable<Object> longClicks(@NonNull View view) {
-    checkNotNull(view, "view == null");
     return new ViewLongClickObservable(view, CALLABLE_ALWAYS_TRUE);
   }
 
@@ -269,8 +252,6 @@ public final class RxView {
   @CheckResult @NonNull
   public static Observable<Object> longClicks(@NonNull View view,
       @NonNull Callable<Boolean> handled) {
-    checkNotNull(view, "view == null");
-    checkNotNull(handled, "handled == null");
     return new ViewLongClickObservable(view, handled);
   }
 
@@ -286,8 +267,6 @@ public final class RxView {
   @CheckResult @NonNull
   public static Observable<Object> preDraws(@NonNull View view,
       @NonNull Callable<Boolean> proceedDrawingPass) {
-    checkNotNull(view, "view == null");
-    checkNotNull(proceedDrawingPass, "proceedDrawingPass == null");
     return new ViewTreeObserverPreDrawObservable(view, proceedDrawingPass);
   }
 
@@ -300,7 +279,6 @@ public final class RxView {
   @RequiresApi(M)
   @CheckResult @NonNull
   public static Observable<ViewScrollChangeEvent> scrollChangeEvents(@NonNull View view) {
-    checkNotNull(view, "view == null");
     return new ViewScrollChangeEventObservable(view);
   }
 
@@ -316,7 +294,6 @@ public final class RxView {
    */
   @CheckResult @NonNull
   public static Observable<Integer> systemUiVisibilityChanges(@NonNull View view) {
-    checkNotNull(view, "view == null");
     return new ViewSystemUiVisibilityChangeObservable(view);
   }
 
@@ -337,7 +314,6 @@ public final class RxView {
    */
   @CheckResult @NonNull
   public static Observable<MotionEvent> touches(@NonNull View view) {
-    checkNotNull(view, "view == null");
     return new ViewTouchObservable(view, PREDICATE_ALWAYS_TRUE);
   }
 
@@ -362,8 +338,6 @@ public final class RxView {
   @CheckResult @NonNull
   public static Observable<MotionEvent> touches(@NonNull View view,
       @NonNull Predicate<? super MotionEvent> handled) {
-    checkNotNull(view, "view == null");
-    checkNotNull(handled, "handled == null");
     return new ViewTouchObservable(view, handled);
   }
 
@@ -377,7 +351,6 @@ public final class RxView {
    */
   @CheckResult @NonNull
   public static Observable<KeyEvent> keys(@NonNull View view) {
-    checkNotNull(view, "view == null");
     return new ViewKeyObservable(view, PREDICATE_ALWAYS_TRUE);
   }
 
@@ -395,8 +368,6 @@ public final class RxView {
   @CheckResult @NonNull
   public static Observable<KeyEvent> keys(@NonNull View view,
       @NonNull Predicate<? super KeyEvent> handled) {
-    checkNotNull(view, "view == null");
-    checkNotNull(handled, "handled == null");
     return new ViewKeyObservable(view, handled);
   }
 
@@ -408,7 +379,6 @@ public final class RxView {
    */
   @CheckResult @NonNull
   public static Consumer<? super Boolean> activated(@NonNull final View view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Boolean>() {
       @Override public void accept(Boolean value) {
         view.setActivated(value);
@@ -424,7 +394,6 @@ public final class RxView {
    */
   @CheckResult @NonNull
   public static Consumer<? super Boolean> clickable(@NonNull final View view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Boolean>() {
       @Override public void accept(Boolean value) {
         view.setClickable(value);
@@ -440,7 +409,6 @@ public final class RxView {
    */
   @CheckResult @NonNull
   public static Consumer<? super Boolean> enabled(@NonNull final View view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Boolean>() {
       @Override public void accept(Boolean value) {
         view.setEnabled(value);
@@ -456,7 +424,6 @@ public final class RxView {
    */
   @CheckResult @NonNull
   public static Consumer<? super Boolean> pressed(@NonNull final View view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Boolean>() {
       @Override public void accept(Boolean value) {
         view.setPressed(value);
@@ -472,7 +439,6 @@ public final class RxView {
    */
   @CheckResult @NonNull
   public static Consumer<? super Boolean> selected(@NonNull final View view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Boolean>() {
       @Override public void accept(Boolean value) {
         view.setSelected(value);
@@ -489,7 +455,6 @@ public final class RxView {
    */
   @CheckResult @NonNull
   public static Consumer<? super Boolean> visibility(@NonNull View view) {
-    checkNotNull(view, "view == null");
     return visibility(view, View.GONE);
   }
 
@@ -505,7 +470,6 @@ public final class RxView {
   @CheckResult @NonNull
   public static Consumer<? super Boolean> visibility(@NonNull final View view,
       final int visibilityWhenFalse) {
-    checkNotNull(view, "view == null");
     if (visibilityWhenFalse == View.VISIBLE) {
       throw new IllegalArgumentException(
           "Setting visibility to VISIBLE when false would have no effect.");

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/RxViewGroup.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/RxViewGroup.java
@@ -5,8 +5,6 @@ import android.support.annotation.NonNull;
 import android.view.ViewGroup;
 import io.reactivex.Observable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 /**
  * Static factory methods for creating {@linkplain Observable observables} for {@link ViewGroup}.
  */
@@ -20,7 +18,6 @@ public final class RxViewGroup {
   @CheckResult @NonNull
   public static Observable<ViewGroupHierarchyChangeEvent> changeEvents(
       @NonNull ViewGroup viewGroup) {
-    checkNotNull(viewGroup, "viewGroup == null");
     return new ViewGroupHierarchyChangeEventObservable(viewGroup);
   }
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxAbsListView.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxAbsListView.java
@@ -5,8 +5,6 @@ import android.support.annotation.NonNull;
 import android.widget.AbsListView;
 import io.reactivex.Observable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 public final class RxAbsListView {
   /**
    * Create an observable of scroll events on {@code absListView}.
@@ -20,7 +18,6 @@ public final class RxAbsListView {
    */
   @CheckResult @NonNull
   public static Observable<AbsListViewScrollEvent> scrollEvents(@NonNull AbsListView absListView) {
-    checkNotNull(absListView, "absListView == null");
     return new AbsListViewScrollEventObservable(absListView);
   }
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxAdapter.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxAdapter.java
@@ -6,8 +6,6 @@ import android.widget.Adapter;
 import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 /**
  * Static factory methods for creating {@linkplain Observable observables} for {@link Adapter}.
  */
@@ -19,7 +17,6 @@ public final class RxAdapter {
    */
   @CheckResult @NonNull
   public static <T extends Adapter> InitialValueObservable<T> dataChanges(@NonNull T adapter) {
-    checkNotNull(adapter, "adapter == null");
     return new AdapterDataChangeObservable<>(adapter);
   }
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxAdapterView.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxAdapterView.java
@@ -11,8 +11,6 @@ import io.reactivex.Observable;
 import io.reactivex.functions.Consumer;
 import io.reactivex.functions.Predicate;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 /**
  * Static factory methods for creating {@linkplain Observable observables} and {@linkplain Consumer
  * actions} for {@link AdapterView}.
@@ -30,7 +28,6 @@ public final class RxAdapterView {
   @CheckResult @NonNull
   public static <T extends Adapter> InitialValueObservable<Integer> itemSelections(
       @NonNull AdapterView<T> view) {
-    checkNotNull(view, "view == null");
     return new AdapterViewItemSelectionObservable(view);
   }
 
@@ -45,7 +42,6 @@ public final class RxAdapterView {
   @CheckResult @NonNull
   public static <T extends Adapter> InitialValueObservable<AdapterViewSelectionEvent>
   selectionEvents(@NonNull AdapterView<T> view) {
-    checkNotNull(view, "view == null");
     return new AdapterViewSelectionObservable(view);
   }
 
@@ -58,7 +54,6 @@ public final class RxAdapterView {
   @CheckResult @NonNull
   public static <T extends Adapter> Observable<Integer> itemClicks(
       @NonNull AdapterView<T> view) {
-    checkNotNull(view, "view == null");
     return new AdapterViewItemClickObservable(view);
   }
 
@@ -71,7 +66,6 @@ public final class RxAdapterView {
   @CheckResult @NonNull
   public static <T extends Adapter> Observable<AdapterViewItemClickEvent> itemClickEvents(
       @NonNull AdapterView<T> view) {
-    checkNotNull(view, "view == null");
     return new AdapterViewItemClickEventObservable(view);
   }
 
@@ -84,7 +78,6 @@ public final class RxAdapterView {
   @CheckResult @NonNull
   public static <T extends Adapter> Observable<Integer> itemLongClicks(
       @NonNull AdapterView<T> view) {
-    checkNotNull(view, "view == null");
     return itemLongClicks(view, Functions.CALLABLE_ALWAYS_TRUE);
   }
 
@@ -100,8 +93,6 @@ public final class RxAdapterView {
   @CheckResult @NonNull
   public static <T extends Adapter> Observable<Integer> itemLongClicks(@NonNull AdapterView<T> view,
       @NonNull Callable<Boolean> handled) {
-    checkNotNull(view, "view == null");
-    checkNotNull(handled, "handled == null");
     return new AdapterViewItemLongClickObservable(view, handled);
   }
 
@@ -114,7 +105,6 @@ public final class RxAdapterView {
   @CheckResult @NonNull
   public static <T extends Adapter> Observable<AdapterViewItemLongClickEvent> itemLongClickEvents(
       @NonNull AdapterView<T> view) {
-    checkNotNull(view, "view == null");
     return itemLongClickEvents(view, Functions.PREDICATE_ALWAYS_TRUE);
   }
 
@@ -131,8 +121,6 @@ public final class RxAdapterView {
   public static <T extends Adapter> Observable<AdapterViewItemLongClickEvent> itemLongClickEvents(
       @NonNull AdapterView<T> view,
       @NonNull Predicate<? super AdapterViewItemLongClickEvent> handled) {
-    checkNotNull(view, "view == null");
-    checkNotNull(handled, "handled == null");
     return new AdapterViewItemLongClickEventObservable(view, handled);
   }
 
@@ -145,7 +133,6 @@ public final class RxAdapterView {
   @CheckResult @NonNull
   public static <T extends Adapter> Consumer<? super Integer> selection(
       @NonNull final AdapterView<T> view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Integer>() {
       @Override public void accept(Integer position) {
         view.setSelection(position);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxAutoCompleteTextView.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxAutoCompleteTextView.java
@@ -6,8 +6,6 @@ import android.widget.AutoCompleteTextView;
 import io.reactivex.Observable;
 import io.reactivex.functions.Consumer;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 /**
  * Static factory methods for creating {@linkplain Observable observables} and {@linkplain Consumer
  * actions} for {@link AutoCompleteTextView}.
@@ -22,7 +20,6 @@ public final class RxAutoCompleteTextView {
   @CheckResult @NonNull
   public static Observable<AdapterViewItemClickEvent> itemClickEvents(
       @NonNull AutoCompleteTextView view) {
-    checkNotNull(view, "view == null");
     return new AutoCompleteTextViewItemClickEventObservable(view);
   }
 
@@ -37,7 +34,6 @@ public final class RxAutoCompleteTextView {
   @CheckResult @NonNull
   public static Consumer<? super CharSequence> completionHint(
       @NonNull final AutoCompleteTextView view) {
-    checkNotNull(view, "view == null");
     return new Consumer<CharSequence>() {
       @Override public void accept(CharSequence completionHint) {
         view.setCompletionHint(completionHint);
@@ -55,7 +51,6 @@ public final class RxAutoCompleteTextView {
    */
   @CheckResult @NonNull
   public static Consumer<? super Integer> threshold(@NonNull final AutoCompleteTextView view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Integer>() {
       @Override public void accept(Integer threshold) {
         view.setThreshold(threshold);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxCheckedTextView.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxCheckedTextView.java
@@ -5,8 +5,6 @@ import android.support.annotation.NonNull;
 import android.widget.CheckedTextView;
 import io.reactivex.functions.Consumer;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 /**
  * Static factory methods for creating {@linkplain Consumer actions} for {@link CheckedTextView}.
  */
@@ -20,7 +18,6 @@ public final class RxCheckedTextView {
    */
   @CheckResult @NonNull
   public static Consumer<? super Boolean> check(@NonNull final CheckedTextView view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Boolean>() {
       @Override public void accept(Boolean check) {
         view.setChecked(check);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxCompoundButton.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxCompoundButton.java
@@ -8,8 +8,6 @@ import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observable;
 import io.reactivex.functions.Consumer;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 /**
  * Static factory methods for creating {@linkplain Observable observables} and {@linkplain Consumer
  * actions} for {@link CompoundButton}.
@@ -28,7 +26,6 @@ public final class RxCompoundButton {
    */
   @CheckResult @NonNull
   public static InitialValueObservable<Boolean> checkedChanges(@NonNull CompoundButton view) {
-    checkNotNull(view, "view == null");
     return new CompoundButtonCheckedChangeObservable(view);
   }
 
@@ -40,7 +37,6 @@ public final class RxCompoundButton {
    */
   @CheckResult @NonNull
   public static Consumer<? super Boolean> checked(@NonNull final CompoundButton view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Boolean>() {
       @Override
       public void accept(Boolean value) throws Exception {
@@ -57,7 +53,6 @@ public final class RxCompoundButton {
    */
   @CheckResult @NonNull
   public static Consumer<? super Object> toggle(@NonNull final CompoundButton view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Object>() {
       @Override public void accept(Object value) {
         view.toggle();

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxPopupMenu.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxPopupMenu.java
@@ -6,8 +6,6 @@ import android.view.MenuItem;
 import android.widget.PopupMenu;
 import io.reactivex.Observable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 /**
  * Static factory methods for creating {@linkplain Observable observables} for {@link PopupMenu}.
  */
@@ -23,7 +21,6 @@ public final class RxPopupMenu {
    */
   @CheckResult @NonNull
   public static Observable<MenuItem> itemClicks(@NonNull PopupMenu view) {
-    checkNotNull(view, "view == null");
     return new PopupMenuItemClickObservable(view);
   }
 
@@ -39,7 +36,6 @@ public final class RxPopupMenu {
    */
   @CheckResult @NonNull
   public static Observable<Object> dismisses(@NonNull PopupMenu view) {
-    checkNotNull(view, "view == null");
     return new PopupMenuDismissObservable(view);
   }
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxProgressBar.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxProgressBar.java
@@ -5,8 +5,6 @@ import android.support.annotation.NonNull;
 import android.widget.ProgressBar;
 import io.reactivex.functions.Consumer;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 public final class RxProgressBar {
   /**
    * An action which increments the progress value of {@code view}.
@@ -16,7 +14,6 @@ public final class RxProgressBar {
    */
   @CheckResult @NonNull
   public static Consumer<? super Integer> incrementProgressBy(@NonNull final ProgressBar view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Integer>() {
       @Override public void accept(Integer value) {
         view.incrementProgressBy(value);
@@ -33,7 +30,6 @@ public final class RxProgressBar {
   @CheckResult @NonNull
   public static Consumer<? super Integer> incrementSecondaryProgressBy(
       @NonNull final ProgressBar view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Integer>() {
       @Override public void accept(Integer value) {
         view.incrementSecondaryProgressBy(value);
@@ -49,7 +45,6 @@ public final class RxProgressBar {
    */
   @CheckResult @NonNull
   public static Consumer<? super Boolean> indeterminate(@NonNull final ProgressBar view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Boolean>() {
       @Override public void accept(Boolean value) {
         view.setIndeterminate(value);
@@ -65,7 +60,6 @@ public final class RxProgressBar {
    */
   @CheckResult @NonNull
   public static Consumer<? super Integer> max(@NonNull final ProgressBar view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Integer>() {
       @Override public void accept(Integer value) {
         view.setMax(value);
@@ -81,7 +75,6 @@ public final class RxProgressBar {
    */
   @CheckResult @NonNull
   public static Consumer<? super Integer> progress(@NonNull final ProgressBar view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Integer>() {
       @Override public void accept(Integer value) {
         view.setProgress(value);
@@ -97,7 +90,6 @@ public final class RxProgressBar {
    */
   @CheckResult @NonNull
   public static Consumer<? super Integer> secondaryProgress(@NonNull final ProgressBar view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Integer>() {
       @Override public void accept(Integer value) {
         view.setSecondaryProgress(value);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxRadioGroup.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxRadioGroup.java
@@ -6,8 +6,6 @@ import android.widget.RadioGroup;
 import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.functions.Consumer;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 public final class RxRadioGroup {
   /**
    * Create an observable of the checked view ID changes in {@code view}.
@@ -19,7 +17,6 @@ public final class RxRadioGroup {
    */
   @CheckResult @NonNull
   public static InitialValueObservable<Integer> checkedChanges(@NonNull RadioGroup view) {
-    checkNotNull(view, "view == null");
     return new RadioGroupCheckedChangeObservable(view);
   }
 
@@ -32,7 +29,6 @@ public final class RxRadioGroup {
    */
   @CheckResult @NonNull
   public static Consumer<? super Integer> checked(@NonNull final RadioGroup view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Integer>() {
       @Override public void accept(Integer value) {
         if (value == -1) {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxRatingBar.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxRatingBar.java
@@ -6,8 +6,6 @@ import android.widget.RatingBar;
 import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.functions.Consumer;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 public final class RxRatingBar {
   /**
    * Create an observable of the rating changes on {@code view}.
@@ -19,7 +17,6 @@ public final class RxRatingBar {
    */
   @CheckResult @NonNull
   public static InitialValueObservable<Float> ratingChanges(@NonNull RatingBar view) {
-    checkNotNull(view, "view == null");
     return new RatingBarRatingChangeObservable(view);
   }
 
@@ -34,7 +31,6 @@ public final class RxRatingBar {
   @CheckResult @NonNull
   public static InitialValueObservable<RatingBarChangeEvent> ratingChangeEvents(
       @NonNull RatingBar view) {
-    checkNotNull(view, "view == null");
     return new RatingBarRatingChangeEventObservable(view);
   }
 
@@ -46,7 +42,6 @@ public final class RxRatingBar {
    */
   @CheckResult @NonNull
   public static Consumer<? super Float> rating(@NonNull final RatingBar view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Float>() {
       @Override public void accept(Float value) {
         view.setRating(value);
@@ -62,7 +57,6 @@ public final class RxRatingBar {
    */
   @CheckResult @NonNull
   public static Consumer<? super Boolean> isIndicator(@NonNull final RatingBar view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Boolean>() {
       @Override public void accept(Boolean value) {
         view.setIsIndicator(value);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxSearchView.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxSearchView.java
@@ -7,8 +7,6 @@ import com.jakewharton.rxbinding2.InitialValueObservable;
 import io.reactivex.Observable;
 import io.reactivex.functions.Consumer;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 /**
  * Static factory methods for creating {@linkplain Observable observables} and {@linkplain Consumer
  * consumers} for {@link SearchView}.
@@ -26,7 +24,6 @@ public final class RxSearchView {
   @CheckResult @NonNull
   public static InitialValueObservable<SearchViewQueryTextEvent> queryTextChangeEvents(
       @NonNull SearchView view) {
-    checkNotNull(view, "view == null");
     return new SearchViewQueryTextChangeEventsObservable(view);
   }
 
@@ -40,7 +37,6 @@ public final class RxSearchView {
    */
   @CheckResult @NonNull
   public static InitialValueObservable<CharSequence> queryTextChanges(@NonNull SearchView view) {
-    checkNotNull(view, "view == null");
     return new SearchViewQueryTextChangesObservable(view);
   }
 
@@ -55,7 +51,6 @@ public final class RxSearchView {
   @CheckResult @NonNull
   public static Consumer<? super CharSequence> query(@NonNull final SearchView view,
       final boolean submit) {
-    checkNotNull(view, "view == null");
     return new Consumer<CharSequence>() {
       @Override public void accept(CharSequence text) {
         view.setQuery(text, submit);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxSeekBar.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxSeekBar.java
@@ -5,8 +5,6 @@ import android.support.annotation.NonNull;
 import android.widget.SeekBar;
 import com.jakewharton.rxbinding2.InitialValueObservable;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 public final class RxSeekBar {
   /**
    * Create an observable of progress value changes on {@code view}.
@@ -18,7 +16,6 @@ public final class RxSeekBar {
    */
   @CheckResult @NonNull
   public static InitialValueObservable<Integer> changes(@NonNull SeekBar view) {
-    checkNotNull(view, "view == null");
     return new SeekBarChangeObservable(view, null);
   }
 
@@ -33,7 +30,6 @@ public final class RxSeekBar {
    */
   @CheckResult @NonNull
   public static InitialValueObservable<Integer> userChanges(@NonNull SeekBar view) {
-    checkNotNull(view, "view == null");
     return new SeekBarChangeObservable(view, true);
   }
 
@@ -48,7 +44,6 @@ public final class RxSeekBar {
    */
   @CheckResult @NonNull
   public static InitialValueObservable<Integer> systemChanges(@NonNull SeekBar view) {
-    checkNotNull(view, "view == null");
     return new SeekBarChangeObservable(view, false);
   }
 
@@ -62,7 +57,6 @@ public final class RxSeekBar {
    */
   @CheckResult @NonNull
   public static InitialValueObservable<SeekBarChangeEvent> changeEvents(@NonNull SeekBar view) {
-    checkNotNull(view, "view == null");
     return new SeekBarChangeEventObservable(view);
   }
 

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxTextSwitcher.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxTextSwitcher.java
@@ -6,8 +6,6 @@ import android.widget.TextSwitcher;
 import io.reactivex.Observable;
 import io.reactivex.functions.Consumer;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 /**
  * Static factory methods for creating {@linkplain Observable observables} and {@linkplain Consumer
  * consumers} for {@link TextSwitcher}.
@@ -21,7 +19,6 @@ public final class RxTextSwitcher {
    */
   @CheckResult @NonNull
   public static Consumer<? super CharSequence> text(@NonNull final TextSwitcher view) {
-    checkNotNull(view, "view == null");
     return new Consumer<CharSequence>() {
       @Override public void accept(CharSequence text) {
         view.setText(text);
@@ -37,7 +34,6 @@ public final class RxTextSwitcher {
    */
   @CheckResult @NonNull
   public static Consumer<? super CharSequence> currentText(@NonNull final TextSwitcher view) {
-    checkNotNull(view, "view == null");
     return new Consumer<CharSequence>() {
       @Override public void accept(CharSequence textRes) {
         view.setCurrentText(textRes);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxTextView.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxTextView.java
@@ -11,8 +11,6 @@ import io.reactivex.Observable;
 import io.reactivex.functions.Consumer;
 import io.reactivex.functions.Predicate;
 
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
-
 /**
  * Static factory methods for creating {@linkplain Observable observables} and {@linkplain Consumer
  * actions} for {@link TextView}.
@@ -29,7 +27,6 @@ public final class RxTextView {
    */
   @CheckResult @NonNull
   public static Observable<Integer> editorActions(@NonNull TextView view) {
-    checkNotNull(view, "view == null");
     return editorActions(view, Functions.PREDICATE_ALWAYS_TRUE);
   }
 
@@ -48,8 +45,6 @@ public final class RxTextView {
   @CheckResult @NonNull
   public static Observable<Integer> editorActions(@NonNull TextView view,
                                                   @NonNull Predicate<? super Integer> handled) {
-    checkNotNull(view, "view == null");
-    checkNotNull(handled, "handled == null");
     return new TextViewEditorActionObservable(view, handled);
   }
 
@@ -64,7 +59,6 @@ public final class RxTextView {
    */
   @CheckResult @NonNull
   public static Observable<TextViewEditorActionEvent> editorActionEvents(@NonNull TextView view) {
-    checkNotNull(view, "view == null");
     return editorActionEvents(view, Functions.PREDICATE_ALWAYS_TRUE);
   }
 
@@ -83,8 +77,6 @@ public final class RxTextView {
   @CheckResult @NonNull
   public static Observable<TextViewEditorActionEvent> editorActionEvents(@NonNull TextView view,
       @NonNull Predicate<? super TextViewEditorActionEvent> handled) {
-    checkNotNull(view, "view == null");
-    checkNotNull(handled, "handled == null");
     return new TextViewEditorActionEventObservable(view, handled);
   }
 
@@ -104,7 +96,6 @@ public final class RxTextView {
    */
   @CheckResult @NonNull
   public static InitialValueObservable<CharSequence> textChanges(@NonNull TextView view) {
-    checkNotNull(view, "view == null");
     return new TextViewTextObservable(view);
   }
 
@@ -125,7 +116,6 @@ public final class RxTextView {
   @CheckResult @NonNull
   public static InitialValueObservable<TextViewTextChangeEvent> textChangeEvents(
       @NonNull TextView view) {
-    checkNotNull(view, "view == null");
     return new TextViewTextChangeEventObservable(view);
   }
 
@@ -140,7 +130,6 @@ public final class RxTextView {
   @CheckResult @NonNull
   public static InitialValueObservable<TextViewBeforeTextChangeEvent> beforeTextChangeEvents(
       @NonNull TextView view) {
-    checkNotNull(view, "view == null");
     return new TextViewBeforeTextChangeEventObservable(view);
   }
 
@@ -156,7 +145,6 @@ public final class RxTextView {
   @CheckResult @NonNull
   public static InitialValueObservable<TextViewAfterTextChangeEvent> afterTextChangeEvents(
       @NonNull TextView view) {
-    checkNotNull(view, "view == null");
     return new TextViewAfterTextChangeEventObservable(view);
   }
 
@@ -168,7 +156,6 @@ public final class RxTextView {
    */
   @CheckResult @NonNull
   public static Consumer<? super CharSequence> text(@NonNull final TextView view) {
-    checkNotNull(view, "view == null");
     return new Consumer<CharSequence>() {
       @Override public void accept(CharSequence text) {
         view.setText(text);
@@ -184,7 +171,6 @@ public final class RxTextView {
    */
   @CheckResult @NonNull
   public static Consumer<? super Integer> textRes(@NonNull final TextView view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Integer>() {
       @Override public void accept(Integer textRes) {
         view.setText(textRes);
@@ -200,7 +186,6 @@ public final class RxTextView {
    */
   @CheckResult @NonNull
   public static Consumer<? super CharSequence> error(@NonNull final TextView view) {
-    checkNotNull(view, "view == null");
     return new Consumer<CharSequence>() {
       @Override public void accept(CharSequence text) {
         view.setError(text);
@@ -216,7 +201,6 @@ public final class RxTextView {
    */
   @CheckResult @NonNull
   public static Consumer<? super Integer> errorRes(@NonNull final TextView view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Integer>() {
       @Override public void accept(Integer textRes) {
         view.setError(view.getContext().getResources().getText(textRes));
@@ -232,7 +216,6 @@ public final class RxTextView {
    */
   @CheckResult @NonNull
   public static Consumer<? super CharSequence> hint(@NonNull final TextView view) {
-    checkNotNull(view, "view == null");
     return new Consumer<CharSequence>() {
       @Override public void accept(CharSequence hint) {
         view.setHint(hint);
@@ -248,7 +231,6 @@ public final class RxTextView {
    */
   @CheckResult @NonNull
   public static Consumer<? super Integer> hintRes(@NonNull final TextView view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Integer>() {
       @Override public void accept(Integer hintRes) {
         view.setHint(hintRes);
@@ -264,7 +246,6 @@ public final class RxTextView {
    */
   @CheckResult @NonNull
   public static Consumer<? super Integer> color(@NonNull final TextView view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Integer>() {
       @Override
       public void accept(Integer color) throws Exception {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxToolbar.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/RxToolbar.java
@@ -10,7 +10,6 @@ import io.reactivex.Observable;
 import io.reactivex.functions.Consumer;
 
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
-import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
 
 /**
  * Static factory methods for creating {@linkplain Observable observables} for {@link Toolbar}.
@@ -25,7 +24,6 @@ public final class RxToolbar {
    */
   @CheckResult @NonNull
   public static Observable<MenuItem> itemClicks(@NonNull Toolbar view) {
-    checkNotNull(view, "view == null");
     return new ToolbarItemClickObservable(view);
   }
 
@@ -41,7 +39,6 @@ public final class RxToolbar {
    */
   @CheckResult @NonNull
   public static Observable<Object> navigationClicks(@NonNull Toolbar view) {
-    checkNotNull(view, "view == null");
     return new ToolbarNavigationClickObservable(view);
   }
 
@@ -53,7 +50,6 @@ public final class RxToolbar {
    */
   @CheckResult @NonNull @GenericTypeNullable
   public static Consumer<? super CharSequence> title(@NonNull final Toolbar view) {
-    checkNotNull(view, "view == null");
     return new Consumer<CharSequence>() {
       @Override public void accept(CharSequence title) {
         view.setTitle(title);
@@ -69,7 +65,6 @@ public final class RxToolbar {
    */
   @CheckResult @NonNull
   public static Consumer<? super Integer> titleRes(@NonNull final Toolbar view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Integer>() {
       @Override public void accept(Integer titleRes) {
         view.setTitle(titleRes);
@@ -85,7 +80,6 @@ public final class RxToolbar {
    */
   @CheckResult @NonNull @GenericTypeNullable
   public static Consumer<? super CharSequence> subtitle(@NonNull final Toolbar view) {
-    checkNotNull(view, "view == null");
     return new Consumer<CharSequence>() {
       @Override public void accept(CharSequence subtitle) {
         view.setSubtitle(subtitle);
@@ -101,7 +95,6 @@ public final class RxToolbar {
    */
   @CheckResult @NonNull
   public static Consumer<? super Integer> subtitleRes(@NonNull final Toolbar view) {
-    checkNotNull(view, "view == null");
     return new Consumer<Integer>() {
       @Override public void accept(Integer subtitleRes) {
         view.setSubtitle(subtitleRes);


### PR DESCRIPTION
Thus *PR* does two things:  
* configures the build to generate *null*-checks based on *NonNull* method parameters/return values annotations
* removes explicit *null*-checks  

The above is achieved by the [Traute](http://traute.oss.harmonysoft.tech/) *javac* plugin - it enhances compilation in a way to insert target checks into generated bytecode.  

Let's consider [RxMenuItem.actionViewEvents()](https://github.com/denis-zhdanov/RxBinding/blob/master/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/RxMenuItem.java#L67):  

*Source code*  

```java
@CheckResult @NonNull
public static Observable<MenuItemActionViewEvent> actionViewEvents(@NonNull MenuItem menuItem) {
  return new MenuItemActionViewEventObservable(menuItem, Functions.PREDICATE_ALWAYS_TRUE);
}
```  

Resulting bytecode looks like if it's compiled from the source below:  

```java
@CheckResult @NonNull
public static Observable<MenuItemActionViewEvent> actionViewEvents(@NonNull MenuItem menuItem) {
  if (munuItem == null) {
    throw new NullPointerException("menuItem == null");
  }
  Observable<MenuItemActionViewEvent> tmpTrauteVar1 = new MenuItemActionViewEventObservable(menuItem, Functions.PREDICATE_ALWAYS_TRUE);
  if (tmpTrauteVar1 == null) {
    throw new NullPointerException("Detected an attempt to return null from a method com.jakewharton.rxbinding2.view.RxMenuItem.actionViewEvents() marked by @android.support.annotation.NonNull");
  }
}
```  

*Bytecode*  

```
javap -c ./rxbinding/build/intermediates/classes/release/com/jakewharton/rxbinding2/view/RxMenuItem.class
...
  public static io.reactivex.Observable<com.jakewharton.rxbinding2.view.MenuItemActionViewEvent> actionViewEvents(android.view.MenuItem);
    Code:
       0: aload_0
       1: ifnonnull     14
       4: new           #1                  // class java/lang/NullPointerException
       7: dup
       8: ldc           #2                  // String menuItem == null
      10: invokespecial #3                  // Method java/lang/NullPointerException."<init>":(Ljava/lang/String;)V
      13: athrow
      14: new           #9                  // class com/jakewharton/rxbinding2/view/MenuItemActionViewEventObservable
      17: dup
      18: aload_0
      19: getstatic     #5                  // Field com/jakewharton/rxbinding2/internal/Functions.PREDICATE_ALWAYS_TRUE:Lio/reactivex/functions/Predicate;
      22: invokespecial #10                 // Method com/jakewharton/rxbinding2/view/MenuItemActionViewEventObservable."<init>":(Landroid/view/MenuItem;Lio/reactivex/functions/Predicate;)V
      25: astore_1
      26: aload_1
      27: ifnonnull     40
      30: new           #1                  // class java/lang/NullPointerException
      33: dup
      34: ldc           #11                 // String Detected an attempt to return null from a method com.jakewharton.rxbinding2.view.RxMenuItem.actionViewEvents() marked by @android.support.annotation.NonNull
      36: invokespecial #3                  // Method java/lang/NullPointerException."<init>":(Ljava/lang/String;)V
      39: athrow
      40: aload_1
      41: areturn
```  

Please note that *Traute* is configured in the same way as the explicit checks:  
* it throws *NullPointerException* from failed checks (default behavior)
* error message pattern is [PARAMETER_NAME == null](https://github.com/denis-zhdanov/RxBinding/blob/traute-null-checks/build.gradle#L21)