### PR TITLE
Deprecate simple consumers in favor of method references.

### DIFF
--- a/buildSrc/src/main/kotlin/com/jakewharton/rxbinding/project/conversion/cleanedDocumentation.kt
+++ b/buildSrc/src/main/kotlin/com/jakewharton/rxbinding/project/conversion/cleanedDocumentation.kt
@@ -43,6 +43,8 @@ private fun cleanUpDoc(doc: String): String {
         val (foo, bar, baz) = result.destructured
         "[$baz][$foo.$bar]"
       }
+      // Remove @deprecated
+      .replace("@deprecated [^.]+\\.".toRegex(), "")
       .trim()
       .plus("\n")
 }

--- a/rxbinding-appcompat-v7-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/support/v7/widget/RxToolbar.kt
+++ b/rxbinding-appcompat-v7-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/support/v7/widget/RxToolbar.kt
@@ -10,6 +10,7 @@ import android.view.MenuItem
 import com.jakewharton.rxbinding2.internal.VoidToUnit
 import io.reactivex.Observable
 import io.reactivex.functions.Consumer
+import kotlin.Deprecated
 import kotlin.Int
 import kotlin.Suppress
 import kotlin.Unit
@@ -42,6 +43,9 @@ inline fun Toolbar.navigationClicks(): Observable<Unit> = RxToolbar.navigationCl
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
  */
+@Deprecated(
+    message = "Use view::setTitle method reference."
+)
 @CheckResult
 inline fun Toolbar.title(): Consumer<in CharSequence?> = RxToolbar.title(this)
 
@@ -51,6 +55,9 @@ inline fun Toolbar.title(): Consumer<in CharSequence?> = RxToolbar.title(this)
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
  */
+@Deprecated(
+    message = "Use view::setTitle method reference."
+)
 @CheckResult
 inline fun Toolbar.titleRes(): Consumer<in Int> = RxToolbar.titleRes(this)
 
@@ -60,6 +67,9 @@ inline fun Toolbar.titleRes(): Consumer<in Int> = RxToolbar.titleRes(this)
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
  */
+@Deprecated(
+    message = "Use view::setSubtitle method reference."
+)
 @CheckResult
 inline fun Toolbar.subtitle(): Consumer<in CharSequence?> = RxToolbar.subtitle(this)
 
@@ -69,5 +79,8 @@ inline fun Toolbar.subtitle(): Consumer<in CharSequence?> = RxToolbar.subtitle(t
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
  */
+@Deprecated(
+    message = "Use view::setSubtitle method reference."
+)
 @CheckResult
 inline fun Toolbar.subtitleRes(): Consumer<in Int> = RxToolbar.subtitleRes(this)

--- a/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RxToolbar.java
+++ b/rxbinding-appcompat-v7/src/main/java/com/jakewharton/rxbinding2/support/v7/widget/RxToolbar.java
@@ -47,7 +47,10 @@ public final class RxToolbar {
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
    * to free this reference.
+   *
+   * @deprecated Use view::setTitle method reference.
    */
+  @Deprecated
   @CheckResult @NonNull @GenericTypeNullable
   public static Consumer<? super CharSequence> title(@NonNull final Toolbar view) {
     checkNotNull(view, "view == null");
@@ -63,7 +66,10 @@ public final class RxToolbar {
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
    * to free this reference.
+   *
+   * @deprecated Use view::setTitle method reference.
    */
+  @Deprecated
   @CheckResult @NonNull
   public static Consumer<? super Integer> titleRes(@NonNull final Toolbar view) {
     checkNotNull(view, "view == null");
@@ -79,7 +85,10 @@ public final class RxToolbar {
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
    * to free this reference.
+   *
+   * @deprecated Use view::setSubtitle method reference.
    */
+  @Deprecated
   @CheckResult @NonNull @GenericTypeNullable
   public static Consumer<? super CharSequence> subtitle(@NonNull final Toolbar view) {
     checkNotNull(view, "view == null");
@@ -95,7 +104,10 @@ public final class RxToolbar {
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
    * to free this reference.
+   *
+   * @deprecated Use view::setSubtitle method reference.
    */
+  @Deprecated
   @CheckResult @NonNull
   public static Consumer<? super Integer> subtitleRes(@NonNull final Toolbar view) {
     checkNotNull(view, "view == null");

--- a/rxbinding-design-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/support/design/widget/RxTextInputLayout.kt
+++ b/rxbinding-design-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/support/design/widget/RxTextInputLayout.kt
@@ -7,6 +7,7 @@ package com.jakewharton.rxbinding2.support.design.widget
 import android.support.annotation.CheckResult
 import android.support.design.widget.TextInputLayout
 import io.reactivex.functions.Consumer
+import kotlin.Deprecated
 import kotlin.Int
 import kotlin.Suppress
 
@@ -16,6 +17,9 @@ import kotlin.Suppress
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
  */
+@Deprecated(
+    message = "Use view::setCounterEnabled method reference."
+)
 @CheckResult
 inline fun TextInputLayout.counterEnabled(): Consumer<in Boolean> = RxTextInputLayout.counterEnabled(this)
 
@@ -25,6 +29,9 @@ inline fun TextInputLayout.counterEnabled(): Consumer<in Boolean> = RxTextInputL
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
  */
+@Deprecated(
+    message = "Use view::setCounterMaxLength method reference."
+)
 @CheckResult
 inline fun TextInputLayout.counterMaxLength(): Consumer<in Int> = RxTextInputLayout.counterMaxLength(this)
 
@@ -34,6 +41,9 @@ inline fun TextInputLayout.counterMaxLength(): Consumer<in Int> = RxTextInputLay
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
  */
+@Deprecated(
+    message = "Use view::setError method reference."
+)
 @CheckResult
 inline fun TextInputLayout.error(): Consumer<in CharSequence?> = RxTextInputLayout.error(this)
 
@@ -43,6 +53,9 @@ inline fun TextInputLayout.error(): Consumer<in CharSequence?> = RxTextInputLayo
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
  */
+@Deprecated(
+    message = "Use view::setError method reference."
+)
 @CheckResult
 inline fun TextInputLayout.errorRes(): Consumer<in Int?> = RxTextInputLayout.errorRes(this)
 
@@ -52,6 +65,9 @@ inline fun TextInputLayout.errorRes(): Consumer<in Int?> = RxTextInputLayout.err
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
  */
+@Deprecated(
+    message = "Use view::setHint method reference."
+)
 @CheckResult
 inline fun TextInputLayout.hint(): Consumer<in CharSequence> = RxTextInputLayout.hint(this)
 
@@ -61,5 +77,8 @@ inline fun TextInputLayout.hint(): Consumer<in CharSequence> = RxTextInputLayout
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
  */
+@Deprecated(
+    message = "Use view::setHint method reference."
+)
 @CheckResult
 inline fun TextInputLayout.hintRes(): Consumer<in Int> = RxTextInputLayout.hintRes(this)

--- a/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/RxTextInputLayout.java
+++ b/rxbinding-design/src/main/java/com/jakewharton/rxbinding2/support/design/widget/RxTextInputLayout.java
@@ -18,7 +18,10 @@ public final class RxTextInputLayout {
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
    * to free this reference.
+   *
+   * @deprecated Use view::setCounterEnabled method reference.
    */
+  @Deprecated
   @CheckResult @NonNull
   public static Consumer<? super Boolean> counterEnabled(@NonNull final TextInputLayout view) {
     checkNotNull(view, "view == null");
@@ -34,7 +37,10 @@ public final class RxTextInputLayout {
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
    * to free this reference.
+   *
+   * @deprecated Use view::setCounterMaxLength method reference.
    */
+  @Deprecated
   @CheckResult @NonNull
   public static Consumer<? super Integer> counterMaxLength(@NonNull final TextInputLayout view) {
     checkNotNull(view, "view == null");
@@ -50,7 +56,10 @@ public final class RxTextInputLayout {
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
    * to free this reference.
+   *
+   * @deprecated Use view::setError method reference.
    */
+  @Deprecated
   @CheckResult @NonNull @GenericTypeNullable
   public static Consumer<? super CharSequence> error(@NonNull final TextInputLayout view) {
     checkNotNull(view, "view == null");
@@ -67,7 +76,10 @@ public final class RxTextInputLayout {
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
    * to free this reference.
+   *
+   * @deprecated Use view::setError method reference.
    */
+  @Deprecated
   @CheckResult @NonNull @GenericTypeNullable
   public static Consumer<? super Integer> errorRes(@NonNull final TextInputLayout view) {
     checkNotNull(view, "view == null");
@@ -84,7 +96,10 @@ public final class RxTextInputLayout {
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
    * to free this reference.
+   *
+   * @deprecated Use view::setHint method reference.
    */
+  @Deprecated
   @CheckResult @NonNull
   public static Consumer<? super CharSequence> hint(@NonNull final TextInputLayout view) {
     checkNotNull(view, "view == null");
@@ -100,7 +115,10 @@ public final class RxTextInputLayout {
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
    * to free this reference.
+   *
+   * @deprecated Use view::setHint method reference.
    */
+  @Deprecated
   @CheckResult @NonNull
   public static Consumer<? super Integer> hintRes(@NonNull final TextInputLayout view) {
     checkNotNull(view, "view == null");

--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/view/RxMenuItem.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/view/RxMenuItem.kt
@@ -11,6 +11,7 @@ import com.jakewharton.rxbinding2.internal.VoidToUnit
 import io.reactivex.Observable
 import io.reactivex.functions.Consumer
 import io.reactivex.functions.Predicate
+import kotlin.Deprecated
 import kotlin.Int
 import kotlin.Suppress
 import kotlin.Unit
@@ -77,6 +78,9 @@ inline fun MenuItem.actionViewEvents(handled: Predicate<in MenuItemActionViewEve
  * *Warning:* The created observable keeps a strong reference to `menuItem`.
  * Unsubscribe to free this reference.
  */
+@Deprecated(
+    message = "Use menuItem::setChecked method reference."
+)
 @CheckResult
 inline fun MenuItem.checked(): Consumer<in Boolean> = RxMenuItem.checked(this)
 
@@ -86,6 +90,9 @@ inline fun MenuItem.checked(): Consumer<in Boolean> = RxMenuItem.checked(this)
  * *Warning:* The created observable keeps a strong reference to `menuItem`.
  * Unsubscribe to free this reference.
  */
+@Deprecated(
+    message = "Use menuItem::setEnabled method reference."
+)
 @CheckResult
 inline fun MenuItem.enabled(): Consumer<in Boolean> = RxMenuItem.enabled(this)
 
@@ -95,6 +102,9 @@ inline fun MenuItem.enabled(): Consumer<in Boolean> = RxMenuItem.enabled(this)
  * *Warning:* The created observable keeps a strong reference to `menuItem`.
  * Unsubscribe to free this reference.
  */
+@Deprecated(
+    message = "Use menuItem::setIcon method reference."
+)
 @CheckResult
 inline fun MenuItem.icon(): Consumer<in Drawable> = RxMenuItem.icon(this)
 
@@ -104,6 +114,9 @@ inline fun MenuItem.icon(): Consumer<in Drawable> = RxMenuItem.icon(this)
  * *Warning:* The created observable keeps a strong reference to `menuItem`.
  * Unsubscribe to free this reference.
  */
+@Deprecated(
+    message = "Use menuItem::setIcon method reference."
+)
 @CheckResult
 inline fun MenuItem.iconRes(): Consumer<in Int> = RxMenuItem.iconRes(this)
 
@@ -113,6 +126,9 @@ inline fun MenuItem.iconRes(): Consumer<in Int> = RxMenuItem.iconRes(this)
  * *Warning:* The created observable keeps a strong reference to `menuItem`.
  * Unsubscribe to free this reference.
  */
+@Deprecated(
+    message = "Use menuItem::setTitle method reference."
+)
 @CheckResult
 inline fun MenuItem.title(): Consumer<in CharSequence> = RxMenuItem.title(this)
 
@@ -122,6 +138,9 @@ inline fun MenuItem.title(): Consumer<in CharSequence> = RxMenuItem.title(this)
  * *Warning:* The created observable keeps a strong reference to `menuItem`.
  * Unsubscribe to free this reference.
  */
+@Deprecated(
+    message = "Use menuItem::setTitle method reference."
+)
 @CheckResult
 inline fun MenuItem.titleRes(): Consumer<in Int> = RxMenuItem.titleRes(this)
 
@@ -131,5 +150,8 @@ inline fun MenuItem.titleRes(): Consumer<in Int> = RxMenuItem.titleRes(this)
  * *Warning:* The created observable keeps a strong reference to `menuItem`.
  * Unsubscribe to free this reference.
  */
+@Deprecated(
+    message = "Use menuItem::setVisible method reference."
+)
 @CheckResult
 inline fun MenuItem.visible(): Consumer<in Boolean> = RxMenuItem.visible(this)

--- a/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/view/RxView.kt
+++ b/rxbinding-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/view/RxView.kt
@@ -16,6 +16,7 @@ import io.reactivex.Observable
 import io.reactivex.functions.Consumer
 import io.reactivex.functions.Predicate
 import java.util.concurrent.Callable
+import kotlin.Deprecated
 import kotlin.Int
 import kotlin.Suppress
 import kotlin.Unit
@@ -322,6 +323,9 @@ inline fun View.keys(handled: Predicate<in KeyEvent>): Observable<KeyEvent> = Rx
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
  */
+@Deprecated(
+    message = "Use view::setActivated method reference."
+)
 @CheckResult
 inline fun View.activated(): Consumer<in Boolean> = RxView.activated(this)
 
@@ -331,6 +335,9 @@ inline fun View.activated(): Consumer<in Boolean> = RxView.activated(this)
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
  */
+@Deprecated(
+    message = "Use view::setClickable method reference."
+)
 @CheckResult
 inline fun View.clickable(): Consumer<in Boolean> = RxView.clickable(this)
 
@@ -340,6 +347,9 @@ inline fun View.clickable(): Consumer<in Boolean> = RxView.clickable(this)
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
  */
+@Deprecated(
+    message = "Use view::setEnabled method reference."
+)
 @CheckResult
 inline fun View.enabled(): Consumer<in Boolean> = RxView.enabled(this)
 
@@ -349,6 +359,9 @@ inline fun View.enabled(): Consumer<in Boolean> = RxView.enabled(this)
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
  */
+@Deprecated(
+    message = "Use view::setPressed method reference."
+)
 @CheckResult
 inline fun View.pressed(): Consumer<in Boolean> = RxView.pressed(this)
 
@@ -358,6 +371,9 @@ inline fun View.pressed(): Consumer<in Boolean> = RxView.pressed(this)
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
  */
+@Deprecated(
+    message = "Use view::setSelected method reference."
+)
 @CheckResult
 inline fun View.selected(): Consumer<in Boolean> = RxView.selected(this)
 

--- a/rxbinding-leanback-v17-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/support/v17/leanback/widget/RxSearchBar.kt
+++ b/rxbinding-leanback-v17-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/support/v17/leanback/widget/RxSearchBar.kt
@@ -8,6 +8,7 @@ import android.support.annotation.CheckResult
 import android.support.v17.leanback.widget.SearchBar
 import io.reactivex.Observable
 import io.reactivex.functions.Consumer
+import kotlin.Deprecated
 import kotlin.Suppress
 
 /**
@@ -35,5 +36,8 @@ inline fun SearchBar.searchQueryChanges(): Observable<String> = RxSearchBar.sear
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
  */
+@Deprecated(
+    message = "Use view::setSearchQuery method reference."
+)
 @CheckResult
 inline fun SearchBar.searchQuery(): Consumer<in String> = RxSearchBar.searchQuery(this)

--- a/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding2/support/v17/leanback/widget/RxSearchBar.java
+++ b/rxbinding-leanback-v17/src/main/java/com/jakewharton/rxbinding2/support/v17/leanback/widget/RxSearchBar.java
@@ -47,7 +47,10 @@ public final class RxSearchBar {
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
    * to free this reference.
+   *
+   * @deprecated Use view::setSearchQuery method reference.
    */
+  @Deprecated
   @CheckResult @NonNull
   public static Consumer<? super String> searchQuery(@NonNull final SearchBar view) {
     checkNotNull(view, "view == null");

--- a/rxbinding-support-v4-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/support/v4/view/RxViewPager.kt
+++ b/rxbinding-support-v4-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/support/v4/view/RxViewPager.kt
@@ -9,6 +9,7 @@ import android.support.v4.view.ViewPager
 import com.jakewharton.rxbinding2.InitialValueObservable
 import io.reactivex.Observable
 import io.reactivex.functions.Consumer
+import kotlin.Deprecated
 import kotlin.Int
 import kotlin.Suppress
 
@@ -38,5 +39,8 @@ inline fun ViewPager.pageSelections(): InitialValueObservable<Int> = RxViewPager
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
  */
+@Deprecated(
+    message = "Use view::setCurrentItem method reference."
+)
 @CheckResult
 inline fun ViewPager.currentItem(): Consumer<in Int> = RxViewPager.currentItem(this)

--- a/rxbinding-support-v4-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/support/v4/widget/RxSwipeRefreshLayout.kt
+++ b/rxbinding-support-v4-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/support/v4/widget/RxSwipeRefreshLayout.kt
@@ -9,6 +9,7 @@ import android.support.v4.widget.SwipeRefreshLayout
 import com.jakewharton.rxbinding2.internal.VoidToUnit
 import io.reactivex.Observable
 import io.reactivex.functions.Consumer
+import kotlin.Deprecated
 import kotlin.Suppress
 import kotlin.Unit
 
@@ -27,5 +28,8 @@ inline fun SwipeRefreshLayout.refreshes(): Observable<Unit> = RxSwipeRefreshLayo
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.
  */
+@Deprecated(
+    message = "Use view::setRefreshing method reference."
+)
 @CheckResult
 inline fun SwipeRefreshLayout.refreshing(): Consumer<in Boolean> = RxSwipeRefreshLayout.refreshing(this)

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/RxViewPager.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/RxViewPager.java
@@ -42,7 +42,10 @@ public final class RxViewPager {
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
    * to free this reference.
+   *
+   * @deprecated Use view::setCurrentItem method reference.
    */
+  @Deprecated
   @CheckResult @NonNull public static Consumer<? super Integer> currentItem(
       @NonNull final ViewPager view) {
     checkNotNull(view, "view == null");

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/RxSwipeRefreshLayout.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/widget/RxSwipeRefreshLayout.java
@@ -26,7 +26,10 @@ public final class RxSwipeRefreshLayout {
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
    * to free this reference.
+   *
+   * @deprecated Use view::setRefreshing method reference.
    */
+  @Deprecated
   @CheckResult @NonNull public static Consumer<? super Boolean> refreshing(
       @NonNull final SwipeRefreshLayout view) {
     checkNotNull(view, "view == null");

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/RxMenuItem.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/RxMenuItem.java
@@ -94,7 +94,10 @@ public final class RxMenuItem {
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code menuItem}.
    * Unsubscribe to free this reference.
+   *
+   * @deprecated Use menuItem::setChecked method reference.
    */
+  @Deprecated
   @CheckResult @NonNull
   public static Consumer<? super Boolean> checked(@NonNull final MenuItem menuItem) {
     checkNotNull(menuItem, "menuItem == null");
@@ -110,7 +113,10 @@ public final class RxMenuItem {
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code menuItem}.
    * Unsubscribe to free this reference.
+   *
+   * @deprecated Use menuItem::setEnabled method reference.
    */
+  @Deprecated
   @CheckResult @NonNull
   public static Consumer<? super Boolean> enabled(@NonNull final MenuItem menuItem) {
     checkNotNull(menuItem, "menuItem == null");
@@ -126,7 +132,10 @@ public final class RxMenuItem {
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code menuItem}.
    * Unsubscribe to free this reference.
+   *
+   * @deprecated Use menuItem::setIcon method reference.
    */
+  @Deprecated
   @CheckResult @NonNull
   public static Consumer<? super Drawable> icon(@NonNull final MenuItem menuItem) {
     checkNotNull(menuItem, "menuItem == null");
@@ -142,7 +151,10 @@ public final class RxMenuItem {
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code menuItem}.
    * Unsubscribe to free this reference.
+   *
+   * @deprecated Use menuItem::setIcon method reference.
    */
+  @Deprecated
   @CheckResult @NonNull
   public static Consumer<? super Integer> iconRes(@NonNull final MenuItem menuItem) {
     checkNotNull(menuItem, "menuItem == null");
@@ -158,7 +170,10 @@ public final class RxMenuItem {
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code menuItem}.
    * Unsubscribe to free this reference.
+   *
+   * @deprecated Use menuItem::setTitle method reference.
    */
+  @Deprecated
   @CheckResult @NonNull
   public static Consumer<? super CharSequence> title(@NonNull final MenuItem menuItem) {
     checkNotNull(menuItem, "menuItem == null");
@@ -174,7 +189,10 @@ public final class RxMenuItem {
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code menuItem}.
    * Unsubscribe to free this reference.
+   *
+   * @deprecated Use menuItem::setTitle method reference.
    */
+  @Deprecated
   @CheckResult @NonNull
   public static Consumer<? super Integer> titleRes(@NonNull final MenuItem menuItem) {
     checkNotNull(menuItem, "menuItem == null");
@@ -190,7 +208,10 @@ public final class RxMenuItem {
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code menuItem}.
    * Unsubscribe to free this reference.
+   *
+   * @deprecated Use menuItem::setVisible method reference.
    */
+  @Deprecated
   @CheckResult @NonNull
   public static Consumer<? super Boolean> visible(@NonNull final MenuItem menuItem) {
     checkNotNull(menuItem, "menuItem == null");

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/RxView.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/view/RxView.java
@@ -405,7 +405,10 @@ public final class RxView {
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
    * to free this reference.
+   *
+   * @deprecated Use view::setActivated method reference.
    */
+  @Deprecated
   @CheckResult @NonNull
   public static Consumer<? super Boolean> activated(@NonNull final View view) {
     checkNotNull(view, "view == null");
@@ -421,7 +424,10 @@ public final class RxView {
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
    * to free this reference.
+   *
+   * @deprecated Use view::setClickable method reference.
    */
+  @Deprecated
   @CheckResult @NonNull
   public static Consumer<? super Boolean> clickable(@NonNull final View view) {
     checkNotNull(view, "view == null");
@@ -437,7 +443,10 @@ public final class RxView {
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
    * to free this reference.
+   *
+   * @deprecated Use view::setEnabled method reference.
    */
+  @Deprecated
   @CheckResult @NonNull
   public static Consumer<? super Boolean> enabled(@NonNull final View view) {
     checkNotNull(view, "view == null");
@@ -453,7 +462,10 @@ public final class RxView {
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
    * to free this reference.
+   *
+   * @deprecated Use view::setPressed method reference.
    */
+  @Deprecated
   @CheckResult @NonNull
   public static Consumer<? super Boolean> pressed(@NonNull final View view) {
     checkNotNull(view, "view == null");
@@ -469,7 +481,10 @@ public final class RxView {
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
    * to free this reference.
+   *
+   * @deprecated Use view::setSelected method reference.
    */
+  @Deprecated
   @CheckResult @NonNull
   public static Consumer<? super Boolean> selected(@NonNull final View view) {
     checkNotNull(view, "view == null");


### PR DESCRIPTION
Closes #389.