### PR TITLE
Disable null parameter checks in Kotlin bindings.

### DIFF
--- a/rxbinding-appcompat-v7-kotlin/build.gradle
+++ b/rxbinding-appcompat-v7-kotlin/build.gradle
@@ -38,3 +38,9 @@ android {
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+  kotlinOptions {
+    freeCompilerArgs = ['-Xno-param-assertions']
+  }
+}

--- a/rxbinding-design-kotlin/build.gradle
+++ b/rxbinding-design-kotlin/build.gradle
@@ -38,3 +38,9 @@ android {
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+  kotlinOptions {
+    freeCompilerArgs = ['-Xno-param-assertions']
+  }
+}

--- a/rxbinding-kotlin/build.gradle
+++ b/rxbinding-kotlin/build.gradle
@@ -37,3 +37,9 @@ android {
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+  kotlinOptions {
+    freeCompilerArgs = ['-Xno-param-assertions']
+  }
+}

--- a/rxbinding-leanback-v17-kotlin/build.gradle
+++ b/rxbinding-leanback-v17-kotlin/build.gradle
@@ -38,3 +38,9 @@ android {
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+  kotlinOptions {
+    freeCompilerArgs = ['-Xno-param-assertions']
+  }
+}

--- a/rxbinding-recyclerview-v7-kotlin/build.gradle
+++ b/rxbinding-recyclerview-v7-kotlin/build.gradle
@@ -38,3 +38,9 @@ android {
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+  kotlinOptions {
+    freeCompilerArgs = ['-Xno-param-assertions']
+  }
+}

--- a/rxbinding-support-v4-kotlin/build.gradle
+++ b/rxbinding-support-v4-kotlin/build.gradle
@@ -38,3 +38,9 @@ android {
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+  kotlinOptions {
+    freeCompilerArgs = ['-Xno-param-assertions']
+  }
+}


### PR DESCRIPTION
We expect them to only be consumed from Kotlin code.