### PR TITLE
Add ViewPager page scroll events binding

### DIFF
--- a/rxbinding-support-v4-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/support/v4/view/RxViewPager.kt
+++ b/rxbinding-support-v4-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/support/v4/view/RxViewPager.kt
@@ -12,6 +12,15 @@ import kotlin.Int
 import kotlin.Suppress
 
 /**
+ * Create an observable of scroll events on `view`.
+ *
+ * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
+ * to free this reference.
+ */
+@CheckResult
+inline fun ViewPager.pageScrollEvents(): Observable<ViewPagerPageScrollEvent> = RxViewPager.pageScrollEvents(this)
+
+/**
  * Create an observable of scroll state change events on `view`.
  *
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe

--- a/rxbinding-support-v4-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/support/v4/view/RxViewPager.kt
+++ b/rxbinding-support-v4-kotlin/src/main/kotlin/com/jakewharton/rxbinding2/support/v4/view/RxViewPager.kt
@@ -12,7 +12,7 @@ import kotlin.Int
 import kotlin.Suppress
 
 /**
- * Create an observable of scroll events on `view`.
+ * Create an observable of page scroll events on `view`.
  *
  * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
  * to free this reference.

--- a/rxbinding-support-v4/build.gradle
+++ b/rxbinding-support-v4/build.gradle
@@ -13,6 +13,9 @@ dependencies {
   implementation rootProject.ext.rxAndroid
   implementation rootProject.ext.supportAnnotations
 
+  compileOnly rootProject.ext.autoValueAnnotations
+  annotationProcessor rootProject.ext.autoValue
+
   androidTestImplementation project(':testing-utils')
   androidTestImplementation rootProject.ext.supportTestRunner
   androidTestImplementation rootProject.ext.supportTestRules
@@ -26,6 +29,8 @@ android {
 
   defaultConfig {
     minSdkVersion rootProject.ext.minSdkVersion
+
+    consumerProguardFiles 'src/main/proguard-consumer.pro'
 
     testInstrumentationRunner 'com.jakewharton.rxbinding.RxBindingTestRunner'
   }

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/RxViewPager.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/RxViewPager.java
@@ -11,7 +11,7 @@ import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
 
 public final class RxViewPager {
   /**
-   * Create an observable of scroll events on {@code view}.
+   * Create an observable of page scroll events on {@code view}.
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
    * to free this reference.

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/RxViewPager.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/RxViewPager.java
@@ -11,6 +11,19 @@ import static com.jakewharton.rxbinding2.internal.Preconditions.checkNotNull;
 
 public final class RxViewPager {
   /**
+   * Create an observable of scroll events on {@code view}.
+   * <p>
+   * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe
+   * to free this reference.
+   * <p>
+   */
+  @CheckResult @NonNull
+  public static Observable<ViewPagerPageScrollEvent> pageScrollEvents(@NonNull ViewPager view) {
+    checkNotNull(view, "view == null");
+    return new ViewPagerPageScrolledObservable(view);
+  }
+
+  /**
    * Create an observable of scroll state change events on {@code view}.
    * <p>
    * <em>Warning:</em> The created observable keeps a strong reference to {@code view}. Unsubscribe

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/ViewPagerPageScrollEvent.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/ViewPagerPageScrollEvent.java
@@ -21,8 +21,7 @@ public abstract class ViewPagerPageScrollEvent {
   /**
    * The view from which this event occurred.
    */
-  @NonNull
-  public abstract ViewPager viewPager();
+  @NonNull public abstract ViewPager viewPager();
   public abstract int position();
   public abstract float positionOffset();
   public abstract int positionOffsetPixels();

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/ViewPagerPageScrollEvent.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/ViewPagerPageScrollEvent.java
@@ -1,0 +1,29 @@
+package com.jakewharton.rxbinding2.support.v4.view;
+
+import android.support.annotation.CheckResult;
+import android.support.annotation.NonNull;
+import android.support.v4.view.ViewPager;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class ViewPagerPageScrollEvent {
+  @CheckResult @NonNull
+  public static ViewPagerPageScrollEvent create(ViewPager viewPager, int position,
+      float positionOffset, int positionOffsetPixels) {
+    return new AutoValue_ViewPagerPageScrollEvent(viewPager, position, positionOffset,
+        positionOffsetPixels);
+  }
+
+  ViewPagerPageScrollEvent() {
+  }
+
+  /**
+   * The view from which this event occurred.
+   */
+  @NonNull
+  public abstract ViewPager viewPager();
+  public abstract int position();
+  public abstract float positionOffset();
+  public abstract int positionOffsetPixels();
+}

--- a/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/ViewPagerPageScrolledObservable.java
+++ b/rxbinding-support-v4/src/main/java/com/jakewharton/rxbinding2/support/v4/view/ViewPagerPageScrolledObservable.java
@@ -1,0 +1,63 @@
+package com.jakewharton.rxbinding2.support.v4.view;
+
+import android.support.v4.view.ViewPager;
+import android.support.v4.view.ViewPager.OnPageChangeListener;
+
+import io.reactivex.Observable;
+import io.reactivex.Observer;
+import io.reactivex.android.MainThreadDisposable;
+
+import static com.jakewharton.rxbinding2.internal.Preconditions.checkMainThread;
+
+final class ViewPagerPageScrolledObservable extends Observable<ViewPagerPageScrollEvent> {
+  private final ViewPager view;
+
+  ViewPagerPageScrolledObservable(ViewPager view) {
+    this.view = view;
+  }
+
+  @Override
+  protected void subscribeActual(Observer<? super ViewPagerPageScrollEvent> observer) {
+    if (!checkMainThread(observer)) {
+      return;
+    }
+    Listener listener = new Listener(view, observer);
+    observer.onSubscribe(listener);
+    view.addOnPageChangeListener(listener);
+  }
+
+  static final class Listener extends MainThreadDisposable implements OnPageChangeListener {
+    private final ViewPager view;
+    private final Observer<? super ViewPagerPageScrollEvent> observer;
+
+    Listener(ViewPager view, Observer<? super ViewPagerPageScrollEvent> observer) {
+      this.view = view;
+      this.observer = observer;
+    }
+
+    @Override
+    public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
+      if (!isDisposed()) {
+        ViewPagerPageScrollEvent event =
+            ViewPagerPageScrollEvent.create(view, position, positionOffset,
+                positionOffsetPixels);
+        observer.onNext(event);
+      }
+    }
+
+    @Override
+    public void onPageSelected(int position) {
+
+    }
+
+    @Override
+    public void onPageScrollStateChanged(int state) {
+
+    }
+
+    @Override
+    protected void onDispose() {
+      view.removeOnPageChangeListener(this);
+    }
+  }
+}

--- a/rxbinding-support-v4/src/main/proguard-consumer.pro
+++ b/rxbinding-support-v4/src/main/proguard-consumer.pro
@@ -1,0 +1,2 @@
+# AutoValue annotations are retained but dependency is compileOnly.
+-dontwarn com.google.auto.value.AutoValue


### PR DESCRIPTION
I added a binding wrapping `ViewPager.OnPageChangedListener.onPageScrolled()`. 

Instrumentation test is based on `RxSlidingPaneLayoutTest.slides()`:
https://github.com/JakeWharton/RxBinding/blob/41fa0a79827fa4b93a0daf9a3406f524b34c1052/rxbinding-support-v4/src/androidTest/java/com/jakewharton/rxbinding2/support/v4/widget/RxSlidingPaneLayoutTest.java#L83

I was wondering whether testing `ViewPagerPageScrollEvent.position()` is needed or not (i.e. scrolling past the second item. I'll add an appropriate assertion if it is.