### PR TITLE
Always emit editor events

### DIFF
--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewEditorActionEventObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewEditorActionEventObservable.java
@@ -46,9 +46,10 @@ final class TextViewEditorActionEventObservable extends Observable<TextViewEdito
     public boolean onEditorAction(TextView textView, int actionId, KeyEvent keyEvent) {
       TextViewEditorActionEvent event = TextViewEditorActionEvent.create(view, actionId, keyEvent);
       try {
-        if (!isDisposed() && handled.test(event)) {
+        if (!isDisposed()) {
+          boolean isHandled = handled.test(event);
           observer.onNext(event);
-          return true;
+          return isHandled;
         }
       } catch (Exception e) {
         observer.onError(e);

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewEditorActionObservable.java
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding2/widget/TextViewEditorActionObservable.java
@@ -44,9 +44,10 @@ final class TextViewEditorActionObservable extends Observable<Integer> {
     @Override
     public boolean onEditorAction(TextView textView, int actionId, KeyEvent keyEvent) {
       try {
-        if (!isDisposed() && handled.test(actionId)) {
+        if (!isDisposed()) {
+          boolean isHandled = handled.test(actionId);
           observer.onNext(actionId);
-          return true;
+          return isHandled;
         }
       } catch (Exception e) {
         observer.onError(e);


### PR DESCRIPTION
Sometimes it is desirable to use an editor event without considering it to be handled. For example when you want an EditText's send action to perform some action and still close the keyboard.

The predicate passed to the RxTextView::editorActions and RxTextView::editorActionEvents can be used to determine whether the event should be considered to have been handled. A simple observable filter can be used to only consider certain events.

```java
// Consider all actions to be unhandled which, as far as I understand it, 
// means "do whatever happens normally when this action is emitted".
RxTextView.editorActions(view, __ -> false) 
    .filter(action -> action == EditorInfo.IME_ACTION_SEND)
    .subscribe( /* ... */ );
```

Perhaps my understanding of what it means to handle an action is wrong or I am missing something entirely. 

I realize this PR is currently incomplete and a breaking change but I wanted to create a starting point for discussion on how to approach this.
