### PR TITLE
Make View param nullable on AdapterView events

### DIFF
--- a/rxbinding/src/main/java/com/jakewharton/rxbinding3/widget/AdapterViewItemClickEventObservable.kt
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding3/widget/AdapterViewItemClickEventObservable.kt
@@ -28,7 +28,7 @@ fun <T : Adapter> AdapterView<T>.itemClickEvents(): Observable<AdapterViewItemCl
 data class AdapterViewItemClickEvent(
   /** The view from which this event occurred.  */
   val view: AdapterView<*>,
-  val clickedView: View,
+  val clickedView: View?,
   val position: Int,
   val id: Long
 )
@@ -51,7 +51,7 @@ private class AdapterViewItemClickEventObservable(
     private val observer: Observer<in AdapterViewItemClickEvent>
   ) : MainThreadDisposable(), OnItemClickListener {
 
-    override fun onItemClick(parent: AdapterView<*>, view: View, position: Int, id: Long) {
+    override fun onItemClick(parent: AdapterView<*>, view: View?, position: Int, id: Long) {
       if (!isDisposed) {
         observer.onNext(AdapterViewItemClickEvent(parent, view, position, id))
       }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding3/widget/AdapterViewItemClickObservable.kt
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding3/widget/AdapterViewItemClickObservable.kt
@@ -44,7 +44,7 @@ private class AdapterViewItemClickObservable(
     private val observer: Observer<in Int>
   ) : MainThreadDisposable(), OnItemClickListener {
 
-    override fun onItemClick(adapterView: AdapterView<*>, view: View, position: Int, id: Long) {
+    override fun onItemClick(adapterView: AdapterView<*>, view: View?, position: Int, id: Long) {
       if (!isDisposed) {
         observer.onNext(position)
       }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding3/widget/AdapterViewItemLongClickEventObservable.kt
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding3/widget/AdapterViewItemLongClickEventObservable.kt
@@ -35,7 +35,7 @@ fun <T : Adapter> AdapterView<T>.itemLongClickEvents(
 data class AdapterViewItemLongClickEvent(
   /** The view from which this event occurred.  */
   val view: AdapterView<*>,
-  val clickedView: View,
+  val clickedView: View?,
   val position: Int,
   val id: Long
 )
@@ -62,7 +62,7 @@ private class AdapterViewItemLongClickEventObservable(
 
     override fun onItemLongClick(
       parent: AdapterView<*>,
-      view: View,
+      view: View?,
       position: Int,
       id: Long
     ): Boolean {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding3/widget/AdapterViewItemLongClickObservable.kt
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding3/widget/AdapterViewItemLongClickObservable.kt
@@ -55,7 +55,7 @@ private class AdapterViewItemLongClickObservable(
 
     override fun onItemLongClick(
       parent: AdapterView<*>,
-      view: View,
+      view: View?,
       position: Int,
       id: Long
     ): Boolean {

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding3/widget/AdapterViewItemSelectionObservable.kt
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding3/widget/AdapterViewItemSelectionObservable.kt
@@ -49,7 +49,7 @@ private class AdapterViewItemSelectionObservable(
     private val observer: Observer<in Int>
   ) : MainThreadDisposable(), OnItemSelectedListener {
 
-    override fun onItemSelected(adapterView: AdapterView<*>, view: View, position: Int, id: Long) {
+    override fun onItemSelected(adapterView: AdapterView<*>, view: View?, position: Int, id: Long) {
       if (!isDisposed) {
         observer.onNext(position)
       }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding3/widget/AdapterViewSelectionEvent.kt
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding3/widget/AdapterViewSelectionEvent.kt
@@ -10,7 +10,7 @@ sealed class AdapterViewSelectionEvent {
 
 data class AdapterViewItemSelectionEvent(
   override val view: AdapterView<*>,
-  val selectedView: View,
+  val selectedView: View?,
   val position: Int,
   val id: Long
 ) : AdapterViewSelectionEvent()

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding3/widget/AdapterViewSelectionObservable.kt
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding3/widget/AdapterViewSelectionObservable.kt
@@ -58,7 +58,7 @@ private class AdapterViewSelectionObservable(
     private val observer: Observer<in AdapterViewSelectionEvent>
   ) : MainThreadDisposable(), OnItemSelectedListener {
 
-    override fun onItemSelected(parent: AdapterView<*>, view: View, position: Int, id: Long) {
+    override fun onItemSelected(parent: AdapterView<*>, view: View?, position: Int, id: Long) {
       if (!isDisposed) {
         observer.onNext(AdapterViewItemSelectionEvent(parent, view, position, id))
       }

--- a/rxbinding/src/main/java/com/jakewharton/rxbinding3/widget/AutoCompleteTextViewItemClickEventObservable.kt
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding3/widget/AutoCompleteTextViewItemClickEventObservable.kt
@@ -43,7 +43,7 @@ private class AutoCompleteTextViewItemClickEventObservable(
     private val observer: Observer<in AdapterViewItemClickEvent>
   ) : MainThreadDisposable(), OnItemClickListener {
 
-    override fun onItemClick(parent: AdapterView<*>, view: View, position: Int, id: Long) {
+    override fun onItemClick(parent: AdapterView<*>, view: View?, position: Int, id: Long) {
       if (!isDisposed) {
         observer.onNext(AdapterViewItemClickEvent(parent, view, position, id))
       }


### PR DESCRIPTION
Not sure if I got all the places that this change is necessary in all of RxBindings, but at least this will fix the null pointer issue for `AdapterView` related events.
Fixes #485  