### PR TITLE
Implements BottomSheetBehavior.Callbacks observables

### DIFF
--- a/rxbinding-material/src/main/java/com/jakewharton/rxbinding3/material/BottomSheetBehaiorStateChangeEventObservable.kt
+++ b/rxbinding-material/src/main/java/com/jakewharton/rxbinding3/material/BottomSheetBehaiorStateChangeEventObservable.kt
@@ -1,0 +1,80 @@
+@file:JvmName("RxBottomSheetBehavior")
+@file:JvmMultifileClass
+
+package com.jakewharton.rxbinding3.material
+
+import android.content.Context
+import android.view.View
+import androidx.annotation.CheckResult
+import androidx.coordinatorlayout.widget.CoordinatorLayout.LayoutParams
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetBehavior.BottomSheetCallback
+import com.jakewharton.rxbinding3.internal.checkMainThread
+import io.reactivex.Observable
+import io.reactivex.Observer
+import io.reactivex.android.MainThreadDisposable
+
+/**
+ * Create an observable which emits the state change events from `view` on
+ * [BottomSheetBehavior]
+ *
+ * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
+ * to free this reference.
+ *
+ * *Warning:* The created observable uses [BottomSheetBehavior.setBottomSheetCallback] to observe
+ * state changes. Only one observable can be used for a view at a time.
+ */
+@CheckResult
+fun View.stateChangeEvents(): Observable<BottomSheetBehaviorStateChangeEvent> {
+  return BottomSheetBehaviorStateChangeEventObservable(this)
+}
+
+/**
+ * A BottomSheetBehavior state change event on a view.
+ *
+ * **Warning:** Instances keep a strong reference to the view. Operators that cache
+ * instances have the potential to leak the associated [Context].
+ */
+data class BottomSheetBehaviorStateChangeEvent(
+    val view: View,
+    val newState: Int
+)
+
+private class BottomSheetBehaviorStateChangeEventObservable(
+    private val view: View
+) : Observable<BottomSheetBehaviorStateChangeEvent>() {
+
+  override fun subscribeActual(observer: Observer<in BottomSheetBehaviorStateChangeEvent>) {
+    if (!checkMainThread(observer)) {
+      return
+    }
+    val params = view.layoutParams as? LayoutParams
+        ?: throw IllegalArgumentException("The view is not in a Coordinator Layout.")
+    val behavior = params.behavior as BottomSheetBehavior<*>?
+        ?: throw IllegalStateException("There's no behavior set on this view.")
+
+    val listener = Listener(behavior, observer)
+    observer.onSubscribe(listener)
+    behavior.setBottomSheetCallback(listener.callback)
+  }
+
+  private class Listener(
+      private val behavior: BottomSheetBehavior<*>,
+      private val observer: Observer<in BottomSheetBehaviorStateChangeEvent>
+  ) : MainThreadDisposable() {
+
+    val callback = object : BottomSheetCallback() {
+      override fun onStateChanged(view: View, newState: Int) {
+        if (!isDisposed) {
+          observer.onNext(BottomSheetBehaviorStateChangeEvent(view, newState))
+        }
+      }
+
+      override fun onSlide(view: View, slideOffset: Float) {}
+    }
+
+    override fun onDispose() {
+      behavior.setBottomSheetCallback(null)
+    }
+  }
+}

--- a/rxbinding-material/src/main/java/com/jakewharton/rxbinding3/material/BottomSheetBehaviorSlideEventObservable.kt
+++ b/rxbinding-material/src/main/java/com/jakewharton/rxbinding3/material/BottomSheetBehaviorSlideEventObservable.kt
@@ -1,0 +1,80 @@
+@file:JvmName("RxBottomSheetBehavior")
+@file:JvmMultifileClass
+
+package com.jakewharton.rxbinding3.material
+
+import android.content.Context
+import android.view.View
+import androidx.annotation.CheckResult
+import androidx.coordinatorlayout.widget.CoordinatorLayout.LayoutParams
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetBehavior.BottomSheetCallback
+import com.jakewharton.rxbinding3.internal.checkMainThread
+import io.reactivex.Observable
+import io.reactivex.Observer
+import io.reactivex.android.MainThreadDisposable
+
+/**
+ * Create an observable which emits the slide events from `view` on
+ * [BottomSheetBehavior]
+ *
+ * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
+ * to free this reference.
+ *
+ * *Warning:* The created observable uses [BottomSheetBehavior.setBottomSheetCallback] to observe
+ * slides. Only one observable can be used for a view at a time.
+ */
+@CheckResult
+fun View.slideEvents(): Observable<BottomSheetBehaviorSlideEvent> {
+  return BottomSheetBehaviorSlideEventObservable(this)
+}
+
+/**
+ * A BottomSheetBehavior slide event on a view.
+ *
+ * **Warning:** Instances keep a strong reference to the view. Operators that cache
+ * instances have the potential to leak the associated [Context].
+ */
+data class BottomSheetBehaviorSlideEvent(
+    val view: View,
+    val slideOffset: Float
+)
+
+private class BottomSheetBehaviorSlideEventObservable(
+    private val view: View
+) : Observable<BottomSheetBehaviorSlideEvent>() {
+
+  override fun subscribeActual(observer: Observer<in BottomSheetBehaviorSlideEvent>) {
+    if (!checkMainThread(observer)) {
+      return
+    }
+    val params = view.layoutParams as? LayoutParams
+        ?: throw IllegalArgumentException("The view is not in a Coordinator Layout.")
+    val behavior = params.behavior as BottomSheetBehavior<*>?
+        ?: throw IllegalStateException("There's no behavior set on this view.")
+
+    val listener = Listener(behavior, observer)
+    observer.onSubscribe(listener)
+    behavior.setBottomSheetCallback(listener.callback)
+  }
+
+  private class Listener(
+      private val behavior: BottomSheetBehavior<*>,
+      private val observer: Observer<in BottomSheetBehaviorSlideEvent>
+  ) : MainThreadDisposable() {
+
+    val callback = object : BottomSheetCallback() {
+      override fun onStateChanged(view: View, newState: Int) {}
+
+      override fun onSlide(view: View, slideOffset: Float) {
+        if (!isDisposed) {
+          observer.onNext(BottomSheetBehaviorSlideEvent(view, slideOffset))
+        }
+      }
+    }
+
+    override fun onDispose() {
+      behavior.setBottomSheetCallback(null)
+    }
+  }
+}

--- a/rxbinding-material/src/main/java/com/jakewharton/rxbinding3/material/BottomSheetBehaviorSlideObservable.kt
+++ b/rxbinding-material/src/main/java/com/jakewharton/rxbinding3/material/BottomSheetBehaviorSlideObservable.kt
@@ -1,0 +1,68 @@
+@file:JvmName("RxBottomSheetBehavior")
+@file:JvmMultifileClass
+
+package com.jakewharton.rxbinding3.material
+
+import android.view.View
+import androidx.annotation.CheckResult
+import androidx.coordinatorlayout.widget.CoordinatorLayout.LayoutParams
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetBehavior.BottomSheetCallback
+import com.jakewharton.rxbinding3.internal.checkMainThread
+import io.reactivex.Observable
+import io.reactivex.Observer
+import io.reactivex.android.MainThreadDisposable
+
+/**
+ * Create an observable which emits the slide offsets from `view` on
+ * [BottomSheetBehavior]
+ *
+ * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
+ * to free this reference.
+ *
+ * *Warning:* The created observable uses [BottomSheetBehavior.setBottomSheetCallback] to observe
+ * slides. Only one observable can be used for a view at a time.
+ */
+@CheckResult
+fun View.slides(): Observable<Float> {
+  return BottomSheetBehaviorSlideObservable(this)
+}
+
+private class BottomSheetBehaviorSlideObservable(
+    private val view: View
+) : Observable<Float>() {
+
+  override fun subscribeActual(observer: Observer<in Float>) {
+    if (!checkMainThread(observer)) {
+      return
+    }
+    val params = view.layoutParams as? LayoutParams
+        ?: throw IllegalArgumentException("The view is not in a Coordinator Layout.")
+    val behavior = params.behavior as BottomSheetBehavior<*>?
+        ?: throw IllegalStateException("There's no behavior set on this view.")
+
+    val listener = Listener(behavior, observer)
+    observer.onSubscribe(listener)
+    behavior.setBottomSheetCallback(listener.callback)
+  }
+
+  private class Listener(
+      private val behavior: BottomSheetBehavior<*>,
+      private val observer: Observer<in Float>
+  ) : MainThreadDisposable() {
+
+    val callback = object : BottomSheetCallback() {
+      override fun onStateChanged(view: View, newState: Int) {}
+
+      override fun onSlide(view: View, slideOffset: Float) {
+        if (!isDisposed) {
+          observer.onNext(slideOffset)
+        }
+      }
+    }
+
+    override fun onDispose() {
+      behavior.setBottomSheetCallback(null)
+    }
+  }
+}

--- a/rxbinding-material/src/main/java/com/jakewharton/rxbinding3/material/BottomSheetBehaviorStateChangeObservable.kt
+++ b/rxbinding-material/src/main/java/com/jakewharton/rxbinding3/material/BottomSheetBehaviorStateChangeObservable.kt
@@ -1,0 +1,68 @@
+@file:JvmName("RxBottomSheetBehavior")
+@file:JvmMultifileClass
+
+package com.jakewharton.rxbinding3.material
+
+import android.view.View
+import androidx.annotation.CheckResult
+import androidx.coordinatorlayout.widget.CoordinatorLayout.LayoutParams
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetBehavior.BottomSheetCallback
+import com.jakewharton.rxbinding3.internal.checkMainThread
+import io.reactivex.Observable
+import io.reactivex.Observer
+import io.reactivex.android.MainThreadDisposable
+
+/**
+ * Create an observable which emits the state changes from `view` on
+ * [BottomSheetBehavior]
+ *
+ * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
+ * to free this reference.
+ *
+ * *Warning:* The created observable uses [BottomSheetBehavior.setBottomSheetCallback] to observe
+ * state changes. Only one observable can be used for a view at a time.
+ */
+@CheckResult
+fun View.stateChanges(): Observable<Int> {
+  return BottomSheetBehaviorStateChangeObservable(this)
+}
+
+private class BottomSheetBehaviorStateChangeObservable(
+    private val view: View
+) : Observable<Int>() {
+
+  override fun subscribeActual(observer: Observer<in Int>) {
+    if (!checkMainThread(observer)) {
+      return
+    }
+    val params = view.layoutParams as? LayoutParams
+        ?: throw IllegalArgumentException("The view is not in a Coordinator Layout.")
+    val behavior = params.behavior as BottomSheetBehavior<*>?
+        ?: throw IllegalStateException("There's no behavior set on this view.")
+
+    val listener = Listener(behavior, observer)
+    observer.onSubscribe(listener)
+    behavior.setBottomSheetCallback(listener.callback)
+  }
+
+  private class Listener(
+      private val behavior: BottomSheetBehavior<*>,
+      private val observer: Observer<in Int>
+  ) : MainThreadDisposable() {
+
+    val callback = object : BottomSheetCallback() {
+      override fun onStateChanged(view: View, newState: Int) {
+        if (!isDisposed) {
+          observer.onNext(newState)
+        }
+      }
+
+      override fun onSlide(view: View, slideOffset: Float) {}
+    }
+
+    override fun onDispose() {
+      behavior.setBottomSheetCallback(null)
+    }
+  }
+}


### PR DESCRIPTION
refs #400 

Implements Observables for `BottomSheetBehavior.Callback`:
- `View.slides()` for slide offset callbacks, `View.slideEvents()` for Event wrapper that includes the View reference
- `View.stateChanges()` for state change callbacks, `View.stateChangeEvents()` for Event wrapper that includes View reference

Opening this now, incomplete without tests. Is the plan to convert the tests to Kotlin? Hadn't seen any work on that for existing tests (obviously lots of changes recently w/ 3.0.0 coming)