### PR TITLE
Add Chip close icon clicks observable

### DIFF
--- a/rxbinding-material/src/androidTest/java/com/jakewharton/rxbinding3/material/RxChipTest.kt
+++ b/rxbinding-material/src/androidTest/java/com/jakewharton/rxbinding3/material/RxChipTest.kt
@@ -1,0 +1,32 @@
+package com.jakewharton.rxbinding3.material
+
+import android.view.ContextThemeWrapper
+import androidx.test.InstrumentationRegistry
+import androidx.test.annotation.UiThreadTest
+import com.google.android.material.chip.Chip
+import com.jakewharton.rxbinding3.RecordingObserver
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class RxChipTest {
+  private val rawContext = InstrumentationRegistry.getContext()
+  private val context = ContextThemeWrapper(rawContext, R.style.Theme_MaterialComponents)
+  private val view = Chip(context)
+
+  @Test @UiThreadTest fun closeIconClicks() {
+    val o = RecordingObserver<Unit>()
+    view.closeIconClicks().subscribe(o)
+    o.assertNoMoreEvents() // No initial value.
+
+    view.performCloseIconClick()
+    assertNotNull(o.takeNext())
+
+    view.performCloseIconClick()
+    assertNotNull(o.takeNext())
+
+    o.dispose()
+
+    view.performCloseIconClick()
+    o.assertNoMoreEvents()
+  }
+}

--- a/rxbinding-material/src/main/java/com/jakewharton/rxbinding3/material/ChipCloseIconClicksObservable.kt
+++ b/rxbinding-material/src/main/java/com/jakewharton/rxbinding3/material/ChipCloseIconClicksObservable.kt
@@ -1,0 +1,58 @@
+@file:JvmName("RxChip")
+@file:JvmMultifileClass
+
+package com.jakewharton.rxbinding3.material
+
+import android.view.View
+import android.view.View.OnClickListener
+import androidx.annotation.CheckResult
+import com.google.android.material.chip.Chip
+import com.jakewharton.rxbinding3.internal.checkMainThread
+import io.reactivex.Observable
+import io.reactivex.Observer
+import io.reactivex.android.MainThreadDisposable
+
+/**
+ * Create an observable which emits on [Chip] close icon click events. The emitted value is
+ * unspecified and should only be used as notification.
+ *
+ * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
+ * to free this reference.
+ *
+ * *Warning:* The created observable uses [Chip.setOnCloseIconClickListener] to observe
+ * clicks. Only one observable can be used for a view at a time.
+ */
+@CheckResult
+fun Chip.closeIconClicks(): Observable<Unit> {
+  return ChipCloseIconClicksObservable(this)
+}
+
+private class ChipCloseIconClicksObservable(
+  private val view: Chip
+) : Observable<Unit>() {
+
+  override fun subscribeActual(observer: Observer<in Unit>) {
+    if (!checkMainThread(observer)) {
+      return
+    }
+    val listener = Listener(view, observer)
+    observer.onSubscribe(listener)
+    view.setOnCloseIconClickListener(listener)
+  }
+
+  private class Listener(
+    private val view: Chip,
+    private val observer: Observer<in Unit>
+  ) : MainThreadDisposable(), OnClickListener {
+
+    override fun onClick(v: View) {
+      if (!isDisposed) {
+        observer.onNext(Unit)
+      }
+    }
+
+    override fun onDispose() {
+      view.setOnCloseIconClickListener(null)
+    }
+  }
+}


### PR DESCRIPTION
As `Chip` inherits from `CompoundButton`, it already has `checkedChanges()` and `clicks()` bindings by default, so I've just added the remaining one as per [documentation](https://github.com/material-components/material-components-android/blob/master/docs/components/Chip.md#handling-clicks)