### PR TITLE
Add RxChipGroup

### DIFF
--- a/rxbinding-material/src/androidTest/java/com/jakewharton/rxbinding3/material/RxChipGroupTest.kt
+++ b/rxbinding-material/src/androidTest/java/com/jakewharton/rxbinding3/material/RxChipGroupTest.kt
@@ -1,0 +1,74 @@
+package com.jakewharton.rxbinding3.material
+
+import android.view.ContextThemeWrapper
+import androidx.test.InstrumentationRegistry
+import androidx.test.annotation.UiThreadTest
+import com.google.android.material.chip.Chip
+import com.google.android.material.chip.ChipGroup
+import com.jakewharton.rxbinding3.RecordingObserver
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@SuppressWarnings("ResourceType")  // Don't need real IDs for test case.
+class RxChipGroupTest {
+  private val rawContext = InstrumentationRegistry.getContext()
+  private val context = ContextThemeWrapper(rawContext, R.style.Theme_MaterialComponents)
+  private val view = ChipGroup(context)
+
+  @Before fun setUp() {
+    val chip1 = Chip(context)
+    chip1.id = 1
+    view.addView(chip1)
+    val chip2 = Chip(context)
+    chip2.id = 2
+    view.addView(chip2)
+  }
+
+  @Test @UiThreadTest fun checkedChangesNotInSingleSelectionModeNotifies() {
+    view.isSingleSelection = false
+
+    val o = RecordingObserver<Int>()
+    view.checkedChanges().subscribe(o)
+
+    val e = o.takeError()
+    assertTrue(e is IllegalStateException)
+    assertTrue(e.message == "The view is not in single selection mode!")
+  }
+
+  @Test @UiThreadTest fun checkedChanges() {
+    view.isSingleSelection = true
+
+    val o = RecordingObserver<Int>()
+    view.checkedChanges().subscribe(o)
+    assertEquals(-1, o.takeNext())
+
+    view.check(1)
+    assertEquals(1, o.takeNext())
+
+    view.clearCheck()
+    assertEquals(-1, o.takeNext())
+
+    view.check(2)
+    assertEquals(2, o.takeNext())
+
+    o.dispose()
+
+    view.check(1)
+    o.assertNoMoreEvents()
+  }
+
+  @Test @UiThreadTest fun checked() {
+    view.isSingleSelection = true // as `checkedChipId` always returns -1 otherwise
+
+    val action = view.checked()
+    assertEquals(-1, view.checkedChipId)
+    action.accept(1)
+    assertEquals(1, view.checkedChipId)
+    action.accept(-1)
+    assertEquals(-1, view.checkedChipId)
+    action.accept(2)
+    assertEquals(2, view.checkedChipId)
+  }
+}

--- a/rxbinding-material/src/main/java/com/jakewharton/rxbinding3/material/ChipGroupCheckedChangeObservable.kt
+++ b/rxbinding-material/src/main/java/com/jakewharton/rxbinding3/material/ChipGroupCheckedChangeObservable.kt
@@ -1,0 +1,72 @@
+@file:JvmName("RxChipGroup")
+@file:JvmMultifileClass
+
+package com.jakewharton.rxbinding3.material
+
+import androidx.annotation.CheckResult
+import com.google.android.material.chip.ChipGroup
+import com.jakewharton.rxbinding3.InitialValueObservable
+import com.jakewharton.rxbinding3.internal.checkMainThread
+import io.reactivex.Observer
+import io.reactivex.android.MainThreadDisposable
+import io.reactivex.disposables.Disposables
+
+/**
+ * Create an observable of the checked view ID changes in [ChipGroup] with
+ * [ChipGroup.isSingleSelection] set to true.
+ *
+ * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
+ * to free this reference.
+ *
+ * *Warning:* The created observable uses [ChipGroup.setOnCheckedChangeListener]
+ * to observe checked changes. Only one observable can be used for a view at a time.
+ *
+ * *Note:* A value will be emitted immediately on subscribe.
+ */
+@CheckResult
+fun ChipGroup.checkedChanges(): InitialValueObservable<Int> {
+  return ChipGroupCheckedChangeObservable(this)
+}
+
+private class ChipGroupCheckedChangeObservable(
+  private val view: ChipGroup
+) : InitialValueObservable<Int>() {
+
+  override fun subscribeListener(observer: Observer<in Int>) {
+    if (!checkMainThread(observer) || !checkSingleSelection(view, observer)) {
+      return
+    }
+    val listener = Listener(view, observer)
+    view.setOnCheckedChangeListener(listener)
+    observer.onSubscribe(listener)
+  }
+
+  override val initialValue get() = view.checkedChipId
+
+  private class Listener(
+    private val view: ChipGroup,
+    private val observer: Observer<in Int>
+  ) : MainThreadDisposable(), ChipGroup.OnCheckedChangeListener {
+    private var lastChecked = -1
+
+    override fun onCheckedChanged(chipGroup: ChipGroup, checkedId: Int) {
+      if (!isDisposed && checkedId != lastChecked) {
+        lastChecked = checkedId
+        observer.onNext(checkedId)
+      }
+    }
+
+    override fun onDispose() {
+      view.setOnCheckedChangeListener(null)
+    }
+  }
+}
+
+private fun checkSingleSelection(view: ChipGroup, observer: Observer<*>): Boolean {
+  if (!view.isSingleSelection) {
+    observer.onSubscribe(Disposables.empty())
+    observer.onError(IllegalStateException("The view is not in single selection mode!"))
+    return false
+  }
+  return true
+}

--- a/rxbinding-material/src/main/java/com/jakewharton/rxbinding3/material/ChipGroupToggleCheckedConsumer.kt
+++ b/rxbinding-material/src/main/java/com/jakewharton/rxbinding3/material/ChipGroupToggleCheckedConsumer.kt
@@ -1,0 +1,26 @@
+@file:JvmName("RxChipGroup")
+@file:JvmMultifileClass
+
+package com.jakewharton.rxbinding3.material
+
+import androidx.annotation.CheckResult
+import com.google.android.material.chip.ChipGroup
+import io.reactivex.functions.Consumer
+
+/**
+ * An action which sets the checked child of [ChipGroup] with ID. Passing `-1` will clear
+ * any checked view.
+ *
+ * *Warning:* The created observable keeps a strong reference to `view`. Unsubscribe
+ * to free this reference.
+ */
+@CheckResult
+fun ChipGroup.checked(): Consumer<in Int> {
+  return Consumer { value ->
+    if (value == -1) {
+      clearCheck()
+    } else {
+      check(value!!)
+    }
+  }
+}


### PR DESCRIPTION
As apparently, the `OnCheckedChangeListener` is not being fired when the `ChipGroup` is not in [single selection mode](https://github.com/material-components/material-components-android/blob/master/lib/java/com/google/android/material/chip/ChipGroup.java#L298), I've also added a check for single selection in the implementation.