### PR TITLE
Fix InstrumentationRegistry deprecation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ buildscript {
     'androidXSwipeRefreshLayout': 'androidx.swiperefreshlayout:swiperefreshlayout:1.0.0',
     'androidXViewPager': 'androidx.viewpager:viewpager:1.0.0',
 
+    'androidXTestCore': 'androidx.test:core:1.1.0',
     'androidXTestRunner': 'androidx.test:runner:1.1.1',
     'androidXTestRules': 'androidx.test:rules:1.1.1',
     'androidXTestEspresso': 'androidx.test.espresso:espresso-core:3.1.1',

--- a/rxbinding-appcompat/build.gradle
+++ b/rxbinding-appcompat/build.gradle
@@ -8,6 +8,7 @@ dependencies {
   implementation deps.rxAndroid
 
   androidTestImplementation project(':testing-utils')
+  androidTestImplementation deps.androidXTestCore
   androidTestImplementation deps.androidXTestRunner
   androidTestImplementation deps.androidXTestRules
   androidTestImplementation deps.androidXTestEspresso

--- a/rxbinding-appcompat/src/androidTest/java/com/jakewharton/rxbinding3/appcompat/RxActionMenuViewTest.java
+++ b/rxbinding-appcompat/src/androidTest/java/com/jakewharton/rxbinding3/appcompat/RxActionMenuViewTest.java
@@ -5,8 +5,8 @@ import android.view.ContextThemeWrapper;
 import android.view.Menu;
 import android.view.MenuItem;
 import androidx.appcompat.widget.ActionMenuView;
-import androidx.test.InstrumentationRegistry;
 import androidx.test.annotation.UiThreadTest;
+import androidx.test.core.app.ApplicationProvider;
 import com.jakewharton.rxbinding3.RecordingObserver;
 import org.junit.Before;
 import org.junit.Test;
@@ -14,7 +14,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertSame;
 
 public final class RxActionMenuViewTest {
-  private final Context rawContext = InstrumentationRegistry.getContext();
+  private final Context rawContext = ApplicationProvider.getApplicationContext();
   private final Context context = new ContextThemeWrapper(rawContext, R.style.Theme_AppCompat);
 
   private ActionMenuView view;

--- a/rxbinding-appcompat/src/androidTest/java/com/jakewharton/rxbinding3/appcompat/RxSearchViewTest.java
+++ b/rxbinding-appcompat/src/androidTest/java/com/jakewharton/rxbinding3/appcompat/RxSearchViewTest.java
@@ -3,8 +3,8 @@ package com.jakewharton.rxbinding3.appcompat;
 import android.content.Context;
 import android.view.ContextThemeWrapper;
 import androidx.appcompat.widget.SearchView;
-import androidx.test.InstrumentationRegistry;
 import androidx.test.annotation.UiThreadTest;
+import androidx.test.core.app.ApplicationProvider;
 import com.jakewharton.rxbinding3.RecordingObserver;
 import org.junit.Before;
 import org.junit.Test;
@@ -14,7 +14,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public final class RxSearchViewTest {
-  private final Context rawContext = InstrumentationRegistry.getContext();
+  private final Context rawContext = ApplicationProvider.getApplicationContext();
   private final Context context = new ContextThemeWrapper(rawContext, R.style.Theme_AppCompat);
 
   private SearchView searchView;

--- a/rxbinding-drawerlayout/src/androidTest/java/com/jakewharton/rxbinding3/drawerlayout/RxDrawerLayoutTest.java
+++ b/rxbinding-drawerlayout/src/androidTest/java/com/jakewharton/rxbinding3/drawerlayout/RxDrawerLayoutTest.java
@@ -2,7 +2,7 @@ package com.jakewharton.rxbinding3.drawerlayout;
 
 import android.app.Instrumentation;
 import androidx.drawerlayout.widget.DrawerLayout;
-import androidx.test.espresso.Espresso;
+import androidx.test.espresso.IdlingRegistry;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.ActivityTestRule;
 import com.jakewharton.rxbinding3.ViewDirtyIdlingResource;
@@ -29,6 +29,7 @@ public final class RxDrawerLayoutTest {
       new ActivityTestRule<>(RxDrawerLayoutTestActivity.class);
 
   private final Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
+  private final IdlingRegistry idlingRegistry = IdlingRegistry.getInstance();
 
   DrawerLayout view;
   private ViewDirtyIdlingResource viewDirtyIdler;
@@ -38,11 +39,11 @@ public final class RxDrawerLayoutTest {
     view = activity.drawerLayout;
 
     viewDirtyIdler = new ViewDirtyIdlingResource(activity);
-    Espresso.registerIdlingResources(viewDirtyIdler);
+    idlingRegistry.register(viewDirtyIdler);
   }
 
   @After public void tearDown() {
-    Espresso.unregisterIdlingResources(viewDirtyIdler);
+    idlingRegistry.unregister(viewDirtyIdler);
   }
 
   @Test public void drawerOpen() {

--- a/rxbinding-leanback/build.gradle
+++ b/rxbinding-leanback/build.gradle
@@ -8,6 +8,7 @@ dependencies {
   implementation deps.rxAndroid
 
   androidTestImplementation project(':testing-utils')
+  androidTestImplementation deps.androidXTestCore
   androidTestImplementation deps.androidXTestRunner
   androidTestImplementation deps.androidXTestRules
   androidTestImplementation deps.androidXTestEspresso

--- a/rxbinding-leanback/src/androidTest/java/com/jakewharton/rxbinding3/leanback/RxSearchEditTextTest.java
+++ b/rxbinding-leanback/src/androidTest/java/com/jakewharton/rxbinding3/leanback/RxSearchEditTextTest.java
@@ -3,8 +3,8 @@ package com.jakewharton.rxbinding3.leanback;
 import android.content.Context;
 import android.view.KeyEvent;
 import androidx.leanback.widget.SearchEditText;
-import androidx.test.InstrumentationRegistry;
 import androidx.test.annotation.UiThreadTest;
+import androidx.test.core.app.ApplicationProvider;
 import com.jakewharton.rxbinding3.RecordingObserver;
 import org.junit.Before;
 import org.junit.Test;
@@ -12,7 +12,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertNotNull;
 
 public final class RxSearchEditTextTest {
-  private final Context context = InstrumentationRegistry.getContext();
+  private final Context context = ApplicationProvider.getApplicationContext();
   private SearchEditText view;
 
   @Before public void setUp() {

--- a/rxbinding-material/build.gradle
+++ b/rxbinding-material/build.gradle
@@ -8,6 +8,7 @@ dependencies {
   implementation deps.rxAndroid
 
   androidTestImplementation project(':testing-utils')
+  androidTestImplementation deps.androidXTestCore
   androidTestImplementation deps.androidXTestRunner
   androidTestImplementation deps.androidXTestRules
   androidTestImplementation deps.androidXTestEspresso

--- a/rxbinding-material/src/androidTest/java/com/jakewharton/rxbinding3/material/RxAppBarLayoutTest.java
+++ b/rxbinding-material/src/androidTest/java/com/jakewharton/rxbinding3/material/RxAppBarLayoutTest.java
@@ -4,8 +4,8 @@ import android.content.Context;
 import android.view.ContextThemeWrapper;
 import android.view.View;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
-import androidx.test.InstrumentationRegistry;
 import androidx.test.annotation.UiThreadTest;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.filters.SdkSuppress;
 import com.google.android.material.appbar.AppBarLayout;
 import com.jakewharton.rxbinding3.RecordingObserver;
@@ -15,7 +15,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
 public class RxAppBarLayoutTest {
-  private final Context rawContext = InstrumentationRegistry.getContext();
+  private final Context rawContext = ApplicationProvider.getApplicationContext();
   private final Context context = new ContextThemeWrapper(rawContext, R.style.Theme_AppCompat);
   private final CoordinatorLayout parent = new CoordinatorLayout(context);
   private final AppBarLayout view = new AppBarLayout(context);

--- a/rxbinding-material/src/androidTest/java/com/jakewharton/rxbinding3/material/RxBottomNavigationViewTest.java
+++ b/rxbinding-material/src/androidTest/java/com/jakewharton/rxbinding3/material/RxBottomNavigationViewTest.java
@@ -4,8 +4,8 @@ import android.content.Context;
 import android.view.ContextThemeWrapper;
 import android.view.Menu;
 import android.view.MenuItem;
-import androidx.test.InstrumentationRegistry;
 import androidx.test.annotation.UiThreadTest;
+import androidx.test.core.app.ApplicationProvider;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.jakewharton.rxbinding3.RecordingObserver;
 import com.jakewharton.rxbinding3.material.test.R;
@@ -16,7 +16,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
 public final class RxBottomNavigationViewTest {
-  private final Context rawContext = InstrumentationRegistry.getContext();
+  private final Context rawContext = ApplicationProvider.getApplicationContext();
   private final Context context = new ContextThemeWrapper(rawContext, R.style.Theme_AppCompat);
   private final BottomNavigationView view = new BottomNavigationView(context);
   private final Menu menu = view.getMenu();

--- a/rxbinding-material/src/androidTest/java/com/jakewharton/rxbinding3/material/RxChipTest.kt
+++ b/rxbinding-material/src/androidTest/java/com/jakewharton/rxbinding3/material/RxChipTest.kt
@@ -1,15 +1,16 @@
 package com.jakewharton.rxbinding3.material
 
+import android.content.Context
 import android.view.ContextThemeWrapper
-import androidx.test.InstrumentationRegistry
 import androidx.test.annotation.UiThreadTest
+import androidx.test.core.app.ApplicationProvider
 import com.google.android.material.chip.Chip
 import com.jakewharton.rxbinding3.RecordingObserver
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 class RxChipTest {
-  private val rawContext = InstrumentationRegistry.getContext()
+  private val rawContext: Context = ApplicationProvider.getApplicationContext()
   private val context = ContextThemeWrapper(rawContext, R.style.Theme_MaterialComponents)
   private val view = Chip(context)
 

--- a/rxbinding-material/src/androidTest/java/com/jakewharton/rxbinding3/material/RxFloatingActionButtonTest.java
+++ b/rxbinding-material/src/androidTest/java/com/jakewharton/rxbinding3/material/RxFloatingActionButtonTest.java
@@ -3,8 +3,8 @@ package com.jakewharton.rxbinding3.material;
 import android.content.Context;
 import android.view.ContextThemeWrapper;
 import android.view.View;
-import androidx.test.InstrumentationRegistry;
 import androidx.test.annotation.UiThreadTest;
+import androidx.test.core.app.ApplicationProvider;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import io.reactivex.functions.Consumer;
 import org.junit.Test;
@@ -12,7 +12,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
 public class RxFloatingActionButtonTest {
-  private final Context rawContext = InstrumentationRegistry.getContext();
+  private final Context rawContext = ApplicationProvider.getApplicationContext();
   private final Context context = new ContextThemeWrapper(rawContext, R.style.Theme_AppCompat);
   private final FloatingActionButton fab = new FloatingActionButton(context);
 

--- a/rxbinding-material/src/androidTest/java/com/jakewharton/rxbinding3/material/RxNavigationViewTest.java
+++ b/rxbinding-material/src/androidTest/java/com/jakewharton/rxbinding3/material/RxNavigationViewTest.java
@@ -4,8 +4,8 @@ import android.content.Context;
 import android.view.ContextThemeWrapper;
 import android.view.Menu;
 import android.view.MenuItem;
-import androidx.test.InstrumentationRegistry;
 import androidx.test.annotation.UiThreadTest;
+import androidx.test.core.app.ApplicationProvider;
 import com.google.android.material.navigation.NavigationView;
 import com.jakewharton.rxbinding3.RecordingObserver;
 import org.junit.Before;
@@ -14,7 +14,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertSame;
 
 public final class RxNavigationViewTest {
-  private final Context rawContext = InstrumentationRegistry.getContext();
+  private final Context rawContext = ApplicationProvider.getApplicationContext();
   private final Context context = new ContextThemeWrapper(rawContext, R.style.Theme_AppCompat);
   private final NavigationView view = new NavigationView(context);
   private final Menu menu = view.getMenu();

--- a/rxbinding-material/src/androidTest/java/com/jakewharton/rxbinding3/material/RxSnackbarTest.java
+++ b/rxbinding-material/src/androidTest/java/com/jakewharton/rxbinding3/material/RxSnackbarTest.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.view.ContextThemeWrapper;
 import android.widget.FrameLayout;
 import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 import com.google.android.material.snackbar.Snackbar;
 import com.jakewharton.rxbinding3.RecordingObserver;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -16,7 +17,7 @@ import static org.junit.Assert.assertEquals;
 
 public final class RxSnackbarTest {
   private final Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
-  private final Context rawContext = InstrumentationRegistry.getContext();
+  private final Context rawContext = ApplicationProvider.getApplicationContext();
   private final Context context = new ContextThemeWrapper(rawContext, R.style.Theme_AppCompat);
   private final FrameLayout parent = new FrameLayout(context);
 

--- a/rxbinding-material/src/androidTest/java/com/jakewharton/rxbinding3/material/RxSnackbarTest.java
+++ b/rxbinding-material/src/androidTest/java/com/jakewharton/rxbinding3/material/RxSnackbarTest.java
@@ -4,7 +4,7 @@ import android.app.Instrumentation;
 import android.content.Context;
 import android.view.ContextThemeWrapper;
 import android.widget.FrameLayout;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.core.app.ApplicationProvider;
 import com.google.android.material.snackbar.Snackbar;
 import com.jakewharton.rxbinding3.RecordingObserver;

--- a/rxbinding-material/src/androidTest/java/com/jakewharton/rxbinding3/material/RxTabLayoutTest.java
+++ b/rxbinding-material/src/androidTest/java/com/jakewharton/rxbinding3/material/RxTabLayoutTest.java
@@ -2,8 +2,8 @@ package com.jakewharton.rxbinding3.material;
 
 import android.content.Context;
 import android.view.ContextThemeWrapper;
-import androidx.test.InstrumentationRegistry;
 import androidx.test.annotation.UiThreadTest;
+import androidx.test.core.app.ApplicationProvider;
 import com.google.android.material.tabs.TabLayout;
 import com.jakewharton.rxbinding3.RecordingObserver;
 import io.reactivex.functions.Consumer;
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 
 public final class RxTabLayoutTest {
-  private final Context rawContext = InstrumentationRegistry.getContext();
+  private final Context rawContext = ApplicationProvider.getApplicationContext();
   private final Context context = new ContextThemeWrapper(rawContext, R.style.Theme_AppCompat);
   private final TabLayout view = new TabLayout(context);
   private final TabLayout.Tab tab1 = view.newTab();

--- a/rxbinding-recyclerview/src/androidTest/java/com/jakewharton/rxbinding3/recyclerview/RxRecyclerViewTest.java
+++ b/rxbinding-recyclerview/src/androidTest/java/com/jakewharton/rxbinding3/recyclerview/RxRecyclerViewTest.java
@@ -7,7 +7,7 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
-import androidx.test.espresso.Espresso;
+import androidx.test.espresso.IdlingRegistry;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.ActivityTestRule;
 import com.jakewharton.rxbinding3.ViewDirtyIdlingResource;
@@ -26,6 +26,7 @@ public final class RxRecyclerViewTest {
       new ActivityTestRule<>(RxRecyclerViewTestActivity.class);
 
   private final Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
+  private final IdlingRegistry idlingRegistry = IdlingRegistry.getInstance();
 
   RecyclerView view;
   private ViewDirtyIdlingResource viewDirtyIdler;
@@ -36,11 +37,11 @@ public final class RxRecyclerViewTest {
     view = activity.recyclerView;
     child = new View(activityRule.getActivity());
     viewDirtyIdler = new ViewDirtyIdlingResource(activity);
-    Espresso.registerIdlingResources(viewDirtyIdler);
+    idlingRegistry.register(viewDirtyIdler);
   }
 
   @After public void tearDown() {
-    Espresso.unregisterIdlingResources(viewDirtyIdler);
+    idlingRegistry.unregister(viewDirtyIdler);
   }
 
   @Test public void childAttachEvents() {

--- a/rxbinding-slidingpanelayout/src/androidTest/java/com/jakewharton/rxbinding3/slidingpanelayout/RxSlidingPaneLayoutTest.java
+++ b/rxbinding-slidingpanelayout/src/androidTest/java/com/jakewharton/rxbinding3/slidingpanelayout/RxSlidingPaneLayoutTest.java
@@ -3,7 +3,7 @@ package com.jakewharton.rxbinding3.slidingpanelayout;
 import android.app.Instrumentation;
 import android.view.View;
 import androidx.slidingpanelayout.widget.SlidingPaneLayout;
-import androidx.test.espresso.Espresso;
+import androidx.test.espresso.IdlingRegistry;
 import androidx.test.espresso.idling.CountingIdlingResource;
 import androidx.test.espresso.matcher.BoundedMatcher;
 import androidx.test.platform.app.InstrumentationRegistry;
@@ -30,6 +30,7 @@ public class RxSlidingPaneLayoutTest {
       new ActivityTestRule<>(RxSlidingPaneLayoutTestActivity.class);
 
   private final Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
+  private final IdlingRegistry idlingRegistry = IdlingRegistry.getInstance();
 
   SlidingPaneLayout view;
 
@@ -40,11 +41,11 @@ public class RxSlidingPaneLayoutTest {
     view = activity.slidingPaneLayout;
 
     idler = new CountingIdlingResource("counting idler");
-    Espresso.registerIdlingResources(idler);
+    idlingRegistry.register(idler);
   }
 
   @After public void teardown() {
-    Espresso.unregisterIdlingResources(idler);
+    idlingRegistry.unregister(idler);
   }
 
   @Test public void paneOpen() {

--- a/rxbinding/build.gradle
+++ b/rxbinding/build.gradle
@@ -8,6 +8,7 @@ dependencies {
   implementation deps.rxAndroid
 
   androidTestImplementation project(':testing-utils')
+  androidTestImplementation deps.androidXTestCore
   androidTestImplementation deps.androidXTestRunner
   androidTestImplementation deps.androidXTestRules
 }

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding3/view/RxMenuItemTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding3/view/RxMenuItemTest.java
@@ -9,8 +9,8 @@ import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.SubMenu;
 import android.view.View;
-import androidx.test.InstrumentationRegistry;
 import androidx.test.annotation.UiThreadTest;
+import androidx.test.core.app.ApplicationProvider;
 import com.jakewharton.rxbinding3.RecordingObserver;
 import kotlin.jvm.functions.Function1;
 import org.junit.Test;
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 public final class RxMenuItemTest {
-  private final Context context = InstrumentationRegistry.getContext();
+  private final Context context = ApplicationProvider.getApplicationContext();
   private final TestMenuItem menuItem = new TestMenuItem(context);
 
   @Test @UiThreadTest public void clicks() {

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding3/view/RxViewGroupTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding3/view/RxViewGroupTest.java
@@ -3,15 +3,15 @@ package com.jakewharton.rxbinding3.view;
 import android.content.Context;
 import android.view.View;
 import android.widget.LinearLayout;
-import androidx.test.InstrumentationRegistry;
 import androidx.test.annotation.UiThreadTest;
+import androidx.test.core.app.ApplicationProvider;
 import com.jakewharton.rxbinding3.RecordingObserver;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
 public final class RxViewGroupTest {
-  private final Context context = InstrumentationRegistry.getTargetContext();
+  private final Context context = ApplicationProvider.getApplicationContext();
   private final LinearLayout parent = new LinearLayout(context);
   private final View child = new View(context);
 

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding3/view/RxViewTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding3/view/RxViewTest.java
@@ -5,8 +5,8 @@ import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.LinearLayout;
-import androidx.test.InstrumentationRegistry;
 import androidx.test.annotation.UiThreadTest;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.filters.SdkSuppress;
 import com.jakewharton.rxbinding3.RecordingObserver;
 import com.jakewharton.rxbinding3.internal.AlwaysTrue;
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public final class RxViewTest {
-  private final Context context = InstrumentationRegistry.getContext();
+  private final Context context = ApplicationProvider.getApplicationContext();
   private final View view = new View(context);
 
   @Test @UiThreadTest public void clicks() {

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding3/widget/RxCompoundButtonTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding3/widget/RxCompoundButtonTest.java
@@ -3,8 +3,8 @@ package com.jakewharton.rxbinding3.widget;
 import android.content.Context;
 import android.widget.CompoundButton;
 import android.widget.ToggleButton;
-import androidx.test.InstrumentationRegistry;
 import androidx.test.annotation.UiThreadTest;
+import androidx.test.core.app.ApplicationProvider;
 import com.jakewharton.rxbinding3.RecordingObserver;
 import org.junit.Test;
 
@@ -12,7 +12,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public final class RxCompoundButtonTest {
-  private final Context context = InstrumentationRegistry.getContext();
+  private final Context context = ApplicationProvider.getApplicationContext();
   private final CompoundButton view = new ToggleButton(context);
 
   @Test @UiThreadTest public void checkedChanges() {

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding3/widget/RxRadioGroupTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding3/widget/RxRadioGroupTest.java
@@ -3,8 +3,8 @@ package com.jakewharton.rxbinding3.widget;
 import android.content.Context;
 import android.widget.RadioButton;
 import android.widget.RadioGroup;
-import androidx.test.InstrumentationRegistry;
 import androidx.test.annotation.UiThreadTest;
+import androidx.test.core.app.ApplicationProvider;
 import com.jakewharton.rxbinding3.RecordingObserver;
 import io.reactivex.functions.Consumer;
 import org.junit.Before;
@@ -14,7 +14,7 @@ import static org.junit.Assert.assertEquals;
 
 @SuppressWarnings("ResourceType") // Don't need real IDs for test case.
 public final class RxRadioGroupTest {
-  private final Context context = InstrumentationRegistry.getContext();
+  private final Context context = ApplicationProvider.getApplicationContext();
   private final RadioGroup view = new RadioGroup(context);
 
   @Before public void setUp() {

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding3/widget/RxSearchViewTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding3/widget/RxSearchViewTest.java
@@ -2,8 +2,8 @@ package com.jakewharton.rxbinding3.widget;
 
 import android.content.Context;
 import android.widget.SearchView;
-import androidx.test.InstrumentationRegistry;
 import androidx.test.annotation.UiThreadTest;
+import androidx.test.core.app.ApplicationProvider;
 import com.jakewharton.rxbinding3.RecordingObserver;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,7 +13,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public final class RxSearchViewTest {
-  private final Context context = InstrumentationRegistry.getContext();
+  private final Context context = ApplicationProvider.getApplicationContext();
 
   private SearchView searchView;
 

--- a/rxbinding/src/androidTest/java/com/jakewharton/rxbinding3/widget/RxTextViewTest.java
+++ b/rxbinding/src/androidTest/java/com/jakewharton/rxbinding3/widget/RxTextViewTest.java
@@ -2,8 +2,8 @@ package com.jakewharton.rxbinding3.widget;
 
 import android.content.Context;
 import android.widget.TextView;
-import androidx.test.InstrumentationRegistry;
 import androidx.test.annotation.UiThreadTest;
+import androidx.test.core.app.ApplicationProvider;
 import com.jakewharton.rxbinding3.RecordingObserver;
 import org.junit.Test;
 
@@ -14,7 +14,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
 public final class RxTextViewTest {
-  private final Context context = InstrumentationRegistry.getContext();
+  private final Context context = ApplicationProvider.getApplicationContext();
   private final TextView view = new TextView(context);
 
   @Test @UiThreadTest public void editorActions() {


### PR DESCRIPTION
`androidx.test.InstrumentationRegistry` is a deprecated class. This PR removes all the places where we were using it.

