### PR TITLE
Clearing gradle cache on macos VM is no longer required.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,6 @@ jobs:
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
 
-      - name: Clean Cache
-        run: mv ~/.gradle/caches ~/.gradle/.invalid_caches
-
       - uses: actions/cache@v1
         with:
           path: ~/.gradle/caches


### PR DESCRIPTION
[Latest macos VM no longer has pre-populated gradle cache](https://github.com/actions/cache/issues/280).