### PR TITLE
Only remove focus change listener when it is `this`

### DIFF
--- a/rxbinding/src/main/java/com/jakewharton/rxbinding4/view/ViewFocusChangeObservable.kt
+++ b/rxbinding/src/main/java/com/jakewharton/rxbinding4/view/ViewFocusChangeObservable.kt
@@ -51,7 +51,9 @@ private class ViewFocusChangeObservable(
     }
 
     override fun onDispose() {
-      view.onFocusChangeListener = null
+      if (view.onFocusChangeListener === this) {
+        view.onFocusChangeListener = null
+      }
     }
   }
 }


### PR DESCRIPTION
Currently, the `onFocusChangeListener` is always set to `null` when disposed, regardless of what the field is actually set to.  
This could lead to some unexpected behavior when the focus change listener is changed manually, after subscribing to the observable.

When we first check that the currently set listener is `this`, then won't override any manually set listener.